### PR TITLE
feat(types): add StellarPublicKey type and update wallet fields

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,3 +1,5 @@
+import { StellarPublicKey } from "@/types/user";
+
 /** Message as returned by the chat API */
 export interface ChatMessageAPI {
   id: number;
@@ -6,7 +8,8 @@ export interface ChatMessageAPI {
   createdAt: string;
   user: {
     username: string;
-    wallet: string;
+    /** Stellar public key (G..., 56 characters) */
+    wallet: StellarPublicKey;
     avatar: string | null;
   };
 }
@@ -18,7 +21,8 @@ export interface ChatMessage {
   message: string;
   color: string;
   avatar?: string | null;
-  wallet?: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet?: StellarPublicKey;
   messageType: "message" | "emote" | "system";
   createdAt: string;
   /** True while an optimistic message is being confirmed by the API */
@@ -27,7 +31,8 @@ export interface ChatMessage {
 
 /** Payload for sending a chat message */
 export interface SendChatMessagePayload {
-  wallet: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet: StellarPublicKey;
   playbackId: string;
   content: string;
   messageType?: "message" | "emote" | "system";

--- a/types/settings/profile.ts
+++ b/types/settings/profile.ts
@@ -1,3 +1,5 @@
+import { StellarPublicKey } from "@/types/user";
+
 // Types
 export type Platform =
   | "instagram"
@@ -19,7 +21,8 @@ export interface FormState {
   username: string;
   email: string;
   bio: string;
-  wallet: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet: StellarPublicKey;
   socialLinkUrl: string;
   socialLinkTitle: string;
   language: string;

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,3 +1,6 @@
+/** Stellar public key — 56-character Base32 string starting with 'G' */
+export type StellarPublicKey = string;
+
 export interface SocialLink {
   socialTitle: string;
   socialLink: string;
@@ -12,7 +15,8 @@ export interface Creator {
 
 export interface User {
   id: string;
-  wallet: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet: StellarPublicKey;
   username: string;
   email: string;
   streamkey?: string;
@@ -29,7 +33,8 @@ export interface User {
 export interface UserRegistrationInput {
   email: string;
   username: string;
-  wallet: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet: StellarPublicKey;
   socialLinks?: SocialLink[];
   emailNotifications?: boolean;
   creator?: Partial<Creator>;
@@ -39,7 +44,8 @@ export type UserUpdateInput = {
   username?: string;
   email?: string;
   bio?: string;
-  wallet?: string;
+  /** Stellar public key (G..., 56 characters) */
+  wallet?: StellarPublicKey;
   avatar?: string | File;
   streamkey?: string;
   emailVerified?: boolean;


### PR DESCRIPTION
## Summary

Closes #241

This PR updates all wallet-related TypeScript type definitions across the `types/` directory to reflect the migration from StarkNet hex addresses to Stellar public keys.

## Changes

### `types/user.ts`
- Added and exported `StellarPublicKey` type alias (`string`) with JSDoc documenting the Stellar format (56-character Base32 string starting with `G`)
- Updated `User.wallet`, `UserRegistrationInput.wallet`, and `UserUpdateInput.wallet` from `string` to `StellarPublicKey` with inline JSDoc comments

### `types/settings/profile.ts`
- Imported `StellarPublicKey` from `@/types/user`
- Updated `FormState.wallet` from `string` to `StellarPublicKey` with JSDoc comment

### `types/chat.ts`
- Imported `StellarPublicKey` from `@/types/user`
- Updated `ChatMessageAPI.user.wallet`, `ChatMessage.wallet`, and `SendChatMessagePayload.wallet` from `string` to `StellarPublicKey` with JSDoc comments

### `types/explore/`, `types/landing-page/`
- Reviewed — no wallet-related fields found, no changes needed

## Acceptance Criteria

- [x] `StellarPublicKey` type alias created and exported from `types/user.ts`
- [x] `User.wallet` typed as `StellarPublicKey` with JSDoc
- [x] `UserRegistrationInput.wallet` typed as `StellarPublicKey`
- [x] `UserUpdateInput.wallet` typed as `StellarPublicKey`
- [x] No references to StarkNet address format (`0x`, hex) in any type definitions
- [x] All wallet-related types across `types/` directory consistently documented
- [ ] `npm run type-check` passes — dependencies not installed in this environment; please verify locally with `npm install && npm run type-check`

