### PR TITLE
feat(backend): add routes-f pagination utility

### DIFF
--- a/app/api/routes-f/_lib/__tests__/pagination.test.ts
+++ b/app/api/routes-f/_lib/__tests__/pagination.test.ts
@@ -1,0 +1,45 @@
+import {
+  decodeCursor,
+  encodeCursor,
+  enforceLimit,
+  stableSortBy,
+} from "../pagination";
+
+describe("routes-f pagination utility", () => {
+  it("encodes and decodes cursor payload", () => {
+    const encoded = encodeCursor({ value: 1730000000, id: "item-1" });
+    const decoded = decodeCursor(encoded);
+
+    expect(decoded).toEqual({ value: 1730000000, id: "item-1" });
+  });
+
+  it("returns null for invalid cursor", () => {
+    expect(decodeCursor("not-a-cursor")).toBeNull();
+  });
+
+  it("enforces minimum and maximum limits", () => {
+    expect(enforceLimit(0, { min: 1, max: 100, fallback: 25 })).toBe(1);
+    expect(enforceLimit(101, { min: 1, max: 100, fallback: 25 })).toBe(100);
+  });
+
+  it("uses fallback limit when input is undefined", () => {
+    expect(enforceLimit(undefined, { min: 5, max: 30, fallback: 12 })).toBe(12);
+  });
+
+  it("applies stable sort with id tie-breaker", () => {
+    const items = [
+      { id: "b", score: 10 },
+      { id: "a", score: 10 },
+      { id: "c", score: 12 },
+    ];
+
+    const sorted = stableSortBy(
+      items,
+      (item) => item.score,
+      (item) => item.id,
+      "desc"
+    );
+
+    expect(sorted.map((item) => item.id)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/app/api/routes-f/_lib/pagination.ts
+++ b/app/api/routes-f/_lib/pagination.ts
@@ -1,0 +1,97 @@
+export type CursorPayload = {
+  value: string | number;
+  id: string;
+};
+
+export type SortDirection = "asc" | "desc";
+
+export function encodeCursor(payload: CursorPayload): string {
+  const json = JSON.stringify(payload);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor: string): CursorPayload | null {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as Partial<CursorPayload>;
+
+    if (
+      !parsed ||
+      (typeof parsed.value !== "string" && typeof parsed.value !== "number") ||
+      typeof parsed.id !== "string" ||
+      parsed.id.length === 0
+    ) {
+      return null;
+    }
+
+    return { value: parsed.value, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export function enforceLimit(
+  limit: number | undefined,
+  options?: { min?: number; max?: number; fallback?: number }
+): number {
+  const min = options?.min ?? 1;
+  const max = options?.max ?? 50;
+  const fallback = options?.fallback ?? 20;
+
+  if (typeof limit !== "number" || Number.isNaN(limit)) {
+    return fallback;
+  }
+
+  const normalized = Math.trunc(limit);
+  if (normalized < min) {
+    return min;
+  }
+  if (normalized > max) {
+    return max;
+  }
+
+  return normalized;
+}
+
+function comparePrimitive(
+  left: string | number,
+  right: string | number,
+  direction: SortDirection
+): number {
+  if (left === right) {
+    return 0;
+  }
+
+  if (direction === "asc") {
+    return left < right ? -1 : 1;
+  }
+
+  return left > right ? -1 : 1;
+}
+
+export function stableSortBy<T>(
+  items: T[],
+  getSortValue: (item: T) => string | number,
+  getId: (item: T) => string,
+  direction: SortDirection = "desc"
+): T[] {
+  return [...items].sort((a, b) => {
+    const valueCompare = comparePrimitive(
+      getSortValue(a),
+      getSortValue(b),
+      direction
+    );
+
+    if (valueCompare !== 0) {
+      return valueCompare;
+    }
+
+    // Deterministic tie-breaker for pagination stability.
+    const idA = getId(a);
+    const idB = getId(b);
+    if (idA === idB) {
+      return 0;
+    }
+    return idA < idB ? -1 : 1;
+  });
+}


### PR DESCRIPTION
## Description
Add a DB-independent Routes-F pagination utility with cursor helpers, limit bounds enforcement, and stable sort logic.

Closes #303

## Changes proposed

### What were you told to do?
I was asked to add a Routes-F pagination utility with cursor encode/decode helpers, enforce min/max limit bounds, and include stable sort logic without DB coupling.

### What did I do?

#### Added pagination utility module
- Added `app/api/routes-f/_lib/pagination.ts`.
- Implemented cursor helpers:
  - `encodeCursor(...)`
  - `decodeCursor(...)`
- Implemented limit enforcement:
  - `enforceLimit(...)` with configurable `min`, `max`, and `fallback`.
- Implemented stable sort logic:
  - `stableSortBy(...)` with deterministic id tie-breaker for pagination stability.

#### Added unit tests
- Added `app/api/routes-f/_lib/__tests__/pagination.test.ts`.
- Covered:
  - Cursor encode/decode roundtrip
  - Invalid cursor handling
  - Min/max limit enforcement
  - Fallback behavior
  - Stable sort tie-break behavior

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [ ] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Focused TypeScript check passed for pagination utility and test files.
- Added unit tests in `app/api/routes-f/_lib/__tests__/pagination.test.ts` for cursor encode/decode and limit bound enforcement.
