### PR TITLE
feat: add routes-f update endpoint with optimistic concurrency

### DIFF
--- a/app/api/routes-f/__tests__/items.test.ts
+++ b/app/api/routes-f/__tests__/items.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Routes-F items endpoints tests.
+ */
+jest.mock("next/server", () => ({
+    NextResponse: {
+        json: (body: unknown, init?: ResponseInit) =>
+            new Response(JSON.stringify(body), {
+                ...init,
+                headers: { "Content-Type": "application/json", ...init?.headers },
+            }),
+    },
+}));
+
+import { GET, PATCH } from "../items/[id]/route";
+import {
+    __test__setRoutesFRecords,
+    getRoutesFRecords,
+} from "@/lib/routes-f/store";
+
+const makeRequest = (method: string, body?: any, headersInit?: HeadersInit) => {
+    return new Request(`http://localhost/api/routes-f/items/rf-1`, {
+        method,
+        headers: headersInit,
+        body: body ? JSON.stringify(body) : null,
+    });
+};
+
+const makeContext = (id: string) => ({
+    params: { id },
+});
+
+const initialRecords = getRoutesFRecords();
+
+describe("PATCH /api/routes-f/items/[id]", () => {
+    beforeEach(() => {
+        __test__setRoutesFRecords([
+            {
+                id: "rf-1",
+                title: "Test Record",
+                description: "Initial",
+                tags: ["test"],
+                createdAt: "2026-02-22T00:00:00.000Z",
+                updatedAt: "2026-02-22T00:00:00.000Z",
+                etag: '"2026-02-22T00:00:00.000Z"'
+            },
+        ]);
+    });
+
+    it("returns 428 when If-Match header is missing", async () => {
+        const res = await PATCH(makeRequest("PATCH", { title: "New" }), makeContext("rf-1"));
+        expect(res.status).toBe(428);
+        const body = await res.json();
+        expect(body.error).toBe("Precondition Required");
+    });
+
+    it("returns 412 when ETag mismatches", async () => {
+        const res = await PATCH(
+            makeRequest("PATCH", { title: "New" }, { "if-match": '"wrong-etag"' }),
+            makeContext("rf-1")
+        );
+        expect(res.status).toBe(412);
+        const body = await res.json();
+        expect(body.error).toBe("Precondition Failed");
+    });
+
+    it("returns 200 and updates record when ETag matches", async () => {
+        const req = makeRequest(
+            "PATCH",
+            { title: "Updated Title" },
+            { "if-match": '"2026-02-22T00:00:00.000Z"' }
+        );
+        const res = await PATCH(req, makeContext("rf-1"));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.title).toBe("Updated Title");
+
+        // Check if store actually updated
+        const getRes = await GET(makeRequest("GET"), makeContext("rf-1"));
+        const getBody = await getRes.json();
+        expect(getBody.title).toBe("Updated Title");
+        expect(getBody.etag).not.toBe('"2026-02-22T00:00:00.000Z"'); // new etag
+    });
+
+    it("handles missing record with 404", async () => {
+        const req = makeRequest(
+            "PATCH",
+            { title: "New" },
+            { "if-match": '"any"' }
+        );
+        const res = await PATCH(req, makeContext("rf-999"));
+        expect(res.status).toBe(404);
+    });
+
+    afterAll(() => {
+        __test__setRoutesFRecords(initialRecords);
+    });
+});

