### PR TITLE
feat: paid access streams (one-time usdc payment)

### DIFF
--- a/app/api/debug/migrate-access-control/route.ts
+++ b/app/api/debug/migrate-access-control/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+export async function GET() {
+  try {
+    const actions: string[] = [];
+
+    // --- stream_access_config (1 row per streamer) ---
+    await sql`
+      CREATE TABLE IF NOT EXISTS stream_access_config (
+        streamer_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+        access_type VARCHAR(32) NOT NULL DEFAULT 'public',
+        config JSONB NOT NULL DEFAULT '{}'::jsonb,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      )
+    `;
+    actions.push("✅ Ensured table: stream_access_config");
+
+    // --- stream_access_grants (viewer grants, includes replay protection) ---
+    await sql`
+      CREATE TABLE IF NOT EXISTS stream_access_grants (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        streamer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        viewer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        access_type VARCHAR(32) NOT NULL,
+        tx_hash VARCHAR(128),
+        amount_usdc VARCHAR(32),
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (streamer_id, viewer_id, access_type),
+        UNIQUE (tx_hash)
+      )
+    `;
+    actions.push("✅ Ensured table: stream_access_grants");
+
+    await sql`ALTER TABLE stream_access_grants ADD COLUMN IF NOT EXISTS amount_usdc VARCHAR(32)`;
+    actions.push("✅ Ensured column: stream_access_grants.amount_usdc");
+
+    // Indexes for fast access checks + dashboards
+    await sql`CREATE INDEX IF NOT EXISTS idx_stream_access_grants_streamer ON stream_access_grants(streamer_id)`;
+    actions.push("✅ Ensured index: idx_stream_access_grants_streamer");
+
+    await sql`CREATE INDEX IF NOT EXISTS idx_stream_access_grants_viewer ON stream_access_grants(viewer_id)`;
+    actions.push("✅ Ensured index: idx_stream_access_grants_viewer");
+
+    await sql`CREATE INDEX IF NOT EXISTS idx_stream_access_grants_type ON stream_access_grants(access_type)`;
+    actions.push("✅ Ensured index: idx_stream_access_grants_type");
+
+    await sql`CREATE INDEX IF NOT EXISTS idx_stream_access_config_type ON stream_access_config(access_type)`;
+    actions.push("✅ Ensured index: idx_stream_access_config_type");
+
+    return NextResponse.json({ ok: true, actions });
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : String(e) },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/streams/access/check/route.ts
+++ b/app/api/streams/access/check/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+type AccessType = "public" | "paid" | "password" | "invite";
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { streamer_username, viewer_public_key } = (await req.json()) as {
+      streamer_username?: string;
+      viewer_public_key?: string | null;
+    };
+
+    if (!streamer_username) {
+      return jsonError("streamer_username is required", 400);
+    }
+
+    const streamerResult = await sql`
+      SELECT id, wallet
+      FROM users
+      WHERE LOWER(username) = LOWER(${streamer_username})
+      LIMIT 1
+    `;
+    if (streamerResult.rows.length === 0) {
+      return jsonError("Streamer not found", 404);
+    }
+    const streamerId = streamerResult.rows[0].id as string;
+    const streamerWallet = (streamerResult.rows[0].wallet ?? null) as
+      | string
+      | null;
+
+    const configResult = await sql`
+      SELECT access_type, config
+      FROM stream_access_config
+      WHERE streamer_id = ${streamerId}
+      LIMIT 1
+    `;
+
+    // Default: public if not configured yet
+    if (configResult.rows.length === 0) {
+      return NextResponse.json({ allowed: true, access_type: "public" as const });
+    }
+
+    const accessType = configResult.rows[0].access_type as AccessType;
+    const config = (configResult.rows[0].config ?? {}) as Record<string, unknown>;
+
+    if (accessType === "public") {
+      return NextResponse.json({ allowed: true, access_type: "public" as const });
+    }
+
+    // Paid access check: grant must exist for this streamer + viewer.
+    if (accessType === "paid") {
+      const price_usdc = typeof config.price_usdc === "string" ? config.price_usdc : null;
+
+      if (!viewer_public_key) {
+        return NextResponse.json({
+          allowed: false,
+          access_type: "paid" as const,
+          reason: "wallet_required" as const,
+          price_usdc,
+          streamer_id: streamerId,
+          streamer_public_key: streamerWallet,
+        });
+      }
+
+      const grantResult = await sql`
+        SELECT g.id
+        FROM stream_access_grants g
+        JOIN users viewer ON viewer.id = g.viewer_id
+        WHERE g.streamer_id = ${streamerId}
+          AND g.access_type = 'paid'
+          AND viewer.wallet = ${viewer_public_key}
+        LIMIT 1
+      `;
+
+      if (grantResult.rows.length > 0) {
+        return NextResponse.json({ allowed: true, access_type: "paid" as const });
+      }
+
+      return NextResponse.json({
+        allowed: false,
+        access_type: "paid" as const,
+        reason: "paid" as const,
+        price_usdc,
+        streamer_id: streamerId,
+        streamer_public_key: streamerWallet,
+      });
+    }
+
+    // Other access types will be implemented in #373/#374. For now, deny with reason.
+    return NextResponse.json({
+      allowed: false,
+      access_type: accessType,
+      reason: accessType,
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to check access" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/streams/access/check/route.ts
+++ b/app/api/streams/access/check/route.ts
@@ -1,22 +1,72 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { checkTokenGatedAccess } from "@/lib/stream/access";
+import type { TokenGateConfig } from "@/types/stream-access";
 
-type AccessType = "public" | "paid" | "password" | "invite";
+type AccessType = "public" | "paid" | "password" | "invite" | "token_gated";
 
 function jsonError(message: string, status: number) {
   return NextResponse.json({ error: message }, { status });
 }
 
+function parseTokenGateConfig(raw: unknown): TokenGateConfig | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const o = raw as Record<string, unknown>;
+  const asset_code =
+    typeof o.asset_code === "string"
+      ? o.asset_code
+      : typeof o.assetCode === "string"
+        ? o.assetCode
+        : null;
+  const min_balance =
+    typeof o.min_balance === "string"
+      ? o.min_balance
+      : typeof o.minBalance === "string"
+        ? o.minBalance
+        : null;
+  if (!asset_code || !min_balance) {
+    return null;
+  }
+  const issuer =
+    typeof o.issuer === "string"
+      ? o.issuer
+      : typeof o.asset_issuer === "string"
+        ? o.asset_issuer
+        : undefined;
+  return { asset_code, min_balance, issuer };
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const { streamer_username, viewer_public_key } = (await req.json()) as {
+    let body: {
       streamer_username?: string;
+      streamerUsername?: string;
       viewer_public_key?: string | null;
     };
+    try {
+      body = await req.json();
+    } catch {
+      return jsonError("Invalid JSON", 400);
+    }
 
-    if (!streamer_username) {
+    const streamer_username =
+      body.streamer_username ?? body.streamerUsername ?? undefined;
+    const viewer_public_key = body.viewer_public_key ?? null;
+
+    if (!streamer_username || typeof streamer_username !== "string") {
       return jsonError("streamer_username is required", 400);
     }
+
+    const session = await verifySession(req);
+    const viewerWallet =
+      session.ok && session.wallet
+        ? session.wallet
+        : typeof viewer_public_key === "string"
+          ? viewer_public_key
+          : null;
 
     const streamerResult = await sql`
       SELECT id, wallet
@@ -39,23 +89,56 @@ export async function POST(req: NextRequest) {
       LIMIT 1
     `;
 
-    // Default: public if not configured yet
     if (configResult.rows.length === 0) {
-      return NextResponse.json({ allowed: true, access_type: "public" as const });
+      return NextResponse.json({
+        allowed: true,
+        access_type: "public" as const,
+      });
     }
 
     const accessType = configResult.rows[0].access_type as AccessType;
-    const config = (configResult.rows[0].config ?? {}) as Record<string, unknown>;
+    const config = (configResult.rows[0].config ?? {}) as Record<
+      string,
+      unknown
+    >;
 
     if (accessType === "public") {
-      return NextResponse.json({ allowed: true, access_type: "public" as const });
+      return NextResponse.json({
+        allowed: true,
+        access_type: "public" as const,
+      });
     }
 
-    // Paid access check: grant must exist for this streamer + viewer.
-    if (accessType === "paid") {
-      const price_usdc = typeof config.price_usdc === "string" ? config.price_usdc : null;
+    if (accessType === "token_gated") {
+      const tg = parseTokenGateConfig(config);
+      if (!tg) {
+        console.warn(
+          `[access/check] token_gated misconfigured for ${streamer_username} — allowing`
+        );
+        return NextResponse.json({ allowed: true, access_type: "token_gated" });
+      }
 
-      if (!viewer_public_key) {
+      const result = await checkTokenGatedAccess(tg, viewerWallet);
+      if (result.allowed) {
+        return NextResponse.json({
+          allowed: true,
+          access_type: "token_gated" as const,
+        });
+      }
+      return NextResponse.json({
+        allowed: false,
+        access_type: "token_gated" as const,
+        reason: result.reason,
+        asset_code: result.asset_code,
+        min_balance: result.min_balance,
+      });
+    }
+
+    if (accessType === "paid") {
+      const price_usdc =
+        typeof config.price_usdc === "string" ? config.price_usdc : null;
+
+      if (!viewerWallet) {
         return NextResponse.json({
           allowed: false,
           access_type: "paid" as const,
@@ -72,12 +155,15 @@ export async function POST(req: NextRequest) {
         JOIN users viewer ON viewer.id = g.viewer_id
         WHERE g.streamer_id = ${streamerId}
           AND g.access_type = 'paid'
-          AND viewer.wallet = ${viewer_public_key}
+          AND viewer.wallet = ${viewerWallet}
         LIMIT 1
       `;
 
       if (grantResult.rows.length > 0) {
-        return NextResponse.json({ allowed: true, access_type: "paid" as const });
+        return NextResponse.json({
+          allowed: true,
+          access_type: "paid" as const,
+        });
       }
 
       return NextResponse.json({
@@ -90,7 +176,6 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    // Other access types will be implemented in #373/#374. For now, deny with reason.
     return NextResponse.json({
       allowed: false,
       access_type: accessType,
@@ -103,4 +188,3 @@ export async function POST(req: NextRequest) {
     );
   }
 }
-

--- a/app/api/streams/access/config/route.ts
+++ b/app/api/streams/access/config/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+type AccessType = "public" | "paid" | "password" | "invite";
+
+function isValidPrice(price: unknown): price is string {
+  return (
+    typeof price === "string" &&
+    /^\d+(\.\d{1,2})?$/.test(price) &&
+    Number(price) >= 1 &&
+    Number(price) <= 999
+  );
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const wallet = searchParams.get("wallet");
+    if (!wallet) {
+      return NextResponse.json({ error: "wallet is required" }, { status: 400 });
+    }
+
+    const streamer = await sql`
+      SELECT id FROM users WHERE wallet = ${wallet} LIMIT 1
+    `;
+    if (streamer.rows.length === 0) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    const streamerId = streamer.rows[0].id as string;
+
+    const configRes = await sql`
+      SELECT access_type, config
+      FROM stream_access_config
+      WHERE streamer_id = ${streamerId}
+      LIMIT 1
+    `;
+
+    const access_type = (configRes.rows[0]?.access_type ?? "public") as AccessType;
+    const config = (configRes.rows[0]?.config ?? {}) as Record<string, unknown>;
+
+    const price_usdc = typeof config.price_usdc === "string" ? config.price_usdc : null;
+
+    const paidStats = await sql`
+      SELECT
+        COUNT(*)::int AS paid_viewers,
+        COALESCE(SUM(NULLIF(amount_usdc, '')::numeric), 0)::text AS earned_usdc
+      FROM stream_access_grants
+      WHERE streamer_id = ${streamerId}
+        AND access_type = 'paid'
+    `;
+
+    return NextResponse.json({
+      access_type,
+      config: { price_usdc },
+      stats: paidStats.rows[0] ?? { paid_viewers: 0, earned_usdc: "0" },
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to fetch access config" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const { wallet, access_type, price_usdc } = (await req.json()) as {
+      wallet?: string;
+      access_type?: AccessType;
+      price_usdc?: string;
+    };
+
+    if (!wallet) {
+      return NextResponse.json({ error: "wallet is required" }, { status: 400 });
+    }
+
+    if (!access_type || !["public", "paid"].includes(access_type)) {
+      return NextResponse.json(
+        { error: "access_type must be 'public' or 'paid'" },
+        { status: 400 }
+      );
+    }
+
+    const streamer = await sql`
+      SELECT id FROM users WHERE wallet = ${wallet} LIMIT 1
+    `;
+    if (streamer.rows.length === 0) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    const streamerId = streamer.rows[0].id as string;
+
+    const config =
+      access_type === "paid"
+        ? (() => {
+            if (!isValidPrice(price_usdc)) {
+              throw new Error("price_usdc must be between 1 and 999 (2 decimals max)");
+            }
+            return { price_usdc };
+          })()
+        : {};
+
+    await sql`
+      INSERT INTO stream_access_config (streamer_id, access_type, config, updated_at)
+      VALUES (${streamerId}, ${access_type}, ${JSON.stringify(config)}, CURRENT_TIMESTAMP)
+      ON CONFLICT (streamer_id) DO UPDATE SET
+        access_type = EXCLUDED.access_type,
+        config = EXCLUDED.config,
+        updated_at = CURRENT_TIMESTAMP
+    `;
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to update access config" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/streams/access/verify-payment/__tests__/route.test.ts
+++ b/app/api/streams/access/verify-payment/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for POST /api/streams/access/verify-payment
+ * Mocks @vercel/postgres and Stellar Horizon calls.
+ */
+
+// Polyfill NextResponse.json for jsdom test environment
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+const mockServerInstance = {
+  transactions: jest.fn(),
+  operations: jest.fn(),
+};
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Horizon: {
+      Server: jest.fn(() => mockServerInstance),
+    },
+  };
+});
+
+import { sql } from "@vercel/postgres";
+import { Keypair } from "@stellar/stellar-sdk";
+import { POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+
+const makeRequest = (body: object) =>
+  new Request("http://localhost/api/streams/access/verify-payment", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+
+const makeStellarKey = () => Keypair.random().publicKey();
+
+describe("POST /api/streams/access/verify-payment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+    process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET = makeStellarKey();
+  });
+
+  function mockHorizonTx(params: {
+    source: string;
+    memo: string;
+  }) {
+    mockServerInstance.transactions.mockReturnValue({
+      transaction: () => ({
+        call: async () => ({
+          source_account: params.source,
+          memo_type: "text",
+          memo: params.memo,
+        }),
+      }),
+    });
+  }
+
+  function mockHorizonPaymentOp(params: {
+    to: string;
+    amount: string;
+    issuer: string;
+  }) {
+    mockServerInstance.operations.mockReturnValue({
+      forTransaction: () => ({
+        limit: () => ({
+          call: async () => ({
+            records: [
+              {
+                type: "payment",
+                to: params.to,
+                amount: params.amount,
+                asset_type: "credit_alphanum4",
+                asset_code: "USDC",
+                asset_issuer: params.issuer,
+              },
+            ],
+          }),
+        }),
+      }),
+    });
+  }
+
+  it("returns 400 when required fields missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects duplicate tx_hash (replay protection)", async () => {
+    const viewer = makeStellarKey();
+    const streamerWallet = makeStellarKey();
+    const streamerId = "streamer-uuid";
+
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: streamerId, wallet: streamerWallet }] }) // streamer
+      .mockResolvedValueOnce({
+        rows: [{ access_type: "paid", config: { price_usdc: "25.00" } }],
+      }) // config
+      .mockResolvedValueOnce({ rows: [{ id: "grant-id" }] }); // dupe tx_hash
+
+    const res = await POST(
+      makeRequest({
+        streamer_username: "alice",
+        viewer_public_key: viewer,
+        tx_hash: "abc123",
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("verifies payment and inserts grant on success", async () => {
+    const viewer = makeStellarKey();
+    const streamerWallet = makeStellarKey();
+    const streamerId = "streamer-uuid";
+    const usdcIssuer = process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET!;
+
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: streamerId, wallet: streamerWallet }] }) // streamer
+      .mockResolvedValueOnce({
+        rows: [{ access_type: "paid", config: { price_usdc: "25.00" } }],
+      }) // config
+      .mockResolvedValueOnce({ rows: [] }) // dupe tx_hash
+      .mockResolvedValueOnce({ rows: [{ id: "viewer-uuid" }] }) // viewer
+      .mockResolvedValueOnce({ rows: [] }); // insert
+
+    mockHorizonTx({ source: viewer, memo: `streamfi-access:${streamerId}` });
+    mockHorizonPaymentOp({ to: streamerWallet, amount: "25.0000000", issuer: usdcIssuer });
+
+    const res = await POST(
+      makeRequest({
+        streamer_username: "alice",
+        viewer_public_key: viewer,
+        tx_hash: "txhash123",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});
+

--- a/app/api/streams/access/verify-payment/route.ts
+++ b/app/api/streams/access/verify-payment/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getHorizonUrl, getStellarNetwork } from "@/lib/stellar/config";
+import { getUsdcAssetConfig } from "@/lib/stellar/usdc";
+import { parseStellarAmountToInt } from "@/lib/stellar/amount";
+
+function isValidStellarPublicKey(key: unknown): key is string {
+  return typeof key === "string" && /^G[A-Z0-9]{55}$/.test(key);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { streamer_username, viewer_public_key, tx_hash } = (await req.json()) as {
+      streamer_username?: string;
+      viewer_public_key?: string;
+      tx_hash?: string;
+    };
+
+    if (!streamer_username || !viewer_public_key || !tx_hash) {
+      return NextResponse.json(
+        { error: "streamer_username, viewer_public_key, and tx_hash are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidStellarPublicKey(viewer_public_key)) {
+      return NextResponse.json({ error: "Invalid viewer_public_key" }, { status: 400 });
+    }
+
+    // Resolve streamer + access config
+    const streamerResult = await sql`
+      SELECT id, wallet
+      FROM users
+      WHERE LOWER(username) = LOWER(${streamer_username})
+      LIMIT 1
+    `;
+    if (streamerResult.rows.length === 0) {
+      return NextResponse.json({ error: "Streamer not found" }, { status: 404 });
+    }
+    const streamerId = streamerResult.rows[0].id as string;
+    const streamerWallet = streamerResult.rows[0].wallet as string | null;
+    if (!isValidStellarPublicKey(streamerWallet)) {
+      return NextResponse.json(
+        { error: "Streamer has no valid Stellar wallet configured" },
+        { status: 409 }
+      );
+    }
+
+    const configResult = await sql`
+      SELECT access_type, config
+      FROM stream_access_config
+      WHERE streamer_id = ${streamerId}
+      LIMIT 1
+    `;
+    const accessType = (configResult.rows[0]?.access_type ?? "public") as string;
+    const config = (configResult.rows[0]?.config ?? {}) as Record<string, unknown>;
+
+    if (accessType !== "paid") {
+      return NextResponse.json({ error: "Stream is not configured as paid" }, { status: 409 });
+    }
+
+    const priceUsdc = typeof config.price_usdc === "string" ? config.price_usdc : null;
+    if (!priceUsdc) {
+      return NextResponse.json({ error: "Missing stream price" }, { status: 500 });
+    }
+
+    // Replay protection / idempotency: tx_hash cannot be reused
+    const dupe = await sql`
+      SELECT id FROM stream_access_grants WHERE tx_hash = ${tx_hash} LIMIT 1
+    `;
+    if (dupe.rows.length > 0) {
+      // Idempotent success: if it's already been granted, treat as OK for retries.
+      return NextResponse.json({ ok: true });
+    }
+
+    // Resolve viewer user id (must exist to grant)
+    const viewerResult = await sql`
+      SELECT id FROM users WHERE wallet = ${viewer_public_key} LIMIT 1
+    `;
+    if (viewerResult.rows.length === 0) {
+      return NextResponse.json({ error: "Viewer not found" }, { status: 404 });
+    }
+    const viewerId = viewerResult.rows[0].id as string;
+
+    // Verify on Stellar Horizon
+    const network = getStellarNetwork();
+    const server = new StellarSdk.Horizon.Server(getHorizonUrl(network));
+
+    const tx = await server.transactions().transaction(tx_hash).call();
+
+    if (tx.source_account !== viewer_public_key) {
+      return NextResponse.json({ error: "Transaction source_account mismatch" }, { status: 400 });
+    }
+
+    const expectedMemo = `streamfi-access:${streamerId}`;
+    if (tx.memo_type !== "text" || tx.memo !== expectedMemo) {
+      return NextResponse.json({ error: "Transaction memo mismatch" }, { status: 400 });
+    }
+
+    const ops = await server.operations().forTransaction(tx_hash).limit(200).call();
+    const payments = ops.records.filter((op: any) => op.type === "payment");
+    if (payments.length === 0) {
+      return NextResponse.json({ error: "No payment operation found" }, { status: 400 });
+    }
+
+    const usdc = getUsdcAssetConfig(network);
+    const required = parseStellarAmountToInt(priceUsdc);
+
+    const matching = payments.find((op: any) => {
+      if (op.to !== streamerWallet) {
+        return false;
+      }
+      if (op.asset_type !== "credit_alphanum4") {
+        return false;
+      }
+      if (op.asset_code !== usdc.code || op.asset_issuer !== usdc.issuer) {
+        return false;
+      }
+      try {
+        return parseStellarAmountToInt(String(op.amount)) >= required;
+      } catch {
+        return false;
+      }
+    });
+
+    if (!matching) {
+      return NextResponse.json(
+        { error: "Payment does not match destination/asset/amount requirements" },
+        { status: 400 }
+      );
+    }
+
+    // Insert grant
+    try {
+      await sql`
+        INSERT INTO stream_access_grants (streamer_id, viewer_id, access_type, tx_hash, amount_usdc)
+        VALUES (${streamerId}, ${viewerId}, 'paid', ${tx_hash}, ${priceUsdc})
+      `;
+    } catch {
+      // If we raced another request, the UNIQUE(tx_hash) or UNIQUE(streamer_id,viewer_id,access_type)
+      // will reject. Treat as idempotent success.
+      return NextResponse.json({ ok: true });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Failed to verify payment" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/components/dashboard/stream-manager/StreamSettings.tsx
+++ b/components/dashboard/stream-manager/StreamSettings.tsx
@@ -1,16 +1,32 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Settings, X, Copy, Check, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { useStellarWallet } from "@/contexts/stellar-wallet-context";
 import { getStellarExplorerUrl } from "@/lib/stellar/config";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function StreamSettings() {
   const { publicKey, privyWallet } = useStellarWallet();
   const walletAddress = publicKey || privyWallet?.wallet || null;
   const [isMinimized, setIsMinimized] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  const [accessType, setAccessType] = useState<"public" | "paid">("public");
+  const [priceUsdc, setPriceUsdc] = useState<string>("25.00");
+  const [paidViewers, setPaidViewers] = useState<number>(0);
+  const [earnedUsdc, setEarnedUsdc] = useState<string>("0");
+  const [isSavingAccess, setIsSavingAccess] = useState(false);
+  const [accessError, setAccessError] = useState<string | null>(null);
+
+  const earningsText = useMemo(() => {
+    if (accessType !== "paid") {
+      return null;
+    }
+    return `${paidViewers} viewers paid · $${earnedUsdc} earned`;
+  }, [accessType, paidViewers, earnedUsdc]);
 
   const copyAddress = () => {
     if (!walletAddress) {
@@ -24,6 +40,69 @@ export default function StreamSettings() {
   const explorerUrl = walletAddress
     ? getStellarExplorerUrl("account", walletAddress)
     : null;
+
+  useEffect(() => {
+    if (!walletAddress) {
+      return;
+    }
+    const load = async () => {
+      try {
+        setAccessError(null);
+        const res = await fetch(
+          `/api/streams/access/config?wallet=${encodeURIComponent(walletAddress)}`
+        );
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data?.error || "Failed to load access settings");
+        }
+        const data = await res.json();
+        setAccessType(data.access_type === "paid" ? "paid" : "public");
+        setPriceUsdc(data.config?.price_usdc ?? "25.00");
+        setPaidViewers(data.stats?.paid_viewers ?? 0);
+        setEarnedUsdc(data.stats?.earned_usdc ?? "0");
+      } catch (e) {
+        setAccessError(e instanceof Error ? e.message : "Failed to load settings");
+      }
+    };
+    void load();
+  }, [walletAddress]);
+
+  const saveAccess = async () => {
+    if (!walletAddress) {
+      return;
+    }
+    setIsSavingAccess(true);
+    setAccessError(null);
+    try {
+      const res = await fetch("/api/streams/access/config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          wallet: walletAddress,
+          access_type: accessType,
+          price_usdc: priceUsdc,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error || "Failed to save access settings");
+      }
+
+      // Refresh stats after save
+      const statsRes = await fetch(
+        `/api/streams/access/config?wallet=${encodeURIComponent(walletAddress)}`
+      );
+      if (statsRes.ok) {
+        const data = await statsRes.json();
+        setPaidViewers(data.stats?.paid_viewers ?? 0);
+        setEarnedUsdc(data.stats?.earned_usdc ?? "0");
+      }
+    } catch (e) {
+      setAccessError(e instanceof Error ? e.message : "Failed to save settings");
+    } finally {
+      setIsSavingAccess(false);
+    }
+  };
 
   if (isMinimized) {
     return (
@@ -98,6 +177,70 @@ export default function StreamSettings() {
             >
               View Wallet &amp; Earnings →
             </Link>
+
+            <div className="pt-3 border-t border-border space-y-2">
+              <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                Stream access
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant={accessType === "public" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setAccessType("public")}
+                >
+                  Public
+                </Button>
+                <Button
+                  type="button"
+                  variant={accessType === "paid" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setAccessType("paid")}
+                >
+                  Paid
+                </Button>
+              </div>
+
+              {accessType === "paid" && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1">
+                      <p className="text-xs text-muted-foreground mb-1">
+                        Price (USDC, min $1, max $999)
+                      </p>
+                      <Input
+                        value={priceUsdc}
+                        onChange={e => setPriceUsdc(e.target.value)}
+                        inputMode="decimal"
+                        placeholder="25.00"
+                      />
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Viewers pay once and can rewatch the recording.
+                  </p>
+                  {earningsText && (
+                    <p className="text-xs text-muted-foreground">{earningsText}</p>
+                  )}
+                </div>
+              )}
+
+              {accessError && (
+                <p className="text-xs text-red-500" role="alert">
+                  {accessError}
+                </p>
+              )}
+
+              <Button
+                type="button"
+                size="sm"
+                className="w-full"
+                disabled={isSavingAccess}
+                onClick={() => void saveAccess()}
+              >
+                {isSavingAccess ? "Saving…" : "Save access settings"}
+              </Button>
+            </div>
           </>
         ) : (
           <p className="text-xs text-muted-foreground text-center py-2">

--- a/components/stream/AccessGate.tsx
+++ b/components/stream/AccessGate.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type React from "react";
+
+import { Button } from "@/components/ui/button";
+
+export function AccessGate(props: {
+  isLoading: boolean;
+  allowed: boolean;
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  onRetry?: () => void;
+}) {
+  const { isLoading, allowed, title, description, action, onRetry } = props;
+
+  if (allowed) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center w-full h-full min-h-[360px] bg-card border border-border rounded-lg p-6">
+      <div className="max-w-md text-center space-y-3">
+        <h2 className="text-xl font-semibold text-foreground">
+          {isLoading ? "Checking access…" : (title ?? "This stream is locked")}
+        </h2>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+        <div className="flex items-center justify-center gap-2 pt-2">
+          {action}
+          {onRetry && (
+            <Button variant="outline" onClick={onRetry} disabled={isLoading}>
+              Retry
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/stream/PaidAccessGate.tsx
+++ b/components/stream/PaidAccessGate.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Ticket } from "lucide-react";
+import { useStellarWallet } from "@/contexts/stellar-wallet-context";
+import { getStellarNetwork } from "@/lib/stellar/config";
+import { buildStreamAccessPayment } from "@/lib/stream/access-payment";
+import { submitTransaction } from "@/lib/stellar/payments";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
+import { hasUsdcTrustline, getUsdcBalance } from "@/lib/stellar/usdc";
+import { EnableUsdcButton } from "@/components/wallet/EnableUsdcButton";
+import { AddFundsButton } from "@/components/wallet/AddFundsButton";
+
+function parseMoneyToNumber(amount: string): number {
+  const n = Number(amount);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function PaidAccessGate(props: {
+  streamerUsername: string;
+  streamerId: string;
+  streamerPublicKey: string | null;
+  viewerPublicKey: string | null;
+  priceUsdc: string | null;
+  onVerified: () => void;
+}) {
+  const {
+    streamerUsername,
+    streamerId,
+    streamerPublicKey,
+    viewerPublicKey,
+    priceUsdc,
+    onVerified,
+  } = props;
+
+  const { kit, connect, isConnected } = useStellarWallet();
+  const network = useMemo(() => getStellarNetwork(), []);
+
+  const [hasTrustline, setHasTrustline] = useState<boolean | null>(null);
+  const [balance, setBalance] = useState<string | null>(null);
+  const [isWorking, setIsWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canPay =
+    !!viewerPublicKey && !!streamerPublicKey && !!priceUsdc && hasTrustline === true;
+
+  const refresh = async () => {
+    if (!viewerPublicKey) {
+      setHasTrustline(null);
+      setBalance(null);
+      return;
+    }
+    try {
+      const tl = await hasUsdcTrustline({ publicKey: viewerPublicKey, network });
+      setHasTrustline(tl);
+      if (tl) {
+        const b = await getUsdcBalance({ publicKey: viewerPublicKey, network });
+        setBalance(b);
+      } else {
+        setBalance(null);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes("NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET")) {
+        setError(
+          "USDC is not configured on this environment. Set NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET in your env to enable USDC payments."
+        );
+      } else {
+        setError(msg || "Failed to load USDC status");
+      }
+      setHasTrustline(null);
+      setBalance(null);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewerPublicKey, network]);
+
+  const insufficient =
+    hasTrustline === true &&
+    !!balance &&
+    !!priceUsdc &&
+    parseMoneyToNumber(balance) < parseMoneyToNumber(priceUsdc);
+
+  const handlePay = async () => {
+    if (!viewerPublicKey || !streamerPublicKey || !priceUsdc) {
+      return;
+    }
+    setIsWorking(true);
+    setError(null);
+    try {
+      const tx = await buildStreamAccessPayment({
+        viewerPublicKey,
+        streamerPublicKey,
+        priceUsdc,
+        streamId: streamerId,
+        network,
+      });
+
+      const walletNetwork =
+        network === "mainnet" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
+      const { signedTxXdr } = await kit.signTransaction(tx.toXDR(), {
+        networkPassphrase: walletNetwork,
+        address: viewerPublicKey,
+      });
+      const signed = TransactionBuilder.fromXDR(
+        signedTxXdr,
+        network === "mainnet"
+          ? "Public Global Stellar Network ; September 2015"
+          : "Test SDF Network ; September 2015"
+      );
+
+      const submit = await submitTransaction(signed as any, network);
+      if (!submit.success || !submit.hash) {
+        throw new Error(submit.error ?? "Payment submission failed");
+      }
+
+      const verify = await fetch("/api/streams/access/verify-payment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          streamer_username: streamerUsername,
+          viewer_public_key: viewerPublicKey,
+          tx_hash: submit.hash,
+        }),
+      });
+      if (!verify.ok) {
+        const data = await verify.json().catch(() => ({}));
+        throw new Error(data?.error ?? "Payment verification failed");
+      }
+
+      onVerified();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Payment failed");
+    } finally {
+      setIsWorking(false);
+      void refresh();
+    }
+  };
+
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <div className="max-w-md w-full text-center space-y-3 bg-card border border-border rounded-lg p-6">
+        <Ticket className="w-12 h-12 text-highlight mx-auto mb-2" />
+        <h2 className="text-xl font-semibold text-foreground">
+          {priceUsdc ? `Watch for $${priceUsdc} USDC` : "Paid stream"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Pay once and watch this stream and its recording forever.
+        </p>
+
+        {!viewerPublicKey && (
+          <Button
+            onClick={() => void connect()}
+            disabled={isWorking}
+            className="w-full"
+          >
+            Connect wallet
+          </Button>
+        )}
+
+        {!!viewerPublicKey && hasTrustline === false && (
+          <div className="space-y-2 pt-2">
+            <EnableUsdcButton
+              walletAddress={viewerPublicKey}
+              onSuccess={() => void refresh()}
+              className="w-full"
+            />
+          </div>
+        )}
+
+        {!!viewerPublicKey && hasTrustline === true && (
+          <div className="space-y-2 pt-2">
+            <Button
+              onClick={() => void handlePay()}
+              disabled={!canPay || isWorking || insufficient}
+              className="w-full"
+            >
+              {isWorking
+                ? "Processing…"
+                : priceUsdc
+                  ? `Pay $${priceUsdc} USDC`
+                  : "Pay USDC"}
+            </Button>
+
+            {insufficient && (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  Insufficient USDC balance.
+                </p>
+                <AddFundsButton
+                  walletAddress={viewerPublicKey}
+                  paramOverrides={{ cryptoCurrencyCode: "USDC" }}
+                  className="w-full"
+                >
+                  Buy USDC
+                </AddFundsButton>
+              </div>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-500 pt-1" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/components/stream/QuickTipBar.tsx
+++ b/components/stream/QuickTipBar.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useStellarWallet } from "@/contexts/stellar-wallet-context";
+import {
+  buildTipTransaction,
+  submitTransaction,
+  hasInsufficientBalance,
+  getCurrentNetwork,
+} from "@/lib/stellar/payments";
+import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
+import { AddFundsButton } from "@/components/wallet/AddFundsButton";
+
+const PRESETS = ["1", "5", "10"] as const;
+
+export function QuickTipBar(props: {
+  playbackId: string;
+  streamerUsername: string;
+  streamerPublicKey: string;
+  viewerPublicKey: string;
+  hidden?: boolean;
+  onCustomTip?: () => void;
+}) {
+  const {
+    playbackId,
+    streamerPublicKey,
+    viewerPublicKey,
+    hidden = false,
+    onCustomTip,
+  } = props;
+
+  const { kit } = useStellarWallet();
+  const [isPaying, setIsPaying] = useState(false);
+  const [insufficient, setInsufficient] = useState(false);
+
+  const network = useMemo(() => getCurrentNetwork(), []);
+
+  if (hidden) {
+    return null;
+  }
+
+  const postTipSystemMessage = async (amount: string) => {
+    const uname =
+      typeof window !== "undefined"
+        ? sessionStorage.getItem("username") || "Someone"
+        : "Someone";
+    const content = `💜 @${uname} tipped ${amount} XLM`;
+    await fetch("/api/streams/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        wallet: viewerPublicKey,
+        playbackId,
+        content,
+        messageType: "system",
+      }),
+    });
+  };
+
+  const sendPreset = async (amount: string) => {
+    setIsPaying(true);
+    setInsufficient(false);
+    try {
+      const noBalance = await hasInsufficientBalance(viewerPublicKey, amount);
+      if (noBalance) {
+        setInsufficient(true);
+        return;
+      }
+
+      const tx = await buildTipTransaction({
+        sourcePublicKey: viewerPublicKey,
+        destinationPublicKey: streamerPublicKey,
+        amount,
+        network,
+      });
+
+      const walletNetwork =
+        network === "mainnet" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
+      const { signedTxXdr } = await kit.signTransaction(tx.toXDR(), {
+        networkPassphrase: walletNetwork,
+        address: viewerPublicKey,
+      });
+      const signed = TransactionBuilder.fromXDR(
+        signedTxXdr,
+        network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET
+      );
+
+      const result = await submitTransaction(signed as any, network);
+      if (!result.success) {
+        throw new Error(result.error ?? "Tip transaction failed");
+      }
+
+      await postTipSystemMessage(amount);
+    } finally {
+      setIsPaying(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 pb-2 flex-wrap">
+      {PRESETS.map(preset => (
+        <Button
+          key={preset}
+          size="sm"
+          variant="outline"
+          disabled={isPaying}
+          onClick={() => void sendPreset(preset)}
+        >
+          {preset} XLM
+        </Button>
+      ))}
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={isPaying}
+        onClick={onCustomTip}
+      >
+        Custom…
+      </Button>
+
+      {insufficient && (
+        <div className="ml-auto">
+          <AddFundsButton walletAddress={viewerPublicKey}>
+            Add XLM
+          </AddFundsButton>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/stream/TipAlertOverlay.tsx
+++ b/components/stream/TipAlertOverlay.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+
+export type TipAlert = {
+  id: string;
+  text: string;
+};
+
+export function TipAlertOverlay(props: {
+  alerts: TipAlert[];
+  onExpire: (id: string) => void;
+  max?: number;
+}) {
+  const { alerts, onExpire, max = 5 } = props;
+
+  useEffect(() => {
+    const timers = alerts
+      .slice(0, max)
+      .map(a => window.setTimeout(() => onExpire(a.id), 5000));
+    return () => timers.forEach(t => window.clearTimeout(t));
+  }, [alerts, onExpire, max]);
+
+  const visible = alerts.slice(0, max);
+
+  return (
+    <div className="absolute bottom-4 left-4 z-30 flex flex-col gap-2 pointer-events-none">
+      {visible.map(a => (
+        <div
+          key={a.id}
+          className="bg-black/70 text-white border border-white/10 backdrop-blur-sm rounded-md px-3 py-2 text-sm"
+        >
+          {a.text}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/stream/TokenGatedAccessGate.tsx
+++ b/components/stream/TokenGatedAccessGate.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Shield, Loader2, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useStellarWallet } from "@/contexts/stellar-wallet-context";
+
+interface TokenGatedAccessGateProps {
+  streamerUsername: string;
+  assetCode: string;
+  minBalance: string;
+  onRetry?: () => void;
+  isChecking?: boolean;
+}
+
+/**
+ * Shown when a token-gated stream denies access (no / insufficient balance).
+ */
+export default function TokenGatedAccessGate({
+  streamerUsername,
+  assetCode,
+  minBalance,
+  onRetry,
+  isChecking = false,
+}: TokenGatedAccessGateProps) {
+  const { isConnected, connect } = useStellarWallet();
+
+  const handleConnect = async () => {
+    await connect();
+    onRetry?.();
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] text-center px-6 py-12 bg-card border border-border rounded-2xl">
+      <div className="p-4 rounded-full bg-highlight/10 mb-6">
+        <Shield className="w-12 h-12 text-highlight" />
+      </div>
+
+      <h2 className="text-xl font-bold text-foreground mb-2">
+        Token-gated stream
+      </h2>
+
+      <p className="text-muted-foreground mb-1">
+        You need to hold at least{" "}
+        <span className="font-semibold text-foreground">
+          {minBalance} {assetCode}
+        </span>{" "}
+        to watch this stream.
+      </p>
+
+      <p className="text-muted-foreground text-sm mb-8">
+        Contact{" "}
+        <span className="font-semibold text-foreground">
+          @{streamerUsername}
+        </span>{" "}
+        to find out how to get {assetCode} tokens.
+      </p>
+
+      {isChecking ? (
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Checking access…
+        </div>
+      ) : !isConnected ? (
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-sm text-muted-foreground">
+            Connect your Stellar wallet to verify token ownership.
+          </p>
+          <Button
+            onClick={handleConnect}
+            className="bg-highlight hover:bg-highlight/90 text-white"
+          >
+            Connect Wallet
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3">
+          <Button variant="outline" onClick={onRetry} disabled={isChecking}>
+            Re-check access
+          </Button>
+          <a
+            href="https://stellar.expert/explorer/public"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-muted-foreground underline hover:text-foreground transition-colors"
+          >
+            View assets on Stellar Expert
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/stream/chat-section.tsx
+++ b/components/stream/chat-section.tsx
@@ -3,12 +3,31 @@
 import type React from "react";
 
 import { useState, useRef, useEffect } from "react";
-import { ChevronRight, Send, Smile, GiftIcon, Wallet } from "lucide-react";
+import {
+  ChevronRight,
+  Send,
+  Smile,
+  GiftIcon,
+  Wallet,
+  MoreVertical,
+  Trash2,
+  Ban,
+  Clock,
+} from "lucide-react";
+import { toast } from "sonner";
 import type { ChatMessage } from "@/types/chat";
+import { QuickTipBar } from "./QuickTipBar";
 
 interface ChatSectionProps {
   messages: ChatMessage[];
   onSendMessage: (message: string) => void;
+  playbackId?: string | null;
+  streamerUsername?: string;
+  streamerPublicKey?: string | null;
+  viewerPublicKey?: string | null;
+  onOpenCustomTip?: () => void;
+  onDeleteMessage?: (messageId: number) => void;
+  onBanUser?: (username: string, durationMinutes?: number) => void;
   isCollapsible?: boolean;
   isFullscreen?: boolean;
   className?: string;
@@ -16,11 +35,19 @@ interface ChatSectionProps {
   showChat?: boolean;
   isWalletConnected?: boolean;
   isSending?: boolean;
+  isStreamOwner?: boolean;
 }
 
 const ChatSection = ({
   messages,
   onSendMessage,
+  playbackId = null,
+  streamerUsername,
+  streamerPublicKey = null,
+  viewerPublicKey = null,
+  onOpenCustomTip,
+  onDeleteMessage,
+  onBanUser,
   isCollapsible = true,
   isFullscreen = false,
   className = "",
@@ -28,17 +55,78 @@ const ChatSection = ({
   showChat = true,
   isWalletConnected = false,
   isSending = false,
+  isStreamOwner = false,
 }: ChatSectionProps) => {
   const [chatMessage, setChatMessage] = useState("");
+  const [isInputFocused, setIsInputFocused] = useState(false);
+  const [highlightId, setHighlightId] = useState<number | null>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    messageId: number;
+    username: string;
+    x: number;
+    y: number;
+    showTimeoutSubmenu?: boolean;
+  } | null>(null);
 
-  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     if (chatContainerRef.current) {
       chatContainerRef.current.scrollTop =
         chatContainerRef.current.scrollHeight;
     }
   }, [messages]);
+
+  useEffect(() => {
+    const last = messages[messages.length - 1];
+    if (!last || last.messageType !== "system") {
+      return;
+    }
+    setHighlightId(last.id);
+    const t = window.setTimeout(() => setHighlightId(null), 3000);
+    return () => window.clearTimeout(t);
+  }, [messages]);
+
+  useEffect(() => {
+    const handleClickOutside = () => setContextMenu(null);
+    if (contextMenu) {
+      document.addEventListener("click", handleClickOutside);
+      return () => document.removeEventListener("click", handleClickOutside);
+    }
+  }, [contextMenu]);
+
+  const handleContextMenu = (
+    e: React.MouseEvent,
+    messageId: number,
+    username: string
+  ) => {
+    if (!isStreamOwner) {
+      return;
+    }
+    e.preventDefault();
+    setContextMenu({
+      messageId,
+      username,
+      x: e.clientX,
+      y: e.clientY,
+    });
+  };
+
+  const handleDeleteMessage = () => {
+    if (contextMenu && onDeleteMessage) {
+      onDeleteMessage(contextMenu.messageId);
+      setContextMenu(null);
+    }
+  };
+
+  const handleBanUser = (durationMinutes?: number) => {
+    if (contextMenu && onBanUser) {
+      onBanUser(contextMenu.username, durationMinutes);
+      setContextMenu(null);
+    } else if (contextMenu) {
+      toast.message("User timeouts and bans are not wired up yet.");
+      setContextMenu(null);
+    }
+  };
 
   const handleSendMessage = () => {
     if (!chatMessage.trim() || !isWalletConnected || isSending) {
@@ -48,7 +136,6 @@ const ChatSection = ({
     onSendMessage(chatMessage);
     setChatMessage("");
 
-    // Auto-scroll to bottom
     if (chatContainerRef.current) {
       setTimeout(() => {
         if (chatContainerRef.current) {
@@ -71,7 +158,6 @@ const ChatSection = ({
 
   return (
     <div className={`bg-background flex flex-col ${className}`}>
-      {/* Chat header */}
       <div className="border border-border p-3 border-b flex justify-between items-center">
         <h3 className="text- font-medium">Chat</h3>
         {isCollapsible && onToggleChat && (
@@ -85,9 +171,7 @@ const ChatSection = ({
         )}
       </div>
 
-      {/* Chat messages */}
       <div className="text-foreground bg-background relative flex-1 overflow-hidden">
-        {/* Gradient overlay at top */}
         <div
           className={`absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-white ${
             isFullscreen ? "dark:from-secondary " : "dark:from-background"
@@ -98,6 +182,21 @@ const ChatSection = ({
           ref={chatContainerRef}
           className={`${isFullscreen ? "h-full" : "h-[calc(100vh-200px)]"} overflow-y-auto scrollbar-hide p-3 space-y-4 pt-8 pb-16`}
         >
+          {typeof highlightId === "number" && (
+            <div className="sticky top-2 z-20">
+              {(() => {
+                const msg = messages.find(m => m.id === highlightId);
+                if (!msg) {
+                  return null;
+                }
+                return (
+                  <div className="bg-highlight/15 border border-highlight/30 text-highlight rounded-md px-3 py-2 text-xs">
+                    {msg.message}
+                  </div>
+                );
+              })()}
+            </div>
+          )}
           {messages.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-full text-center p-4">
               <p className="text-sm font-semibold mb-2 text-foreground">
@@ -111,27 +210,50 @@ const ChatSection = ({
             messages.map(message => (
               <div
                 key={message.id}
-                className={`text-xs xl:text-sm flex ${message.isPending ? "opacity-50" : ""}`}
+                className={`text-xs xl:text-sm flex group relative ${
+                  message.isPending ? "opacity-50" : ""
+                } ${message.messageType === "system" ? "text-highlight" : ""}`}
+                onContextMenu={e =>
+                  handleContextMenu(e, message.id, message.username)
+                }
               >
                 <div
-                  className="w-1 mr-2 rounded-full"
+                  className="w-1 mr-2 rounded-full shrink-0"
                   style={{ backgroundColor: message.color }}
                 />
-                <div>
+                <div className="flex-1 min-w-0">
                   <span
                     className="font-medium"
                     style={{ color: message.color }}
                   >
-                    {message.username}:{" "}
+                    {message.messageType === "system"
+                      ? "System: "
+                      : `${message.username}: `}
                   </span>
                   <span>{message.message}</span>
                 </div>
+                {isStreamOwner && (
+                  <button
+                    type="button"
+                    onClick={e => {
+                      e.stopPropagation();
+                      setContextMenu({
+                        messageId: message.id,
+                        username: message.username,
+                        x: e.currentTarget.getBoundingClientRect().right,
+                        y: e.currentTarget.getBoundingClientRect().top,
+                      });
+                    }}
+                    className="opacity-0 group-hover:opacity-100 ml-2 p-1 hover:bg-secondary rounded transition-opacity shrink-0"
+                  >
+                    <MoreVertical className="h-3 w-3" />
+                  </button>
+                )}
               </div>
             ))
           )}
         </div>
 
-        {/* Gradient overlay at bottom */}
         <div
           className={`absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white ${
             isFullscreen ? "dark:from-secondary" : "dark:from-background"
@@ -139,33 +261,60 @@ const ChatSection = ({
         />
       </div>
 
-      {/* Chat input */}
       <div className="border border-border p-3 border-t">
         {isWalletConnected ? (
-          <div className="relative flex items-center">
-            <input
-              type="text"
-              value={chatMessage}
-              onChange={e => setChatMessage(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Send a message"
-              disabled={isSending}
-              className="w-full bg-secondary text-foreground rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-highlight disabled:opacity-50"
-            />
-            <div className="absolute right-2 top-2 flex space-x-1 items-center">
-              <button className="text-muted-foreground hover:text-foreground">
-                <Smile className="h-4 w-4" />
-              </button>
-              <button className="text-muted-foreground hover:text-foreground">
-                <GiftIcon className="h-4 w-4" />
-              </button>
-              <button
-                className="text-muted-foreground hover:text-foreground disabled:opacity-50"
-                onClick={handleSendMessage}
-                disabled={!chatMessage.trim() || isSending}
-              >
-                <Send className="h-4 w-4" />
-              </button>
+          <div>
+            {playbackId &&
+              streamerUsername &&
+              streamerPublicKey &&
+              viewerPublicKey && (
+                <QuickTipBar
+                  playbackId={playbackId}
+                  streamerUsername={streamerUsername}
+                  streamerPublicKey={streamerPublicKey}
+                  viewerPublicKey={viewerPublicKey}
+                  hidden={
+                    isInputFocused && typeof window !== "undefined"
+                      ? window.innerWidth < 640
+                      : false
+                  }
+                  onCustomTip={onOpenCustomTip}
+                />
+              )}
+            <div className="relative flex items-center">
+              <input
+                type="text"
+                value={chatMessage}
+                onChange={e => setChatMessage(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onFocus={() => setIsInputFocused(true)}
+                onBlur={() => setIsInputFocused(false)}
+                placeholder="Send a message"
+                disabled={isSending}
+                className="w-full bg-secondary text-foreground rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-highlight disabled:opacity-50"
+              />
+              <div className="absolute right-2 top-2 flex space-x-1 items-center">
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <Smile className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <GiftIcon className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+                  onClick={handleSendMessage}
+                  disabled={!chatMessage.trim() || isSending}
+                >
+                  <Send className="h-4 w-4" />
+                </button>
+              </div>
             </div>
           </div>
         ) : (
@@ -175,6 +324,85 @@ const ChatSection = ({
           </div>
         )}
       </div>
+
+      {contextMenu && isStreamOwner && (
+        <div
+          className="fixed bg-background border border-border rounded-md shadow-lg z-50 py-1 min-w-[160px]"
+          style={{
+            top: `${contextMenu.y}px`,
+            left: `${contextMenu.x}px`,
+          }}
+          onClick={e => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={handleDeleteMessage}
+            className="w-full px-3 py-2 text-left text-sm hover:bg-secondary flex items-center gap-2"
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete message
+          </button>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() =>
+                setContextMenu(prev =>
+                  prev
+                    ? { ...prev, showTimeoutSubmenu: !prev.showTimeoutSubmenu }
+                    : null
+                )
+              }
+              className="w-full px-3 py-2 text-left text-sm hover:bg-secondary flex items-center gap-2 justify-between"
+            >
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Timeout
+              </div>
+              <ChevronRight className="h-3 w-3" />
+            </button>
+            {contextMenu.showTimeoutSubmenu && (
+              <div className="absolute left-full top-0 ml-1 bg-background border border-border rounded-md shadow-lg py-1 min-w-[120px]">
+                <button
+                  type="button"
+                  onClick={() => handleBanUser(1)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-secondary"
+                >
+                  1 minute
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleBanUser(5)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-secondary"
+                >
+                  5 minutes
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleBanUser(10)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-secondary"
+                >
+                  10 minutes
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleBanUser(60)}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-secondary"
+                >
+                  1 hour
+                </button>
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => handleBanUser()}
+            className="w-full px-3 py-2 text-left text-sm hover:bg-secondary flex items-center gap-2 text-red-500"
+          >
+            <Ban className="h-4 w-4" />
+            Ban user
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/stream/view-stream.tsx
+++ b/components/stream/view-stream.tsx
@@ -41,6 +41,11 @@ import { useChat } from "@/hooks/useChat";
 import { TipButton, TipModalContainer } from "@/components/tipping";
 import { useTipModal } from "@/hooks/useTipModal";
 import { toast } from "sonner";
+import { AccessGate } from "./AccessGate";
+import { PaidAccessGate } from "./PaidAccessGate";
+import TokenGatedAccessGate from "./TokenGatedAccessGate";
+import { useStreamAccess } from "@/hooks/useStreamAccess";
+import { TipAlertOverlay, type TipAlert } from "./TipAlertOverlay";
 
 const socialIcons: Record<string, JSX.Element> = {
   twitter: <Twitter className="h-4 w-4" />,
@@ -279,6 +284,17 @@ const ViewStream = ({
   const address = publicKey || privyWallet?.wallet || null;
   const tipModalState = useTipModal();
 
+  const {
+    access,
+    isLoading: isCheckingAccess,
+    refresh,
+  } = useStreamAccess({
+    streamerUsername: username,
+    viewerPublicKey: address,
+    enabled: !isOwner,
+  });
+  const isAllowed = isOwner || !access || access.allowed === true;
+
   const videoContainerRef = useRef<HTMLDivElement>(null);
   const mainContentRef = useRef<HTMLDivElement>(null);
   const overlayScrollRef = useRef<HTMLDivElement>(null);
@@ -286,8 +302,31 @@ const ViewStream = ({
   const {
     messages: chatMessages,
     sendMessage,
+    deleteMessage,
+    banUser,
     isSending,
-  } = useChat(userData?.playbackId, address, isLive);
+  } = useChat(userData?.playbackId, address, isLive, showChat || isFullscreen);
+
+  const [tipAlerts, setTipAlerts] = useState<TipAlert[]>([]);
+  const lastTipMessageId = useRef<number | null>(null);
+
+  useEffect(() => {
+    const last = chatMessages[chatMessages.length - 1];
+    if (!last || last.messageType !== "system") {
+      return;
+    }
+    if (lastTipMessageId.current === last.id) {
+      return;
+    }
+    if (!last.message.startsWith("💜")) {
+      return;
+    }
+    lastTipMessageId.current = last.id;
+    setTipAlerts(prev => {
+      const next = [{ id: String(last.id), text: last.message }, ...prev];
+      return next.slice(0, 5);
+    });
+  }, [chatMessages]);
 
   // Stable refs so the native keydown listener always reads current values
   const chatOverlayMessageRef = useRef(chatOverlayMessage);
@@ -521,6 +560,47 @@ const ViewStream = ({
               ref={videoContainerRef}
               className={`relative bg-black overflow-hidden group ${isFullscreen ? "flex h-screen" : "w-full aspect-video min-h-[56vw] lg:min-h-[360px]"}`}
             >
+              <TipAlertOverlay
+                alerts={tipAlerts}
+                onExpire={id =>
+                  setTipAlerts(prev => prev.filter(a => a.id !== id))
+                }
+                max={5}
+              />
+              {!isAllowed && access && (
+                <div className="absolute inset-0 z-20 flex items-center justify-center p-4 bg-black/80 overflow-y-auto">
+                  {access.access_type === "paid" &&
+                  "streamer_id" in access &&
+                  (access.reason === "paid" ||
+                    access.reason === "wallet_required") ? (
+                    <PaidAccessGate
+                      streamerUsername={username}
+                      streamerId={access.streamer_id}
+                      streamerPublicKey={access.streamer_public_key}
+                      viewerPublicKey={address}
+                      priceUsdc={access.price_usdc}
+                      onVerified={() => void refresh()}
+                    />
+                  ) : access.access_type === "token_gated" &&
+                    "asset_code" in access ? (
+                    <TokenGatedAccessGate
+                      streamerUsername={username}
+                      assetCode={access.asset_code}
+                      minBalance={access.min_balance}
+                      onRetry={() => void refresh()}
+                      isChecking={isCheckingAccess}
+                    />
+                  ) : (
+                    <AccessGate
+                      isLoading={isCheckingAccess}
+                      allowed={false}
+                      title="This stream is locked"
+                      description="You don't have access to this stream."
+                      onRetry={() => void refresh()}
+                    />
+                  )}
+                </div>
+              )}
               {/* Video content area */}
               <div
                 className={`relative ${isFullscreen ? "flex-1" : "w-full h-full"}`}
@@ -533,7 +613,7 @@ const ViewStream = ({
                     : undefined
                 }
               >
-                {isLive && userData?.playbackId ? (
+                {isAllowed && isLive && userData?.playbackId ? (
                   <MuxPlayer
                     playbackId={userData.playbackId}
                     streamType="live:dvr"
@@ -955,6 +1035,13 @@ const ViewStream = ({
               <ChatSection
                 messages={chatMessages}
                 onSendMessage={sendMessage}
+                playbackId={userData?.playbackId ?? null}
+                streamerUsername={username}
+                streamerPublicKey={streamData?.stellarAddress ?? null}
+                viewerPublicKey={address}
+                onOpenCustomTip={tipModalState.openTipModal}
+                onDeleteMessage={deleteMessage}
+                onBanUser={banUser}
                 isCollapsible={true}
                 isFullscreen={false}
                 className="h-full"
@@ -962,6 +1049,7 @@ const ViewStream = ({
                 showChat={showChat}
                 isWalletConnected={!!address}
                 isSending={isSending}
+                isStreamOwner={isOwner}
               />
             </div>
           )}
@@ -1024,6 +1112,7 @@ const ViewStream = ({
         recipientPublicKey={streamData?.stellarAddress || ""}
         recipientAvatar={streamData?.avatarUrl}
         senderPublicKey={publicKey}
+        isPrivyUser={!!privyWallet && !publicKey}
         onSuccess={tipModalState.showSuccess}
         onError={tipModalState.showError}
         confirmationState={tipModalState.tipConfirmation}

--- a/components/tipping/TipModal.tsx
+++ b/components/tipping/TipModal.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, XCircle, AlertTriangle } from "lucide-react";
+import { AddFundsButton } from "@/components/wallet/AddFundsButton";
 import {
   buildTipTransaction,
   submitTransaction,
@@ -24,7 +25,6 @@ import {
 import { TransactionBuilder, Networks } from "@stellar/stellar-sdk";
 import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
 import { useStellarWallet } from "@/contexts/stellar-wallet-context";
-import { TipConfirmation } from "./TipConfirmation";
 
 interface TipModalProps {
   isOpen: boolean;
@@ -33,6 +33,7 @@ interface TipModalProps {
   recipientPublicKey: string;
   recipientAvatar?: string;
   senderPublicKey: string;
+  isPrivyUser?: boolean;
   onSuccess?: (txHash: string, amount: string) => void;
   onError?: (error: string) => void;
 }
@@ -42,11 +43,10 @@ type TransactionState =
   | "building"
   | "signing"
   | "submitting"
-  | "success"
   | "error";
 
 const PRESET_AMOUNTS = [1, 5, 10, 25];
-const MAX_TIP_AMOUNT = 10000; // 10,000 XLM cap
+const MAX_TIP_AMOUNT = 10000;
 const MIN_TIP_AMOUNT = 0.0000001;
 
 export function TipModal({
@@ -56,32 +56,24 @@ export function TipModal({
   recipientPublicKey,
   recipientAvatar,
   senderPublicKey,
+  isPrivyUser = false,
   onSuccess,
   onError,
 }: TipModalProps) {
-  // Fix #3 - Single state for amount (no more DRY violation)
   const [amount, setAmount] = useState<string>("");
   const [transactionState, setTransactionState] =
     useState<TransactionState>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [txHash, setTxHash] = useState<string | null>(null);
   const [xlmPrice, setXlmPrice] = useState<number>(0);
   const [isLoadingPrice, setIsLoadingPrice] = useState<boolean>(false);
-  // Fix #5 - Track price fetch failures
   const [priceFetchFailed, setPriceFetchFailed] = useState<boolean>(false);
-  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
-  const [structuredError, setStructuredError] = useState<{
-    message: string;
-    details?: string;
-    code?: string;
-  } | null>(null);
+  const [isInsufficientBalance, setIsInsufficientBalance] = useState(false);
 
   const { kit } = useStellarWallet();
   const fee = calculateFeeEstimate();
   const usdEquivalent =
     xlmPrice && amount ? (parseFloat(amount) * xlmPrice).toFixed(2) : "0.00";
 
-  // Fix #5 - Fetch XLM price with failure tracking
   useEffect(() => {
     if (isOpen) {
       setIsLoadingPrice(true);
@@ -99,7 +91,6 @@ export function TipModal({
     }
   }, [isOpen]);
 
-  // Reset state when modal closes
   useEffect(() => {
     if (!isOpen) {
       resetModal();
@@ -110,25 +101,23 @@ export function TipModal({
     setAmount("");
     setTransactionState("idle");
     setError(null);
-    setTxHash(null);
-    setIsConfirmationOpen(false);
-    setStructuredError(null);
+    setIsInsufficientBalance(false);
   };
 
   const handlePresetClick = (presetAmount: number) => {
     setAmount(presetAmount.toString());
     setError(null);
+    setIsInsufficientBalance(false);
   };
 
   const handleAmountChange = (value: string) => {
-    // Only allow valid decimal numbers
     if (value === "" || /^\d*\.?\d*$/.test(value)) {
       setAmount(value);
       setError(null);
+      setIsInsufficientBalance(false);
     }
   };
 
-  // Fix #4 - Validate Stellar public key format
   const isValidStellarPublicKey = (key: string): boolean => {
     return key.startsWith("G") && key.length === 56;
   };
@@ -146,7 +135,6 @@ export function TipModal({
       return false;
     }
 
-    // Fix #4 - Max amount validation
     if (parsedAmount > MAX_TIP_AMOUNT) {
       setError(
         `Amount is too large. Maximum is ${MAX_TIP_AMOUNT.toLocaleString()} XLM`
@@ -154,7 +142,6 @@ export function TipModal({
       return false;
     }
 
-    // Fix #4 - Validate Stellar public keys
     if (!isValidStellarPublicKey(recipientPublicKey)) {
       setError("Invalid recipient Stellar address");
       return false;
@@ -169,15 +156,14 @@ export function TipModal({
   };
 
   const handleSubmit = async () => {
-    // Validate amount
     if (!validateAmount()) {
       return;
     }
 
     setError(null);
+    setIsInsufficientBalance(false);
 
     try {
-      // Check for sufficient balance
       setTransactionState("building");
       const insufficientBalance = await hasInsufficientBalance(
         senderPublicKey,
@@ -188,14 +174,11 @@ export function TipModal({
         setError(
           "Insufficient balance. Please ensure you have enough XLM to cover the tip and transaction fee."
         );
+        setIsInsufficientBalance(true);
         setTransactionState("error");
-        if (onError) {
-          onError("Insufficient balance");
-        }
         return;
       }
 
-      // Build transaction
       const network =
         process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
           ? "mainnet"
@@ -207,7 +190,6 @@ export function TipModal({
         network: network as "testnet" | "mainnet",
       });
 
-      // Sign transaction with connected wallet
       setTransactionState("signing");
       const walletNetwork =
         network === "mainnet" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
@@ -222,7 +204,6 @@ export function TipModal({
         networkPassphrase
       );
 
-      // Submit signed transaction
       setTransactionState("submitting");
       const result = await submitTransaction(
         signedTransaction as any,
@@ -230,22 +211,17 @@ export function TipModal({
       );
 
       if (result.success) {
-        setTransactionState("success");
-        setTxHash(result.hash ?? null);
-        setIsConfirmationOpen(true);
-        // Call onSuccess callback if provided
         if (onSuccess && result.hash) {
           onSuccess(result.hash, amount);
         }
-      } else {
-        throw result.error
-          ? new Error(result.error)
-          : new Error("Transaction failed");
+        return;
       }
+      throw result.error
+        ? new Error(result.error)
+        : new Error("Transaction failed");
     } catch (err: unknown) {
       console.error("Transaction error:", err);
 
-      // Fix #6 - Better error handling for balance issues in submit flow
       let errorMessage = "An unexpected error occurred. Please try again.";
 
       if (err instanceof Error) {
@@ -260,6 +236,7 @@ export function TipModal({
         ) {
           errorMessage =
             "Insufficient balance. Your balance may have changed. Please try a smaller amount.";
+          setIsInsufficientBalance(true);
         } else if (err.message.includes("timeout")) {
           errorMessage = "Transaction timed out. Please try again.";
         } else if (
@@ -274,35 +251,19 @@ export function TipModal({
       }
 
       setError(errorMessage);
-      setStructuredError({
-        message: errorMessage,
-        details: err instanceof Error ? err.stack || err.message : String(err),
-        code: (err as any)?.code || (err as any)?.status?.toString(),
-      });
       setTransactionState("error");
-      setIsConfirmationOpen(true);
-      // Call onError callback if provided
       if (onError) {
         onError(errorMessage);
       }
     }
   };
 
-  const handleRetry = () => {
-    setError(null);
-    setTransactionState("idle");
-  };
-
   const handleClose = () => {
-    // Prevent closing during signing/submitting
     if (transactionState === "signing" || transactionState === "submitting") {
       return;
     }
     onClose();
   };
-
-  const currentConfirmationState =
-    transactionState === "success" ? "success" : "error";
 
   const getStateMessage = () => {
     switch (transactionState) {
@@ -312,8 +273,6 @@ export function TipModal({
         return "Please approve the transaction in your wallet";
       case "submitting":
         return "Submitting transaction to network...";
-      case "success":
-        return "Tip sent successfully!";
       case "error":
         return "Transaction failed";
       default:
@@ -334,13 +293,10 @@ export function TipModal({
         <DialogHeader>
           <DialogTitle>Send Tip</DialogTitle>
           <DialogDescription>
-            {transactionState === "success"
-              ? "Your tip has been sent successfully!"
-              : `Send a tip to @${recipientUsername}`}
+            Send a tip to @{recipientUsername}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-6 py-4">
-          {/* Recipient Info */}
           <div className="flex items-center gap-3 p-3 bg-muted rounded-lg">
             <Avatar className="h-12 w-12">
               <AvatarImage src={recipientAvatar} alt={recipientUsername} />
@@ -348,57 +304,14 @@ export function TipModal({
                 {recipientUsername.slice(0, 2).toUpperCase()}
               </AvatarFallback>
             </Avatar>
-            <div>
+            <div className="min-w-0">
               <p className="font-semibold">@{recipientUsername}</p>
-              <p className="text-xs text-muted-foreground truncate max-w-[200px]">
+              <p className="text-xs text-muted-foreground truncate max-w-[220px]">
                 {recipientPublicKey}
               </p>
             </div>
-
-            {/* Amount Summary */}
-            {amount !== "" && parseFloat(amount) > 0 && (
-              <div className="space-y-2 p-3 bg-muted rounded-lg text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Amount:</span>
-                  <span className="font-semibold">{amount} XLM</span>
-                </div>
-                {xlmPrice > 0 && !isLoadingPrice && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">USD Value:</span>
-                    <span className="font-semibold">≈ ${usdEquivalent}</span>
-                  </div>
-                )}
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Network Fee:</span>
-                  <span className="font-semibold">{fee.toFixed(7)} XLM</span>
-                </div>
-                <div className="border-t border-border pt-2 flex justify-between font-semibold">
-                  <span>Total:</span>
-                  <span>{(parseFloat(amount) + fee).toFixed(7)} XLM</span>
-                </div>
-              </div>
-            )}
-
-            {/* State Messages */}
-            {isProcessing && (
-              <div className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
-                <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
-                <p className="text-sm text-blue-500">{getStateMessage()}</p>
-              </div>
-            )}
-
-            {/* Error Message (validation or transaction error) */}
-            {error && (
-              <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
-                <XCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
-                <div className="flex-1">
-                  <p className="text-sm text-red-500">{error}</p>
-                </div>
-              </div>
-            )}
           </div>
 
-          {/* Fix #5 - Price fetch failure warning */}
           {priceFetchFailed && !isLoadingPrice && (
             <div className="flex items-center gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
               <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
@@ -408,7 +321,6 @@ export function TipModal({
             </div>
           )}
 
-          {/* Preset Amounts */}
           <div className="space-y-2">
             <Label>Select Amount</Label>
             <div className="grid grid-cols-4 gap-2">
@@ -428,7 +340,6 @@ export function TipModal({
             </div>
           </div>
 
-          {/* Custom Amount */}
           <div className="space-y-2">
             <Label htmlFor="custom-amount">Or Enter Custom Amount</Label>
             <div className="relative">
@@ -450,7 +361,6 @@ export function TipModal({
             </p>
           </div>
 
-          {/* Amount Summary */}
           {amount !== "" && parseFloat(amount) > 0 && (
             <div className="space-y-2 p-3 bg-muted rounded-lg text-sm">
               <div className="flex justify-between">
@@ -474,7 +384,6 @@ export function TipModal({
             </div>
           )}
 
-          {/* State Messages */}
           {isProcessing && (
             <div className="flex items-center gap-2 p-3 bg-blue-500/10 border border-blue-500/30 rounded-lg">
               <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
@@ -482,13 +391,24 @@ export function TipModal({
             </div>
           )}
 
-          {/* Error Message */}
-          {error && transactionState === "error" && !isConfirmationOpen && (
+          {error && transactionState === "error" && (
             <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
               <XCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
               <div className="flex-1">
                 <p className="text-sm text-red-500">{error}</p>
               </div>
+            </div>
+          )}
+
+          {isInsufficientBalance && transactionState === "error" && (
+            <div className="flex items-center justify-between gap-3 p-3 bg-highlight/10 border border-highlight/20 rounded-lg">
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Need more XLM? Top up your wallet with fiat.
+              </p>
+              <AddFundsButton
+                walletAddress={senderPublicKey}
+                isPrivyUser={isPrivyUser}
+              />
             </div>
           )}
         </div>
@@ -520,29 +440,6 @@ export function TipModal({
           </div>
         </DialogFooter>
       </DialogContent>
-
-      <TipConfirmation
-        isOpen={isConfirmationOpen}
-        onClose={() => {
-          setIsConfirmationOpen(false);
-          if (transactionState === "success") {
-            onClose();
-          }
-        }}
-        state={currentConfirmationState}
-        amount={amount}
-        recipientUsername={recipientUsername}
-        txHash={txHash || undefined}
-        error={structuredError || undefined}
-        onRetry={() => {
-          setIsConfirmationOpen(false);
-          handleRetry();
-        }}
-        onSendAnother={() => {
-          setIsConfirmationOpen(false);
-          resetModal();
-        }}
-      />
     </Dialog>
   );
 }

--- a/components/tipping/TipModalContainer.tsx
+++ b/components/tipping/TipModalContainer.tsx
@@ -12,6 +12,7 @@ interface TipModalContainerProps {
   recipientPublicKey: string;
   recipientAvatar?: string;
   senderPublicKey: string | null;
+  isPrivyUser?: boolean;
   onSuccess: (txHash: string, amount: string) => void;
   onError: (error: string) => void;
 
@@ -32,6 +33,7 @@ export function TipModalContainer({
   recipientPublicKey,
   recipientAvatar,
   senderPublicKey,
+  isPrivyUser,
   onSuccess,
   onError,
   confirmationState,
@@ -48,6 +50,7 @@ export function TipModalContainer({
           recipientPublicKey={recipientPublicKey}
           recipientAvatar={recipientAvatar}
           senderPublicKey={senderPublicKey}
+          isPrivyUser={isPrivyUser}
           onSuccess={onSuccess}
           onError={onError}
         />

--- a/components/wallet/AddFundsButton.tsx
+++ b/components/wallet/AddFundsButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export function AddFundsButton(props: {
+  walletAddress: string;
+  paramOverrides?: Record<string, string>;
+  className?: string;
+  children?: React.ReactNode;
+}) {
+  const { walletAddress, paramOverrides, className, children } = props;
+
+  const params = new URLSearchParams({
+    walletAddress,
+    ...(paramOverrides ?? {}),
+  });
+
+  const href = `https://global.transak.com/?${params.toString()}`;
+
+  return (
+    <Button asChild variant="outline" className={className}>
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        {children ?? "Add funds"}
+      </a>
+    </Button>
+  );
+}
+

--- a/components/wallet/AddFundsButton.tsx
+++ b/components/wallet/AddFundsButton.tsx
@@ -1,28 +1,315 @@
 "use client";
 
+import { useState, useMemo, type ReactNode } from "react";
+import {
+  PlusCircle,
+  Loader2,
+  AlertTriangle,
+  ExternalLink,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useTransak } from "@/hooks/useTransak";
+import Link from "next/link";
+import type { TransakCryptoCurrency, TransakOrderData } from "@/types/transak";
+import { cn } from "@/lib/utils";
 
-export function AddFundsButton(props: {
+export interface AddFundsButtonProps {
   walletAddress: string;
-  paramOverrides?: Record<string, string>;
+  email?: string;
+  isPrivyUser?: boolean;
+  onOrderComplete?: (order: TransakOrderData) => void;
   className?: string;
-  children?: React.ReactNode;
-}) {
-  const { walletAddress, paramOverrides, className, children } = props;
-
-  const params = new URLSearchParams({
-    walletAddress,
-    ...(paramOverrides ?? {}),
-  });
-
-  const href = `https://global.transak.com/?${params.toString()}`;
-
-  return (
-    <Button asChild variant="outline" className={className}>
-      <a href={href} target="_blank" rel="noopener noreferrer">
-        {children ?? "Add funds"}
-      </a>
-    </Button>
-  );
+  /** Merged into Transak query (e.g. `cryptoCurrencyCode` for deep links) */
+  paramOverrides?: Record<string, string>;
+  children?: ReactNode;
 }
 
+/**
+ * Transak on-ramp: currency picker, USDC trustline warning, and link fallback.
+ * `paramOverrides` can pin a currency (e.g. paid streams: USDC only).
+ */
+export function AddFundsButton({
+  walletAddress,
+  email,
+  isPrivyUser = false,
+  onOrderComplete,
+  className,
+  paramOverrides,
+  children,
+}: AddFundsButtonProps) {
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false);
+  const [showUsdcWarning, setShowUsdcWarning] = useState(false);
+  const [showPrivyToast, setShowPrivyToast] = useState(false);
+  const [showFallback, setShowFallback] = useState(false);
+
+  const pinnedCurrency = useMemo((): TransakCryptoCurrency | null => {
+    const code = paramOverrides?.cryptoCurrencyCode?.toUpperCase();
+    if (code === "USDC") {
+      return "USDC";
+    }
+    if (code === "XLM") {
+      return "XLM";
+    }
+    return null;
+  }, [paramOverrides]);
+
+  const handleOrderComplete = (order: TransakOrderData) => {
+    onOrderComplete?.(order);
+    if (isPrivyUser) {
+      setShowPrivyToast(true);
+      window.setTimeout(() => setShowPrivyToast(false), 8000);
+    }
+  };
+
+  const { openTransak, isLoading, error } = useTransak({
+    walletAddress,
+    email,
+    onOrderComplete: handleOrderComplete,
+    onError: message => {
+      if (
+        message.includes("not configured") ||
+        message.includes("Failed to load") ||
+        message.includes("API key")
+      ) {
+        setShowFallback(true);
+      }
+    },
+  });
+
+  const openWithOverrides = (currency: TransakCryptoCurrency) => {
+    const rest = { ...(paramOverrides ?? {}) };
+    delete rest.cryptoCurrencyCode;
+    openTransak(currency, rest);
+  };
+
+  const handleCurrencySelect = (currency: TransakCryptoCurrency) => {
+    setShowCurrencyPicker(false);
+    if (currency === "USDC") {
+      setShowUsdcWarning(true);
+    } else {
+      openWithOverrides("XLM");
+    }
+  };
+
+  const handleUsdcProceed = () => {
+    setShowUsdcWarning(false);
+    openWithOverrides("USDC");
+  };
+
+  const handlePrimaryClick = () => {
+    if (pinnedCurrency === "USDC") {
+      setShowUsdcWarning(true);
+      return;
+    }
+    if (pinnedCurrency === "XLM") {
+      openWithOverrides("XLM");
+      return;
+    }
+    setShowCurrencyPicker(true);
+  };
+
+  const hrefFallback = `https://global.transak.com/?${new URLSearchParams({
+    walletAddress,
+    ...(paramOverrides ?? {}),
+  }).toString()}`;
+
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        onClick={handlePrimaryClick}
+        disabled={isLoading}
+        className={cn(
+          "flex items-center gap-1.5 bg-highlight hover:bg-highlight/90 text-white",
+          className
+        )}
+      >
+        {isLoading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <PlusCircle className="w-3.5 h-3.5" />
+        )}
+        {children ?? "Add Funds"}
+      </Button>
+
+      {showCurrencyPicker && (
+        <div className="absolute top-full right-0 mt-2 z-50 w-48 bg-card border border-border rounded-xl shadow-lg p-2 flex flex-col gap-1">
+          <p className="text-xs text-muted-foreground px-2 py-1 font-medium">
+            Select currency
+          </p>
+          <button
+            type="button"
+            onClick={() => handleCurrencySelect("XLM")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors text-sm text-left"
+          >
+            <span className="font-semibold text-highlight">XLM</span>
+            <span className="text-muted-foreground">Stellar Lumens</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => handleCurrencySelect("USDC")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors text-sm text-left"
+          >
+            <span className="font-semibold text-highlight">USDC</span>
+            <span className="text-muted-foreground">USD Coin</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowCurrencyPicker(false)}
+            className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors text-left"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {showUsdcWarning && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-card border border-border rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="flex items-start gap-3 mb-4">
+              <AlertTriangle className="w-5 h-5 text-yellow-500 shrink-0 mt-0.5" />
+              <div>
+                <h3 className="font-semibold text-foreground text-sm">
+                  USDC Trustline Required
+                </h3>
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  To receive USDC on Stellar, your wallet must first establish a
+                  trustline for the USDC asset. Without it, the deposit will
+                  fail.
+                </p>
+              </div>
+            </div>
+            <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 mb-4 text-xs text-yellow-700 dark:text-yellow-400 space-y-1">
+              <p className="font-medium">How to add the USDC trustline:</p>
+              <ol className="list-decimal list-inside space-y-0.5 text-muted-foreground">
+                <li>Open your Stellar wallet (e.g. Freighter)</li>
+                <li>Go to &quot;Manage Assets&quot;</li>
+                <li>Search for USDC (issued by Centre)</li>
+                <li>Click &quot;Add trustline&quot;</li>
+              </ol>
+              <a
+                href="https://stellar.expert/explorer/public/asset/USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 underline mt-1"
+              >
+                View USDC asset on Stellar Expert
+                <ExternalLink className="w-3 h-3 inline" />
+              </a>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowUsdcWarning(false)}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleUsdcProceed}
+                className="flex-1 bg-highlight hover:bg-highlight/90 text-white"
+              >
+                I have a trustline
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {(showFallback || error) && !showUsdcWarning && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-card border border-border rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="flex items-start justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-destructive" />
+                <h3 className="font-semibold text-foreground text-sm">
+                  Unable to open widget
+                </h3>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowFallback(false)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground leading-relaxed mb-4">
+              The Transak widget could not be loaded. This may be due to a
+              network issue, an unsupported region, or a missing API key.
+            </p>
+            <p className="text-xs text-muted-foreground mb-3">
+              You can still open Transak in a new tab or buy XLM on an exchange
+              and send it to your wallet:
+            </p>
+            <div className="flex flex-col gap-2">
+              <a
+                href={hrefFallback}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Open Transak <ExternalLink className="w-3 h-3" />
+              </a>
+              <a
+                href="https://www.coinbase.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Buy on Coinbase <ExternalLink className="w-3 h-3" />
+              </a>
+              <a
+                href="https://www.kraken.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Buy on Kraken <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full mt-4"
+              onClick={() => setShowFallback(false)}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {showPrivyToast && (
+        <div className="fixed bottom-6 right-6 z-50 max-w-xs bg-card border border-border rounded-xl shadow-xl p-4 flex items-start gap-3">
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-foreground">
+              Funds received!
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+              Your purchase landed in your StreamFi custodial wallet. To
+              withdraw, export your private key from{" "}
+              <Link
+                href="/settings/privacy"
+                className="underline text-highlight"
+              >
+                Settings → Privacy &amp; Security
+              </Link>
+              .
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowPrivyToast(false)}
+            className="text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/wallet/EnableUsdcButton.tsx
+++ b/components/wallet/EnableUsdcButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useStellarWallet } from "@/contexts/stellar-wallet-context";
+import { buildUsdcTrustlineTransaction } from "@/lib/stellar/usdc";
+import { submitTransaction } from "@/lib/stellar/payments";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
+import { getNetworkPassphrase, getStellarNetwork } from "@/lib/stellar/config";
+import { WalletNetwork } from "@creit.tech/stellar-wallets-kit";
+
+export function EnableUsdcButton(props: {
+  walletAddress: string;
+  onSuccess?: () => void;
+  className?: string;
+}) {
+  const { walletAddress, onSuccess, className } = props;
+  const { kit } = useStellarWallet();
+  const [isWorking, setIsWorking] = useState(false);
+
+  const handleEnable = async () => {
+    setIsWorking(true);
+    try {
+      const network = getStellarNetwork();
+      const tx = await buildUsdcTrustlineTransaction({
+        publicKey: walletAddress,
+        network,
+      });
+
+      const { signedTxXdr } = await kit.signTransaction(tx.toXDR(), {
+        networkPassphrase:
+          network === "mainnet" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+        address: walletAddress,
+      });
+
+      const signed = TransactionBuilder.fromXDR(
+        signedTxXdr,
+        getNetworkPassphrase(network)
+      );
+
+      const result = await submitTransaction(signed as any, network);
+      if (!result.success) {
+        throw new Error(result.error ?? "Failed to submit trustline transaction");
+      }
+      onSuccess?.();
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  return (
+    <Button
+      onClick={handleEnable}
+      disabled={isWorking}
+      className={className}
+      variant="outline"
+    >
+      {isWorking ? "Enabling USDC…" : "Enable USDC"}
+    </Button>
+  );
+}
+

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import useSWR from "swr";
+import { toast } from "sonner";
 import type { ChatMessage, ChatMessageAPI, UseChatReturn } from "@/types/chat";
 
 const MAX_MESSAGES = 200;
@@ -60,12 +61,14 @@ const chatFetcher = async (url: string): Promise<ChatMessage[]> => {
  *
  * @param playbackId  - Mux playback ID for the stream (null disables fetching)
  * @param wallet      - Connected wallet address (required to send messages)
- * @param isLive      - Whether the stream is currently live (stops polling when false)
+ * @param isLive         - Whether the stream is currently live (stops polling when false)
+ * @param enablePolling  - When false, loads history once without refresh interval (e.g. chat panel hidden)
  */
 export function useChat(
   playbackId: string | null | undefined,
   wallet: string | null | undefined,
-  isLive: boolean = true
+  isLive: boolean = true,
+  enablePolling: boolean = true
 ): UseChatReturn {
   const [isSending, setIsSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
@@ -77,7 +80,7 @@ export function useChat(
   const cacheKey = playbackId
     ? `/api/streams/chat?playbackId=${playbackId}&limit=${MAX_MESSAGES}`
     : null;
-  const shouldPoll = !!playbackId && isLive;
+  const shouldPoll = !!playbackId && isLive && enablePolling;
 
   const { data, error, isLoading, mutate } = useSWR<ChatMessage[]>(
     cacheKey,
@@ -197,10 +200,20 @@ export function useChat(
     [wallet, mutate]
   );
 
+  const banUser = useCallback(
+    async (username: string, durationMinutes?: number) => {
+      void username;
+      void durationMinutes;
+      toast.message("User timeouts and bans are not available yet.");
+    },
+    []
+  );
+
   return {
     messages,
     sendMessage,
     deleteMessage,
+    banUser,
     isLoading,
     isSending,
     error: error?.message || sendError,

--- a/hooks/useStreamAccess.ts
+++ b/hooks/useStreamAccess.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import useSWR from "swr";
+
+export type StreamAccessResult =
+  | { allowed: true; access_type: "public" | "paid" | "password" | "invite" }
+  | {
+      allowed: false;
+      access_type: "paid";
+      reason: "paid" | "wallet_required";
+      price_usdc: string | null;
+      streamer_id: string;
+      streamer_public_key: string | null;
+    }
+  | {
+      allowed: false;
+      access_type: "password" | "invite";
+      reason: "password" | "invite";
+    };
+
+async function fetcher(url: string, body: unknown): Promise<StreamAccessResult> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.error || "Failed to check stream access");
+  }
+  return res.json();
+}
+
+export function useStreamAccess(params: {
+  streamerUsername: string | null | undefined;
+  viewerPublicKey: string | null | undefined;
+  enabled?: boolean;
+  pause?: boolean;
+}) {
+  const {
+    streamerUsername,
+    viewerPublicKey,
+    enabled = true,
+    pause = false,
+  } = params;
+
+  const key =
+    enabled && !pause && streamerUsername
+      ? [
+          "/api/streams/access/check",
+          { streamer_username: streamerUsername, viewer_public_key: viewerPublicKey ?? null },
+        ]
+      : null;
+
+  const { data, error, isLoading, mutate } = useSWR<StreamAccessResult>(
+    key,
+    ([url, body]) => fetcher(url, body),
+    { revalidateOnFocus: false }
+  );
+
+  return { access: data, error: error?.message ?? null, isLoading, refresh: mutate };
+}
+

--- a/hooks/useStreamAccess.ts
+++ b/hooks/useStreamAccess.ts
@@ -3,7 +3,7 @@
 import useSWR from "swr";
 
 export type StreamAccessResult =
-  | { allowed: true; access_type: "public" | "paid" | "password" | "invite" }
+  | { allowed: true; access_type: "public" | "paid" | "token_gated" }
   | {
       allowed: false;
       access_type: "paid";
@@ -14,14 +14,25 @@ export type StreamAccessResult =
     }
   | {
       allowed: false;
+      access_type: "token_gated";
+      reason: "no_wallet" | "token_gated";
+      asset_code: string;
+      min_balance: string;
+    }
+  | {
+      allowed: false;
       access_type: "password" | "invite";
       reason: "password" | "invite";
     };
 
-async function fetcher(url: string, body: unknown): Promise<StreamAccessResult> {
+async function fetcher(
+  url: string,
+  body: unknown
+): Promise<StreamAccessResult> {
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -48,7 +59,10 @@ export function useStreamAccess(params: {
     enabled && !pause && streamerUsername
       ? [
           "/api/streams/access/check",
-          { streamer_username: streamerUsername, viewer_public_key: viewerPublicKey ?? null },
+          {
+            streamer_username: streamerUsername,
+            viewer_public_key: viewerPublicKey ?? null,
+          },
         ]
       : null;
 
@@ -58,6 +72,10 @@ export function useStreamAccess(params: {
     { revalidateOnFocus: false }
   );
 
-  return { access: data, error: error?.message ?? null, isLoading, refresh: mutate };
+  return {
+    access: data,
+    error: error?.message ?? null,
+    isLoading,
+    refresh: mutate,
+  };
 }
-

--- a/hooks/useTransak.ts
+++ b/hooks/useTransak.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { TransakCryptoCurrency } from "@/types/transak";
+
+type UseTransakOptions = {
+  walletAddress: string;
+  email?: string;
+  onOrderComplete?: (order: { id?: string; status?: string }) => void;
+  onError?: (message: string) => void;
+};
+
+/**
+ * Opens Transak in a new tab with StreamFi defaults.
+ * Full widget SDK can replace this later; order completion is not observed for the tab flow.
+ */
+export function useTransak({
+  walletAddress,
+  email,
+  onOrderComplete,
+  onError,
+}: UseTransakOptions) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const openTransak = useCallback(
+    (currency: TransakCryptoCurrency, extraParams?: Record<string, string>) => {
+      const apiKey = process.env.NEXT_PUBLIC_TRANSAK_API_KEY;
+      if (!apiKey) {
+        const msg =
+          "Transak API key is not configured. Set NEXT_PUBLIC_TRANSAK_API_KEY.";
+        setError(msg);
+        onError?.(msg);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const params = new URLSearchParams({
+          apiKey,
+          walletAddress,
+          defaultCryptoCurrency: currency,
+          ...(email ? { email } : {}),
+          ...(extraParams ?? {}),
+        });
+        const href = `https://global.transak.com/?${params.toString()}`;
+        window.open(href, "_blank", "noopener,noreferrer");
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Failed to open Transak";
+        setError(msg);
+        onError?.(msg);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [walletAddress, email, onError, onOrderComplete]
+  );
+
+  return { openTransak, isLoading, error };
+}

--- a/lib/stellar/amount.ts
+++ b/lib/stellar/amount.ts
@@ -1,0 +1,13 @@
+export function parseStellarAmountToInt(amount: string): bigint {
+  if (typeof amount !== "string" || amount.trim() === "") {
+    throw new Error("Invalid amount");
+  }
+  const normalized = amount.trim();
+  if (!/^\d+(\.\d+)?$/.test(normalized)) {
+    throw new Error("Invalid amount");
+  }
+  const [whole, fracRaw = ""] = normalized.split(".");
+  const frac = (fracRaw + "0000000").slice(0, 7);
+  return BigInt(whole) * BigInt(10_000_000) + BigInt(frac);
+}
+

--- a/lib/stellar/transactions.ts
+++ b/lib/stellar/transactions.ts
@@ -1,0 +1,34 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getHorizonUrl, getNetworkPassphrase, type StellarNetwork } from "./config";
+
+export async function buildPaymentTransaction(params: {
+  sourcePublicKey: string;
+  destinationPublicKey: string;
+  asset: StellarSdk.Asset;
+  amount: string;
+  memoText?: string;
+  network: StellarNetwork;
+  timeoutSeconds?: number;
+}): Promise<StellarSdk.Transaction> {
+  const server = new StellarSdk.Horizon.Server(getHorizonUrl(params.network));
+  const sourceAccount = await server.loadAccount(params.sourcePublicKey);
+  const networkPassphrase = getNetworkPassphrase(params.network);
+
+  const builder = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase,
+  }).addOperation(
+    StellarSdk.Operation.payment({
+      destination: params.destinationPublicKey,
+      asset: params.asset,
+      amount: params.amount,
+    })
+  );
+
+  if (params.memoText) {
+    builder.addMemo(StellarSdk.Memo.text(params.memoText));
+  }
+
+  return builder.setTimeout(params.timeoutSeconds ?? 30).build();
+}
+

--- a/lib/stellar/usdc.ts
+++ b/lib/stellar/usdc.ts
@@ -1,0 +1,90 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getHorizonUrl, getNetworkPassphrase, type StellarNetwork } from "./config";
+
+export type UsdcAssetConfig = {
+  code: "USDC";
+  issuer: string;
+};
+
+const MAINNET_USDC_ISSUER_FALLBACK =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+export function getUsdcAssetConfig(network: StellarNetwork): UsdcAssetConfig {
+  const envIssuer =
+    network === "mainnet"
+      ? process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER_MAINNET
+      : process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET;
+
+  if (envIssuer && /^G[A-Z0-9]{55}$/.test(envIssuer)) {
+    return { code: "USDC", issuer: envIssuer };
+  }
+
+  if (network === "mainnet") {
+    return { code: "USDC", issuer: MAINNET_USDC_ISSUER_FALLBACK };
+  }
+
+  throw new Error(
+    "Missing NEXT_PUBLIC_STELLAR_USDC_ISSUER_TESTNET (must be a Stellar G-address)"
+  );
+}
+
+export function getUsdcAsset(network: StellarNetwork): StellarSdk.Asset {
+  const { code, issuer } = getUsdcAssetConfig(network);
+  return new StellarSdk.Asset(code, issuer);
+}
+
+export async function hasUsdcTrustline(params: {
+  publicKey: string;
+  network: StellarNetwork;
+}): Promise<boolean> {
+  const server = new StellarSdk.Horizon.Server(getHorizonUrl(params.network));
+  const account = await server.loadAccount(params.publicKey);
+  const { issuer } = getUsdcAssetConfig(params.network);
+  return account.balances.some(b => {
+    if (b.asset_type !== "credit_alphanum4") {
+      return false;
+    }
+    return (b as any).asset_code === "USDC" && (b as any).asset_issuer === issuer;
+  });
+}
+
+export async function getUsdcBalance(params: {
+  publicKey: string;
+  network: StellarNetwork;
+}): Promise<string> {
+  const server = new StellarSdk.Horizon.Server(getHorizonUrl(params.network));
+  const account = await server.loadAccount(params.publicKey);
+  const { issuer } = getUsdcAssetConfig(params.network);
+  const bal = account.balances.find(b => {
+    if (b.asset_type !== "credit_alphanum4") {
+      return false;
+    }
+    return (b as any).asset_code === "USDC" && (b as any).asset_issuer === issuer;
+  });
+  return bal ? String((bal as any).balance ?? "0") : "0";
+}
+
+export async function buildUsdcTrustlineTransaction(params: {
+  publicKey: string;
+  network: StellarNetwork;
+}): Promise<StellarSdk.Transaction> {
+  const server = new StellarSdk.Horizon.Server(getHorizonUrl(params.network));
+  const account = await server.loadAccount(params.publicKey);
+
+  const networkPassphrase = getNetworkPassphrase(params.network);
+  const usdc = getUsdcAsset(params.network);
+
+  return new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      StellarSdk.Operation.changeTrust({
+        asset: usdc,
+      })
+    )
+    .addMemo(StellarSdk.Memo.text("StreamFi USDC"))
+    .setTimeout(30)
+    .build();
+}
+

--- a/lib/stream/access-payment.ts
+++ b/lib/stream/access-payment.ts
@@ -1,0 +1,37 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { getStellarNetwork, type StellarNetwork } from "@/lib/stellar/config";
+import { getUsdcAsset, hasUsdcTrustline } from "@/lib/stellar/usdc";
+import { buildPaymentTransaction } from "@/lib/stellar/transactions";
+
+export type StreamAccessPaymentParams = {
+  viewerPublicKey: string;
+  streamerPublicKey: string;
+  priceUsdc: string;
+  streamId: string;
+  network?: StellarNetwork;
+};
+
+export async function buildStreamAccessPayment(
+  params: StreamAccessPaymentParams
+): Promise<StellarSdk.Transaction> {
+  const network = params.network ?? getStellarNetwork();
+
+  const trustlineOk = await hasUsdcTrustline({
+    publicKey: params.viewerPublicKey,
+    network,
+  });
+  if (!trustlineOk) {
+    throw new Error("USDC trustline required");
+  }
+
+  return buildPaymentTransaction({
+    sourcePublicKey: params.viewerPublicKey,
+    destinationPublicKey: params.streamerPublicKey,
+    asset: getUsdcAsset(network),
+    amount: params.priceUsdc,
+    memoText: `streamfi-access:${params.streamId}`,
+    network,
+    timeoutSeconds: 30,
+  });
+}
+

--- a/lib/stream/access.ts
+++ b/lib/stream/access.ts
@@ -1,0 +1,103 @@
+import { Horizon } from "@stellar/stellar-sdk";
+import type { TokenGateConfig } from "@/types/stream-access";
+
+const Server = Horizon.Server;
+
+function getServer(): InstanceType<typeof Server> {
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+  const url =
+    network === "mainnet"
+      ? "https://horizon.stellar.org"
+      : "https://horizon-testnet.stellar.org";
+  return new Server(url);
+}
+
+function isNativeAsset(code: string): boolean {
+  const c = code.toUpperCase();
+  return c === "XLM" || c === "NATIVE";
+}
+
+/**
+ * Server-side token balance check for token-gated streams.
+ */
+export async function checkTokenGatedAccess(
+  config: TokenGateConfig,
+  viewerWallet: string | null
+): Promise<
+  | { allowed: true; reason?: string }
+  | {
+      allowed: false;
+      reason: "no_wallet" | "token_gated";
+      asset_code: string;
+      min_balance: string;
+    }
+> {
+  const asset_code = config.asset_code;
+  const min_balance = config.min_balance;
+
+  if (!viewerWallet) {
+    return {
+      allowed: false,
+      reason: "no_wallet",
+      asset_code,
+      min_balance,
+    };
+  }
+
+  const server = getServer();
+  let account: Awaited<ReturnType<typeof server.loadAccount>>;
+  try {
+    account = await server.loadAccount(viewerWallet);
+  } catch {
+    return {
+      allowed: false,
+      reason: "token_gated",
+      asset_code,
+      min_balance,
+    };
+  }
+
+  const min = parseFloat(min_balance);
+  if (!Number.isFinite(min) || min < 0) {
+    console.warn("[checkTokenGatedAccess] invalid min_balance — denying");
+    return {
+      allowed: false,
+      reason: "token_gated",
+      asset_code,
+      min_balance,
+    };
+  }
+
+  let balance = 0;
+  const lines = account.balances as Array<{
+    asset_type: string;
+    balance: string;
+    asset_code?: string;
+    asset_issuer?: string;
+  }>;
+
+  if (isNativeAsset(asset_code)) {
+    const native = lines.find(b => b.asset_type === "native");
+    balance = parseFloat(native?.balance ?? "0");
+  } else {
+    const match = lines.find(
+      b =>
+        b.asset_type !== "native" &&
+        b.asset_type !== "liquidity_pool_shares" &&
+        b.asset_code === asset_code &&
+        (!config.issuer || b.asset_issuer === config.issuer)
+    );
+    balance = parseFloat(match?.balance ?? "0");
+  }
+
+  if (balance >= min) {
+    return { allowed: true, reason: "public" };
+  }
+
+  return {
+    allowed: false,
+    reason: "token_gated",
+    asset_code,
+    min_balance,
+  };
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -43,6 +43,8 @@ export interface UseChatReturn {
   messages: ChatMessage[];
   sendMessage: (content: string) => Promise<void>;
   deleteMessage: (messageId: number) => Promise<void>;
+  /** Placeholder until chat moderation API exists */
+  banUser: (username: string, durationMinutes?: number) => Promise<void>;
   isLoading: boolean;
   isSending: boolean;
   error: string | null;

--- a/types/stream-access.ts
+++ b/types/stream-access.ts
@@ -1,0 +1,17 @@
+/**
+ * Stream access types shared by `/api/streams/access/check` and token-gate helpers.
+ */
+export type StreamAccessType =
+  | "public"
+  | "paid"
+  | "token_gated"
+  | "password"
+  | "invite";
+
+/** JSON stored in `stream_access_config.config` when `access_type` is `token_gated` */
+export interface TokenGateConfig {
+  asset_code: string;
+  min_balance: string;
+  /** Stellar issuer public key; omit for native XLM */
+  issuer?: string;
+}

--- a/types/transak.ts
+++ b/types/transak.ts
@@ -1,0 +1,7 @@
+export type TransakCryptoCurrency = "XLM" | "USDC";
+
+/** Minimal order shape when the embedded flow reports completion */
+export type TransakOrderData = {
+  id?: string;
+  status?: string;
+};


### PR DESCRIPTION
## Description
Implement one-time USDC paid access for streams with Stellar payment verification and persistent paid access grants.

Closes #375

## Changes proposed

### What were you told to do?
- Add paid stream access flow with one-time USDC payment.
- Verify Stellar transaction server-side before granting access.
- Add replay protection with tx hash checks.
- Support USDC trustline requirement and fallback funding UX.
- Show paid access settings and paid earnings on dashboard.

### What did I do?
#### Access control foundation + APIs
- Added access control migration route for config/grants tables and grant amount column.
- Added `/api/streams/access/check` to evaluate access by streamer + viewer wallet.
- Added `/api/streams/access/config` for streamer paid/public settings and earnings stats.
- Added `/api/streams/access/verify-payment` to verify Horizon tx details and grant paid access.

#### Stellar USDC payment plumbing
- Added USDC helpers for issuer config, trustline checks, trustline transaction, and balance checks.
- Added shared payment transaction builder and amount parser utilities.
- Added `buildStreamAccessPayment()` for memoed stream access payments.

#### Viewer + dashboard UX
- Added `PaidAccessGate` UI for trustline setup, payment, and verify/unlock flow.
- Added env-missing error handling for missing testnet USDC issuer config.
- Added paid/public access controls and earnings display in stream manager settings.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --watchman=false --runTestsByPath app/api/streams/access/verify-payment/__tests__/route.test.ts`
- Commit hooks also passed `npm run type-check` and `next build` during commit.


Made with [Cursor](https://cursor.com)