### PR TITLE
feat(routes-f): implement stubs for #336 #327 #328 #309

### DIFF
--- a/app/api/routes-f/__tests__/activity-daily.test.ts
+++ b/app/api/routes-f/__tests__/activity-daily.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Routes-F daily activity endpoint tests.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Content-Type", "application/json");
+      return new Response(JSON.stringify(body), {
+        ...init,
+        headers,
+      });
+    },
+  },
+}));
+
+import { GET } from "../activity/daily/route";
+
+const makeRequest = (search = "") =>
+  new Request(`http://localhost/api/routes-f/activity/daily${search}`);
+
+describe("GET /api/routes-f/activity/daily", () => {
+  it("uses default day window when query param is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.days).toBe(7);
+    expect(Array.isArray(body.perDay)).toBe(true);
+    expect(body.perDay).toHaveLength(7);
+  });
+
+  it("enforces upper bound for days parameter", async () => {
+    const res = await GET(makeRequest("?days=1000"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.days).toBe(body.limits.maxDays);
+    expect(body.perDay).toHaveLength(body.limits.maxDays);
+  });
+
+  it("returns deterministic bucket shape and total count", async () => {
+    const res = await GET(makeRequest("?days=5"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.perDay).toHaveLength(5);
+    const sum = body.perDay.reduce((acc: number, item: { count: number }) => acc + item.count, 0);
+    expect(body.totalCount).toBe(sum);
+    expect(body.perDay[0]).toHaveProperty("date");
+    expect(body.perDay[0]).toHaveProperty("count");
+  });
+});

--- a/app/api/routes-f/__tests__/deps.test.ts
+++ b/app/api/routes-f/__tests__/deps.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Routes-F dependency health endpoint tests.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Content-Type", "application/json");
+      return new Response(JSON.stringify(body), {
+        ...init,
+        headers,
+      });
+    },
+  },
+}));
+
+import { GET } from "../deps/route";
+import { __test__resetCircuitBreaker } from "@/lib/routes-f/circuit-breaker";
+
+const makeRequest = (search = "") =>
+  new Request(`http://localhost/api/routes-f/deps${search}`);
+
+const originalEnv = { ...process.env };
+
+describe("GET /api/routes-f/deps", () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    __test__resetCircuitBreaker();
+  });
+
+  it("returns stable healthy dependency payload", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.healthy).toBe(true);
+    expect(Array.isArray(body.deps)).toBe(true);
+    expect(body.deps[0]).toHaveProperty("key");
+    expect(body.deps[0]).toHaveProperty("healthy");
+    expect(body.deps[0]).toHaveProperty("latencyMs");
+    expect(body.deps[0]).toHaveProperty("checkedAt");
+  });
+
+  it("returns retry hint when checks are short-circuited", async () => {
+    process.env.ROUTES_F_CIRCUIT_BREAKER_THRESHOLD = "2";
+    process.env.ROUTES_F_CIRCUIT_BREAKER_COOLDOWN_MS = "60000";
+
+    await GET(makeRequest("?fail=auth-service"));
+    await GET(makeRequest("?fail=auth-service"));
+    const shortCircuited = await GET(makeRequest());
+
+    expect(shortCircuited.status).toBe(503);
+    const body = await shortCircuited.json();
+    expect(body.error).toContain("short-circuited");
+    expect(body.retryAfterSeconds).toBeGreaterThan(0);
+    expect(body.circuitState).toBe("open");
+  });
+
+  afterAll(() => {
+    process.env = { ...originalEnv };
+  });
+});

