### PR TITLE
feat(backend): add routes-f async job enqueue endpoint

### DIFF
--- a/app/api/routes-f/_lib/jobs.ts
+++ b/app/api/routes-f/_lib/jobs.ts
@@ -1,0 +1,38 @@
+export type RoutesFJobType = "index_item" | "recompute_stats" | "notify_user";
+
+export type RoutesFJob = {
+  id: string;
+  type: RoutesFJobType;
+  payload: Record<string, unknown>;
+  status: "queued";
+  createdAt: string;
+};
+
+export const ROUTES_F_JOB_TYPES: readonly RoutesFJobType[] = [
+  "index_item",
+  "recompute_stats",
+  "notify_user",
+];
+
+const inMemoryQueue: RoutesFJob[] = [];
+let sequence = 1;
+
+export function isValidRoutesFJobType(value: unknown): value is RoutesFJobType {
+  return typeof value === "string" && ROUTES_F_JOB_TYPES.includes(value as RoutesFJobType);
+}
+
+export function enqueueRoutesFJob(
+  type: RoutesFJobType,
+  payload: Record<string, unknown>
+): RoutesFJob {
+  const job: RoutesFJob = {
+    id: `job_${sequence++}`,
+    type,
+    payload,
+    status: "queued",
+    createdAt: new Date().toISOString(),
+  };
+
+  inMemoryQueue.push(job);
+  return job;
+}

--- a/app/api/routes-f/jobs/__tests__/route.test.ts
+++ b/app/api/routes-f/jobs/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { POST } from "../route";
+
+const makeRequest = (body: object) =>
+  new Request("http://localhost/api/routes-f/jobs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/routes-f/jobs", () => {
+  it("enqueues a job and returns queued status with job id", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "index_item",
+        payload: { itemId: "item-1001" },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.status).toBe("queued");
+    expect(body.jobId).toMatch(/^job_\d+$/);
+  });
+
+  it("returns 400 for invalid job type", async () => {
+    const response = await POST(
+      makeRequest({
+        type: "unknown_type",
+        payload: { any: true },
+      })
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/invalid job type/i);
+  });
+});

--- a/app/api/routes-f/jobs/route.ts
+++ b/app/api/routes-f/jobs/route.ts
@@ -1,0 +1,44 @@
+import {
+  enqueueRoutesFJob,
+  isValidRoutesFJobType,
+  ROUTES_F_JOB_TYPES,
+} from "../_lib/jobs";
+
+type JobRequestBody = {
+  type?: unknown;
+  payload?: unknown;
+};
+
+export async function POST(request: Request) {
+  let body: JobRequestBody;
+
+  try {
+    body = (await request.json()) as JobRequestBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isValidRoutesFJobType(body.type)) {
+    return Response.json(
+      {
+        error: "Invalid job type",
+        details: { allowedTypes: ROUTES_F_JOB_TYPES },
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!body.payload || typeof body.payload !== "object" || Array.isArray(body.payload)) {
+    return Response.json({ error: "payload must be an object" }, { status: 400 });
+  }
+
+  const job = enqueueRoutesFJob(body.type, body.payload as Record<string, unknown>);
+
+  return Response.json(
+    {
+      jobId: job.id,
+      status: job.status,
+    },
+    { status: 201 }
+  );
+}


### PR DESCRIPTION
## Description
Add a Routes-F async job enqueue endpoint stub with in-memory queue behavior.

Closes #305

## Changes proposed

### What were you told to do?
I was asked to add `POST /api/routes-f/jobs` that accepts `{ type, payload }`, returns a queued job response, and uses an in-memory queue without real queue integration.

### What did I do?

#### Added in-memory job queue helper
- Added `app/api/routes-f/_lib/jobs.ts`.
- Defined allowed job types in one place.
- Added `enqueueRoutesFJob(...)` helper to enqueue and return a generated job record.

#### Added async job enqueue endpoint
- Added `app/api/routes-f/jobs/route.ts`.
- Implemented `POST /api/routes-f/jobs`:
  - Accepts `{ type, payload }`.
  - Validates `type` against allowed in-memory job types.
  - Validates `payload` is an object.
  - Returns `{ jobId, status: "queued" }` with `201` when valid.
  - Returns `400` for invalid job type.

#### Added endpoint tests
- Added `app/api/routes-f/jobs/__tests__/route.test.ts`.
- Covered:
  - Job enqueue response (`jobId` + `status: queued`)
  - Invalid job type (`400`)

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Focused TypeScript check passed for new Routes-F job files.
- Added route tests in `app/api/routes-f/jobs/__tests__/route.test.ts` for enqueue response and invalid type behavior.