--- a/app/api/routes-f/items/[id]/route.ts
+++ b/app/api/routes-f/items/[id]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { getRoutesFRecordById, updateRoutesFRecord } from "@/lib/routes-f/store";
+
+export async function PATCH(
+    req: Request,
+    { params }: { params: Promise<{ id: string }> | { id: string } }
+) {
+    // Handle both Next.js 14 and 15+ param formats
+    const resolvedParams = await Promise.resolve(params);
+    const { id } = resolvedParams;
+
+    const ifMatch = req.headers.get("if-match");
+    if (!ifMatch) {
+        return NextResponse.json(
+            { error: "Precondition Required", message: "If-Match header is missing" },
+            { status: 428 }
+        );
+    }
+
+    let updates;
+    try {
+        updates = await req.json();
+    } catch (error) {
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    try {
+        const updated = updateRoutesFRecord(id, updates, ifMatch);
+
+        if (!updated) {
+            return NextResponse.json({ error: "Not Found" }, { status: 404 });
+        }
+
+        const headers = new Headers();
+        if (updated.etag) {
+            headers.set("ETag", updated.etag);
+        }
+
+        return NextResponse.json(updated, { status: 200, headers });
+    } catch (e: any) {
+        if (e.message === "ETAG_MISMATCH") {
+            return NextResponse.json(
+                { error: "Precondition Failed", message: "ETag mismatch" },
+                { status: 412 }
+            );
+        }
+        return NextResponse.json(
+            { error: "Internal Server Error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function GET(
+    req: Request,
+    { params }: { params: Promise<{ id: string }> | { id: string } }
+) {
+    const resolvedParams = await Promise.resolve(params);
+    const { id } = resolvedParams;
+
+    const record = getRoutesFRecordById(id);
+    if (!record) {
+        return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    }
+
+    const headers = new Headers();
+    const etag = record.etag || `"${record.updatedAt || record.createdAt}"`;
+    headers.set("ETag", etag);
+
+    return NextResponse.json(record, { status: 200, headers });
+}

--- a/lib/routes-f/store.ts
+++ b/lib/routes-f/store.ts
@@ -59,6 +59,41 @@ export function getRecentRoutesFRecords(limit: number): RoutesFRecord[] {
     .slice(0, limit);
 }
 
+export function getRoutesFRecordById(id: string): RoutesFRecord | undefined {
+  return routesFRecords.find((r) => r.id === id);
+}
+
+export function updateRoutesFRecord(
+  id: string,
+  updates: Partial<RoutesFRecord>,
+  ifMatchHeader?: string
+): RoutesFRecord | null {
+  const index = routesFRecords.findIndex((r) => r.id === id);
+  if (index === -1) return null;
+
+  const current = routesFRecords[index];
+
+  // If-Match concurrency control
+  if (ifMatchHeader) {
+    const etag = current.etag || `"${current.updatedAt || current.createdAt}"`;
+    if (ifMatchHeader !== etag) {
+      throw new Error("ETAG_MISMATCH");
+    }
+  }
+
+  const updated: RoutesFRecord = {
+    ...current,
+    ...updates,
+    id: current.id, // Cannot update ID
+    updatedAt: new Date().toISOString(),
+  };
+
+  updated.etag = `"${updated.updatedAt}"`;
+
+  routesFRecords[index] = updated;
+  return updated;
+}
+
 export function searchRoutesFRecords(params: {
   query?: string;
   tag?: string;

--- a/lib/routes-f/types.ts
+++ b/lib/routes-f/types.ts
@@ -5,6 +5,7 @@ export interface RoutesFRecord {
   tags: string[];
   createdAt: string;
   updatedAt?: string;
+  etag?: string;
 }
 
 export interface MaintenanceWindow {


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use Closes #999 to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

_Closes #299_

# Changes proposed

## What were you told to do?

<!-- Write the title of the issue/feature you are working on -->
Backend: Add routes-f update endpoint with optimistic concurrency (#299)

## What did you do?

<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->
- Added optional `etag` property to the `RoutesFRecord` interface (`lib/routes-f/types.ts`).
- Created `getRoutesFRecordById` and `updateRoutesFRecord` methods in the mock store (`lib/routes-f/store.ts`), managing ETag matching logic and ETag assignments for updates.
- Added `PATCH` and `GET` handlers for `/api/routes-f/items/[id]` (`app/api/routes-f/items/[id]/route.ts`). The `PATCH` endpoint verifies the `If-Match` header and returns a `428` error if it is missing or `412` if the ETag mismatches.
- Authored test cases covering these concurrency flows (`app/api/routes-f/__tests__/items.test.ts`).

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](../CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Correct; marked as *not* done

[] - Not Correct; syntax error
[ x] - Not Correct; space between the brackets
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the _main branch_ (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
N/A - This is a purely backend feature with tests validating the requests and responses under the hood.