--- a/app/api/routes-f/__tests__/uploads-sign.test.ts
+++ b/app/api/routes-f/__tests__/uploads-sign.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Routes-F signed upload endpoint tests.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Content-Type", "application/json");
+      return new Response(JSON.stringify(body), {
+        ...init,
+        headers,
+      });
+    },
+  },
+}));
+
+import { POST } from "../uploads/sign/route";
+
+const makeRequest = (payload: unknown) =>
+  new Request("http://localhost/api/routes-f/uploads/sign", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+describe("POST /api/routes-f/uploads/sign", () => {
+  it("returns 400 for invalid file metadata", async () => {
+    const res = await POST(
+      makeRequest({
+        fileName: "clip.mov",
+        fileType: "video/quicktime",
+        fileSize: 1024,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it("returns signed upload payload with expected shape", async () => {
+    const res = await POST(
+      makeRequest({
+        fileName: "stream.mp4",
+        fileType: "video/mp4",
+        fileSize: 12 * 1024 * 1024,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.method).toBe("PUT");
+    expect(typeof body.url).toBe("string");
+    expect(body.url).toContain("stream.mp4");
+    expect(typeof body.expiresAt).toBe("string");
+    expect(Number.isNaN(Date.parse(body.expiresAt))).toBe(false);
+  });
+});

--- a/app/api/routes-f/activity/daily/route.ts
+++ b/app/api/routes-f/activity/daily/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import {
+  getActivityLimitConfig,
+  getDailyActivitySummary,
+} from "@/lib/routes-f/activity";
+import { withRoutesFLogging } from "@/lib/routes-f/logging";
+
+export async function GET(req: Request) {
+  return withRoutesFLogging(req, async request => {
+    const url = new URL(request.url);
+    const daysParam = url.searchParams.get("days");
+    const summary = getDailyActivitySummary({ days: daysParam });
+    const limits = getActivityLimitConfig();
+
+    return NextResponse.json(
+      {
+        days: summary.days,
+        totalCount: summary.totalCount,
+        perDay: summary.buckets,
+        limits,
+      },
+      { status: 200 }
+    );
+  });
+}

--- a/app/api/routes-f/deps/route.ts
+++ b/app/api/routes-f/deps/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { runWithCircuitBreaker } from "@/lib/routes-f/circuit-breaker";
+import { checkDependencies, getDependencyKeys } from "@/lib/routes-f/deps";
+import { withRoutesFLogging } from "@/lib/routes-f/logging";
+
+const CIRCUIT_KEY = "routes-f/deps";
+
+export async function GET(req: Request) {
+  return withRoutesFLogging(req, async request => {
+    const url = new URL(request.url);
+    const failDependencyKey = url.searchParams.get("fail") ?? undefined;
+
+    const result = await runWithCircuitBreaker({
+      key: CIRCUIT_KEY,
+      action: async () =>
+        checkDependencies({
+          failDependencyKey,
+        }),
+    });
+
+    if (result.ok) {
+      return NextResponse.json(result.value, { status: 200 });
+    }
+
+    if (result.shortCircuited) {
+      return NextResponse.json(
+        {
+          healthy: false,
+          deps: getDependencyKeys().map(key => ({
+            key,
+            healthy: false,
+            latencyMs: 0,
+            checkedAt: new Date().toISOString(),
+          })),
+          error: "Dependency checks are temporarily short-circuited",
+          retryAfterSeconds: Math.max(1, Math.ceil(result.retryAfterMs / 1000)),
+          circuitState: result.state,
+        },
+        { status: 503 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        healthy: false,
+        deps: getDependencyKeys().map(key => ({
+          key,
+          healthy: false,
+          latencyMs: 0,
+          checkedAt: new Date().toISOString(),
+        })),
+        error: "Dependency health check failed",
+        retryAfterSeconds: Math.max(1, Math.ceil(result.retryAfterMs / 1000)),
+        circuitState: result.state,
+      },
+      { status: 503 }
+    );
+  });
+}

--- a/app/api/routes-f/uploads/sign/route.ts
+++ b/app/api/routes-f/uploads/sign/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { withRoutesFLogging } from "@/lib/routes-f/logging";
+
+const ALLOWED_FILE_TYPES = new Set([
+  "video/mp4",
+  "video/webm",
+  "image/jpeg",
+  "image/png",
+]);
+const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+const SIGNED_URL_TTL_SECONDS = 900;
+
+interface UploadSignBody {
+  fileName?: unknown;
+  fileType?: unknown;
+  fileSize?: unknown;
+}
+
+function validateUploadBody(body: UploadSignBody): string | null {
+  if (typeof body.fileName !== "string" || body.fileName.trim().length === 0) {
+    return "fileName is required";
+  }
+
+  if (typeof body.fileType !== "string" || !ALLOWED_FILE_TYPES.has(body.fileType)) {
+    return "Unsupported fileType";
+  }
+
+  if (!Number.isFinite(body.fileSize) || (body.fileSize as number) <= 0) {
+    return "fileSize must be a positive number";
+  }
+
+  if ((body.fileSize as number) > MAX_FILE_SIZE_BYTES) {
+    return `fileSize exceeds max allowed size of ${MAX_FILE_SIZE_BYTES} bytes`;
+  }
+
+  return null;
+}
+
+export async function POST(req: Request) {
+  return withRoutesFLogging(req, async request => {
+    let body: UploadSignBody;
+
+    try {
+      body = (await request.json()) as UploadSignBody;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+
+    const validationError = validateUploadBody(body);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    const now = Date.now();
+    const expiresAt = new Date(now + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    const encodedName = encodeURIComponent(String(body.fileName));
+
+    return NextResponse.json(
+      {
+        url: `https://uploads.streamfi.local/mock/${encodedName}?token=stub-signature`,
+        method: "PUT",
+        expiresAt,
+      },
+      { status: 200 }
+    );
+  });
+}

--- a/lib/routes-f/__tests__/circuit-breaker.test.ts
+++ b/lib/routes-f/__tests__/circuit-breaker.test.ts
@@ -1,0 +1,104 @@
+import {
+  __test__resetCircuitBreaker,
+  getCircuitBreakerSnapshot,
+  runWithCircuitBreaker,
+} from "../circuit-breaker";
+
+describe("routes-f circuit breaker", () => {
+  beforeEach(() => {
+    __test__resetCircuitBreaker();
+  });
+
+  it("stays closed after successful calls", async () => {
+    const result = await runWithCircuitBreaker({
+      key: "dep-a",
+      now: 100,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => "ok",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.state).toBe("closed");
+
+    const snapshot = getCircuitBreakerSnapshot("dep-a");
+    expect(snapshot.state).toBe("closed");
+    expect(snapshot.failures).toBe(0);
+  });
+
+  it("opens after threshold and short-circuits during cooldown", async () => {
+    await runWithCircuitBreaker({
+      key: "dep-b",
+      now: 100,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => {
+        throw new Error("fail-1");
+      },
+    });
+
+    const secondFailure = await runWithCircuitBreaker({
+      key: "dep-b",
+      now: 200,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => {
+        throw new Error("fail-2");
+      },
+    });
+
+    expect(secondFailure.ok).toBe(false);
+    expect(secondFailure.state).toBe("open");
+    expect(secondFailure.shortCircuited).toBe(false);
+
+    const shortCircuit = await runWithCircuitBreaker({
+      key: "dep-b",
+      now: 700,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => "unexpected",
+    });
+
+    expect(shortCircuit.ok).toBe(false);
+    expect(shortCircuit.shortCircuited).toBe(true);
+    expect(shortCircuit.state).toBe("open");
+    expect(shortCircuit.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("moves to half-open after cooldown and closes on recovery", async () => {
+    await runWithCircuitBreaker({
+      key: "dep-c",
+      now: 100,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => {
+        throw new Error("fail-1");
+      },
+    });
+
+    await runWithCircuitBreaker({
+      key: "dep-c",
+      now: 200,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => {
+        throw new Error("fail-2");
+      },
+    });
+
+    const recovered = await runWithCircuitBreaker({
+      key: "dep-c",
+      now: 1300,
+      failureThreshold: 2,
+      cooldownMs: 1000,
+      action: async () => "ok",
+    });
+
+    expect(recovered.ok).toBe(true);
+    expect(recovered.state).toBe("closed");
+
+    const snapshot = getCircuitBreakerSnapshot("dep-c");
+    expect(snapshot.state).toBe("closed");
+    expect(snapshot.failures).toBe(0);
+  });
+});

--- a/lib/routes-f/activity.ts
+++ b/lib/routes-f/activity.ts
@@ -1,0 +1,90 @@
+export interface DailyActivityBucket {
+  date: string;
+  count: number;
+}
+
+export interface DailyActivitySummary {
+  days: number;
+  totalCount: number;
+  buckets: DailyActivityBucket[];
+}
+
+const DEFAULT_DAYS = 7;
+const MAX_DAYS = 31;
+
+const MOCK_EVENTS: string[] = [
+  "2026-02-24T20:05:00.000Z",
+  "2026-02-24T10:44:00.000Z",
+  "2026-02-23T15:10:00.000Z",
+  "2026-02-23T03:42:00.000Z",
+  "2026-02-22T06:30:00.000Z",
+  "2026-02-21T08:20:00.000Z",
+  "2026-02-21T22:45:00.000Z",
+  "2026-02-20T09:10:00.000Z",
+  "2026-02-19T19:55:00.000Z",
+  "2026-02-18T12:05:00.000Z",
+  "2026-02-18T23:01:00.000Z",
+  "2026-02-17T02:37:00.000Z",
+  "2026-02-16T16:20:00.000Z",
+  "2026-02-14T11:00:00.000Z",
+  "2026-02-12T21:30:00.000Z",
+];
+
+function parseDayCount(input: string | null): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_DAYS;
+  }
+
+  return Math.min(Math.floor(parsed), MAX_DAYS);
+}
+
+function toDayKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function getDailyActivitySummary(params: {
+  days?: string | null;
+  now?: Date;
+}): DailyActivitySummary {
+  const now = params.now ?? new Date();
+  const days = parseDayCount(params.days ?? null);
+
+  const bucketOrder: string[] = [];
+  const bucketMap = new Map<string, number>();
+
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const day = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    day.setUTCDate(day.getUTCDate() - i);
+    const key = toDayKey(day);
+    bucketOrder.push(key);
+    bucketMap.set(key, 0);
+  }
+
+  for (const eventIso of MOCK_EVENTS) {
+    const key = eventIso.slice(0, 10);
+    if (bucketMap.has(key)) {
+      bucketMap.set(key, (bucketMap.get(key) ?? 0) + 1);
+    }
+  }
+
+  const buckets = bucketOrder.map(date => ({
+    date,
+    count: bucketMap.get(date) ?? 0,
+  }));
+
+  const totalCount = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+
+  return {
+    days,
+    totalCount,
+    buckets,
+  };
+}
+
+export function getActivityLimitConfig() {
+  return {
+    defaultDays: DEFAULT_DAYS,
+    maxDays: MAX_DAYS,
+  };
+}

--- a/lib/routes-f/circuit-breaker.ts
+++ b/lib/routes-f/circuit-breaker.ts
@@ -1,0 +1,168 @@
+export type CircuitState = "closed" | "open" | "half-open";
+
+interface CircuitBreakerEntry {
+  state: CircuitState;
+  failures: number;
+  openedAt: number | null;
+}
+
+export interface CircuitBreakerConfig {
+  failureThreshold?: number;
+  cooldownMs?: number;
+}
+
+export interface CircuitBreakerRunOptions<T> extends CircuitBreakerConfig {
+  key: string;
+  now?: number;
+  action: () => Promise<T>;
+}
+
+export type CircuitBreakerResult<T> =
+  | {
+      ok: true;
+      value: T;
+      state: CircuitState;
+      failures: number;
+      shortCircuited: false;
+      retryAfterMs: 0;
+    }
+  | {
+      ok: false;
+      error?: unknown;
+      state: CircuitState;
+      failures: number;
+      shortCircuited: boolean;
+      retryAfterMs: number;
+    };
+
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_COOLDOWN_MS = 30_000;
+const breakerStore = new Map<string, CircuitBreakerEntry>();
+
+function getThreshold(value: number | undefined): number {
+  if (Number.isFinite(value) && (value as number) > 0) {
+    return Math.floor(value as number);
+  }
+
+  const envValue = Number(process.env.ROUTES_F_CIRCUIT_BREAKER_THRESHOLD);
+  return Number.isFinite(envValue) && envValue > 0
+    ? Math.floor(envValue)
+    : DEFAULT_THRESHOLD;
+}
+
+function getCooldownMs(value: number | undefined): number {
+  if (Number.isFinite(value) && (value as number) > 0) {
+    return Math.floor(value as number);
+  }
+
+  const envValue = Number(process.env.ROUTES_F_CIRCUIT_BREAKER_COOLDOWN_MS);
+  return Number.isFinite(envValue) && envValue > 0
+    ? Math.floor(envValue)
+    : DEFAULT_COOLDOWN_MS;
+}
+
+function getOrCreateEntry(key: string): CircuitBreakerEntry {
+  const existing = breakerStore.get(key);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created: CircuitBreakerEntry = {
+    state: "closed",
+    failures: 0,
+    openedAt: null,
+  };
+  breakerStore.set(key, created);
+  return created;
+}
+
+function remainingCooldown(openedAt: number, now: number, cooldownMs: number): number {
+  return Math.max(0, openedAt + cooldownMs - now);
+}
+
+function toOpen(entry: CircuitBreakerEntry, now: number): void {
+  entry.state = "open";
+  entry.openedAt = now;
+}
+
+export async function runWithCircuitBreaker<T>(
+  options: CircuitBreakerRunOptions<T>
+): Promise<CircuitBreakerResult<T>> {
+  const now = options.now ?? Date.now();
+  const threshold = getThreshold(options.failureThreshold);
+  const cooldownMs = getCooldownMs(options.cooldownMs);
+  const entry = getOrCreateEntry(options.key);
+
+  if (entry.state === "open") {
+    const openedAt = entry.openedAt ?? now;
+    const retryAfterMs = remainingCooldown(openedAt, now, cooldownMs);
+
+    if (retryAfterMs > 0) {
+      return {
+        ok: false,
+        state: "open",
+        failures: entry.failures,
+        shortCircuited: true,
+        retryAfterMs,
+      };
+    }
+
+    entry.state = "half-open";
+  }
+
+  try {
+    const value = await options.action();
+    entry.state = "closed";
+    entry.failures = 0;
+    entry.openedAt = null;
+
+    return {
+      ok: true,
+      value,
+      state: "closed",
+      failures: 0,
+      shortCircuited: false,
+      retryAfterMs: 0,
+    };
+  } catch (error) {
+    entry.failures += 1;
+
+    const shouldOpen = entry.state === "half-open" || entry.failures >= threshold;
+
+    if (shouldOpen) {
+      toOpen(entry, now);
+      return {
+        ok: false,
+        error,
+        state: "open",
+        failures: entry.failures,
+        shortCircuited: false,
+        retryAfterMs: cooldownMs,
+      };
+    }
+
+    entry.state = "closed";
+    return {
+      ok: false,
+      error,
+      state: "closed",
+      failures: entry.failures,
+      shortCircuited: false,
+      retryAfterMs: 0,
+    };
+  }
+}
+
+export function getCircuitBreakerSnapshot(key: string): CircuitBreakerEntry {
+  const entry = getOrCreateEntry(key);
+  return {
+    state: entry.state,
+    failures: entry.failures,
+    openedAt: entry.openedAt,
+  };
+}
+
+export function __test__resetCircuitBreaker(): void {
+  breakerStore.clear();
+}

--- a/lib/routes-f/deps.ts
+++ b/lib/routes-f/deps.ts
@@ -1,0 +1,47 @@
+export interface DependencyStatus {
+  key: string;
+  healthy: boolean;
+  latencyMs: number;
+  checkedAt: string;
+}
+
+export interface DependencyHealthPayload {
+  healthy: boolean;
+  deps: DependencyStatus[];
+}
+
+const MOCK_DEPENDENCIES = [
+  { key: "auth-service", healthy: true, latencyMs: 32 },
+  { key: "stream-indexer", healthy: true, latencyMs: 54 },
+  { key: "tip-ledger", healthy: true, latencyMs: 41 },
+] as const;
+
+export async function checkDependencies(params?: {
+  now?: Date;
+  failDependencyKey?: string;
+}): Promise<DependencyHealthPayload> {
+  const checkedAt = (params?.now ?? new Date()).toISOString();
+
+  const deps: DependencyStatus[] = MOCK_DEPENDENCIES.map(dep => ({
+    key: dep.key,
+    healthy:
+      params?.failDependencyKey && params.failDependencyKey === dep.key
+        ? false
+        : dep.healthy,
+    latencyMs: dep.latencyMs,
+    checkedAt,
+  }));
+
+  if (deps.some(dep => !dep.healthy)) {
+    throw new Error("Dependency check failed");
+  }
+
+  return {
+    healthy: true,
+    deps,
+  };
+}
+
+export function getDependencyKeys(): string[] {
+  return MOCK_DEPENDENCIES.map(dep => dep.key);
+}


### PR DESCRIPTION
Closes #336
Closes #327
Closes #328
Closes #309

## Summary
This PR delivers 4 backend `routes-f` stubs in one branch:
- #336 Add route-level circuit breaker stub for external dependency calls.
- #327 Add signed upload URL generation endpoint (stub).
- #328 Add daily activity aggregation endpoint.
- #309 Add dependency health check endpoint (stub).

## What Changed
- Added in-memory deterministic circuit breaker with per-key failure tracking and state transitions:
  - `closed -> open` at threshold
  - auto `open -> half-open` after cooldown
  - `half-open -> closed` on success, `half-open -> open` on failure
- Added `POST /api/routes-f/uploads/sign`:
  - validates file metadata (`fileName`, `fileType`, `fileSize`)
  - enforces allowed MIME types and max size
  - returns fake signed URL response `{ url, expiresAt, method }`
- Added `GET /api/routes-f/activity/daily?days=`:
  - defaults to last 7 days when missing/invalid
  - enforces upper bound for requested days
  - returns total count and per-day buckets from mock data
- Added `GET /api/routes-f/deps`:
  - returns stable typed dependency payload when healthy
  - uses route-level circuit breaker around dependency checks
  - returns short-circuit response with retry hint when breaker is open

## Files Added
- `lib/routes-f/circuit-breaker.ts`
- `lib/routes-f/activity.ts`
- `lib/routes-f/deps.ts`
- `app/api/routes-f/uploads/sign/route.ts`
- `app/api/routes-f/activity/daily/route.ts`
- `app/api/routes-f/deps/route.ts`
- `lib/routes-f/__tests__/circuit-breaker.test.ts`
- `app/api/routes-f/__tests__/uploads-sign.test.ts`
- `app/api/routes-f/__tests__/activity-daily.test.ts`
- `app/api/routes-f/__tests__/deps.test.ts`

## Acceptance Criteria Mapping
- #336:
  - consecutive failures tracked per dependency key
  - breaker opens at threshold, short-circuits while open
  - auto half-open after cooldown
  - short-circuit response includes `retryAfterSeconds`
  - tests cover closed/open/half-open transitions
- #327:
  - endpoint accepts metadata and validates
  - invalid metadata returns 400
  - response includes `url`, `expiresAt`, `method`
  - tests cover validation and response shape
- #328:
  - endpoint supports `days` query with default 7
  - max-day upper bound enforced
  - response includes total and daily buckets
  - tests cover bucket generation
- #309:
  - endpoint returns `{ healthy, deps }` using fixed/stubbed checks
  - route is callable without auth
  - tests cover response shape

## Validation
- Implemented and committed all new route + helper tests.
- Local Jest execution in this environment currently fails at startup with `Bus error (core dumped)` before suites run.
- Existing repo-wide TypeScript check also has pre-existing unrelated errors (e.g. missing type declarations for `framer-motion` / `react-icons`) not introduced by this PR.

## Notes
- Circuit breaker is intentionally in-memory for now, per requirement.
- No cloud provider integration for signed URLs yet (stub response only).