### PR TITLE
feat: complete transak on-ramp integration (#364)

### DIFF
--- a/app/api/wallet/onramp/order/route.ts
+++ b/app/api/wallet/onramp/order/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/wallet/onramp/order
+ *
+ * Called by the client (useTransak hook) after a successful Transak order event.
+ * Upserts the order record in transak_orders tied to the authenticated user.
+ *
+ * This is a convenience path for client-initiated upserts. The authoritative
+ * record update comes via the server-side webhook at /api/webhooks/transak.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  let body: {
+    id?: string;
+    status?: string;
+    cryptoAmount?: number | null;
+    cryptoCurrency?: string;
+    fiatAmount?: number;
+    fiatCurrency?: string;
+    walletAddress?: string;
+    txHash?: string | null;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const {
+    id,
+    status,
+    cryptoAmount,
+    cryptoCurrency,
+    fiatAmount,
+    fiatCurrency,
+    walletAddress,
+    txHash,
+  } = body;
+
+  if (!id || typeof id !== "string" || id.trim() === "") {
+    return NextResponse.json({ error: "Missing order id" }, { status: 400 });
+  }
+  if (!status || typeof status !== "string") {
+    return NextResponse.json({ error: "Missing order status" }, { status: 400 });
+  }
+
+  try {
+    await sql`
+      INSERT INTO transak_orders (
+        id, user_id, status, crypto_amount, crypto_currency,
+        fiat_amount, fiat_currency, wallet_address, tx_hash,
+        created_at, updated_at
+      )
+      VALUES (
+        ${id},
+        ${session.userId},
+        ${status},
+        ${cryptoAmount ?? null},
+        ${cryptoCurrency ?? null},
+        ${fiatAmount ?? null},
+        ${fiatCurrency ?? null},
+        ${walletAddress ?? null},
+        ${txHash ?? null},
+        now(),
+        now()
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        status        = EXCLUDED.status,
+        crypto_amount = COALESCE(EXCLUDED.crypto_amount, transak_orders.crypto_amount),
+        tx_hash       = COALESCE(EXCLUDED.tx_hash,       transak_orders.tx_hash),
+        updated_at    = now()
+    `;
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[onramp/order] DB error:", err);
+    return NextResponse.json({ error: "Failed to save order" }, { status: 500 });
+  }
+}

--- a/app/api/webhooks/transak/route.ts
+++ b/app/api/webhooks/transak/route.ts
@@ -1,0 +1,125 @@
+/**
+ * POST /api/webhooks/transak
+ *
+ * Receives server-side order status updates from Transak.
+ * Verifies the X-Transak-Signature HMAC-SHA256 header, then upserts
+ * the order into transak_orders.
+ *
+ * Setup:
+ *  1. In the Transak dashboard, set the webhook URL to:
+ *       https://<your-domain>/api/webhooks/transak
+ *  2. Copy the webhook secret into TRANSAK_WEBHOOK_SECRET env var.
+ *
+ * Signature format (Transak):
+ *   X-Transak-Signature: <hex-encoded HMAC-SHA256(secret, rawBody)>
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import type { TransakWebhookPayload } from "@/types/transak";
+
+function verifyTransakSignature(
+  signature: string,
+  rawBody: string,
+  secret: string
+): boolean {
+  const expected = createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request) {
+  const rawBody = await req.text();
+  const signature = req.headers.get("x-transak-signature");
+  const webhookSecret = process.env.TRANSAK_WEBHOOK_SECRET;
+
+  if (webhookSecret) {
+    if (!signature) {
+      console.error("❌ [transak webhook] Missing X-Transak-Signature header");
+      return NextResponse.json({ error: "Missing signature" }, { status: 401 });
+    }
+    if (!verifyTransakSignature(signature, rawBody, webhookSecret)) {
+      console.error("❌ [transak webhook] Invalid signature");
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  } else {
+    console.warn(
+      "⚠️  TRANSAK_WEBHOOK_SECRET not set — skipping signature verification (set it in production)"
+    );
+  }
+
+  let payload: TransakWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const order = payload?.webhookData;
+  if (!order?.id || !order?.status) {
+    console.error("❌ [transak webhook] Missing order data in payload", payload);
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  console.log(`🔔 Transak webhook: order ${order.id} → ${order.status}`);
+
+  try {
+    // Resolve the StreamFi user by wallet address so we can associate the order.
+    // wallet_address is the Stellar public key the user provided to Transak.
+    const userResult = await sql`
+      SELECT id FROM users WHERE wallet = ${order.walletAddress} LIMIT 1
+    `;
+    const userId: string | null =
+      userResult.rows.length > 0 ? userResult.rows[0].id : null;
+
+    await sql`
+      INSERT INTO transak_orders (
+        id, user_id, status, crypto_amount, crypto_currency,
+        fiat_amount, fiat_currency, wallet_address, tx_hash,
+        created_at, updated_at
+      )
+      VALUES (
+        ${order.id},
+        ${userId},
+        ${order.status},
+        ${order.cryptoAmount ?? null},
+        ${order.cryptoCurrency ?? null},
+        ${order.fiatAmount ?? null},
+        ${order.fiatCurrency ?? null},
+        ${order.walletAddress ?? null},
+        ${order.transactionHash ?? null},
+        now(),
+        now()
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        status        = EXCLUDED.status,
+        crypto_amount = COALESCE(EXCLUDED.crypto_amount, transak_orders.crypto_amount),
+        tx_hash       = COALESCE(EXCLUDED.tx_hash,       transak_orders.tx_hash),
+        updated_at    = now()
+    `;
+
+    console.log(`✅ [transak webhook] Upserted order ${order.id}`);
+    return NextResponse.json({ received: true });
+  } catch (err) {
+    console.error("❌ [transak webhook] DB error:", err);
+    return NextResponse.json(
+      { error: "Failed to process webhook" },
+      { status: 500 }
+    );
+  }
+}
+
+// Health check
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    message: "Transak webhook endpoint is active",
+  });
+}

--- a/app/dashboard/payout/page.tsx
+++ b/app/dashboard/payout/page.tsx
@@ -6,6 +6,8 @@ import useSWR from "swr";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { TipCounter } from "@/components/tipping";
+import { AddFundsButton } from "@/components/wallet/AddFundsButton";
+import { TRANSAK_ORDER_COMPLETE_EVENT } from "@/hooks/useTransak";
 import {
   Wallet,
   Copy,
@@ -85,6 +87,15 @@ export default function PayoutPage() {
     return () => clearInterval(interval);
   }, [fetchPrice]);
 
+  // Refresh balance automatically after a completed Transak order
+  useEffect(() => {
+    const handler = () => {
+      void refreshBalance();
+    };
+    window.addEventListener(TRANSAK_ORDER_COMPLETE_EVENT, handler);
+    return () => window.removeEventListener(TRANSAK_ORDER_COMPLETE_EVENT, handler);
+  }, [refreshBalance]);
+
   const handleCopy = () => {
     if (!walletAddress) {
       return;
@@ -146,18 +157,27 @@ export default function PayoutPage() {
                     Stellar Balance
                   </span>
                 </div>
-                <button
-                  onClick={() => refreshBalance()}
-                  className="p-1.5 rounded-lg hover:bg-muted transition-colors text-muted-foreground"
-                  aria-label="Refresh balance"
-                >
-                  <RefreshCcw
-                    className={cn(
-                      "w-4 h-4",
-                      balanceLoading && "animate-spin text-highlight"
-                    )}
-                  />
-                </button>
+                <div className="flex items-center gap-2">
+                  {walletAddress && (
+                    <AddFundsButton
+                      walletAddress={walletAddress}
+                      email={privyWallet?.email ?? undefined}
+                      isPrivyUser={isPrivyUser}
+                    />
+                  )}
+                  <button
+                    onClick={() => refreshBalance()}
+                    className="p-1.5 rounded-lg hover:bg-muted transition-colors text-muted-foreground"
+                    aria-label="Refresh balance"
+                  >
+                    <RefreshCcw
+                      className={cn(
+                        "w-4 h-4",
+                        balanceLoading && "animate-spin text-highlight"
+                      )}
+                    />
+                  </button>
+                </div>
               </div>
 
               {/* Balance amount */}

--- a/components/tipping/TipModal.tsx
+++ b/components/tipping/TipModal.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2, XCircle, AlertTriangle } from "lucide-react";
+import { AddFundsButton } from "@/components/wallet/AddFundsButton";
 import {
   buildTipTransaction,
   submitTransaction,
@@ -33,6 +34,8 @@ interface TipModalProps {
   recipientPublicKey: string;
   recipientAvatar?: string;
   senderPublicKey: string;
+  /** Whether the sender is a Privy custodial user — used to contextualise the "Add Funds" nudge */
+  isPrivyUser?: boolean;
   onSuccess?: (txHash: string, amount: string) => void;
   onError?: (error: string) => void;
 }
@@ -56,6 +59,7 @@ export function TipModal({
   recipientPublicKey,
   recipientAvatar,
   senderPublicKey,
+  isPrivyUser = false,
   onSuccess,
   onError,
 }: TipModalProps) {
@@ -75,6 +79,7 @@ export function TipModal({
     details?: string;
     code?: string;
   } | null>(null);
+  const [isInsufficientBalance, setIsInsufficientBalance] = useState(false);
 
   const { kit } = useStellarWallet();
   const fee = calculateFeeEstimate();
@@ -113,6 +118,7 @@ export function TipModal({
     setTxHash(null);
     setIsConfirmationOpen(false);
     setStructuredError(null);
+    setIsInsufficientBalance(false);
   };
 
   const handlePresetClick = (presetAmount: number) => {
@@ -188,6 +194,7 @@ export function TipModal({
         setError(
           "Insufficient balance. Please ensure you have enough XLM to cover the tip and transaction fee."
         );
+        setIsInsufficientBalance(true);
         setTransactionState("error");
         if (onError) {
           onError("Insufficient balance");
@@ -489,6 +496,19 @@ export function TipModal({
               <div className="flex-1">
                 <p className="text-sm text-red-500">{error}</p>
               </div>
+            </div>
+          )}
+
+          {/* Add Funds nudge — shown when balance is too low */}
+          {isInsufficientBalance && transactionState === "error" && !isConfirmationOpen && (
+            <div className="flex items-center justify-between gap-3 p-3 bg-highlight/10 border border-highlight/20 rounded-lg">
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Need more XLM? Top up your wallet instantly with fiat.
+              </p>
+              <AddFundsButton
+                walletAddress={senderPublicKey}
+                isPrivyUser={isPrivyUser}
+              />
             </div>
           )}
         </div>

--- a/components/wallet/AddFundsButton.tsx
+++ b/components/wallet/AddFundsButton.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { PlusCircle, Loader2, AlertTriangle, ExternalLink, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useTransak, TRANSAK_ORDER_COMPLETE_EVENT } from "@/hooks/useTransak";
+import { useTransak } from "@/hooks/useTransak";
+import Link from "next/link";
 import type { TransakCryptoCurrency, TransakOrderData } from "@/types/transak";
 import { cn } from "@/lib/utils";
 
@@ -256,9 +257,9 @@ export function AddFundsButton({
             <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
               Your purchase landed in your StreamFi custodial wallet. To
               withdraw, export your private key from{" "}
-              <a href="/settings/privacy" className="underline text-highlight">
+              <Link href="/settings/privacy" className="underline text-highlight">
                 Settings → Privacy &amp; Security
-              </a>
+              </Link>
               .
             </p>
           </div>

--- a/components/wallet/AddFundsButton.tsx
+++ b/components/wallet/AddFundsButton.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useState } from "react";
+import { PlusCircle, Loader2, AlertTriangle, ExternalLink, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTransak, TRANSAK_ORDER_COMPLETE_EVENT } from "@/hooks/useTransak";
+import type { TransakCryptoCurrency, TransakOrderData } from "@/types/transak";
+import { cn } from "@/lib/utils";
+
+interface AddFundsButtonProps {
+  walletAddress: string;
+  email?: string;
+  isPrivyUser?: boolean;
+  /** Called after a successful Transak order completes */
+  onOrderComplete?: (order: TransakOrderData) => void;
+  className?: string;
+}
+
+/**
+ * AddFundsButton — launches the Transak on-ramp widget.
+ *
+ * - Lets the user choose between XLM and USDC before opening Transak.
+ * - For USDC, shows a trustline warning before proceeding.
+ * - Shows a fallback message if the API key is missing or the widget fails to load.
+ * - For Privy (custodial) users, shows a toast after completion explaining
+ *   that funds landed in their custodial wallet.
+ */
+export function AddFundsButton({
+  walletAddress,
+  email,
+  isPrivyUser = false,
+  onOrderComplete,
+  className,
+}: AddFundsButtonProps) {
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false);
+  const [showUsdcWarning, setShowUsdcWarning] = useState(false);
+  const [showPrivyToast, setShowPrivyToast] = useState(false);
+  const [showFallback, setShowFallback] = useState(false);
+
+  const handleOrderComplete = (order: TransakOrderData) => {
+    onOrderComplete?.(order);
+    if (isPrivyUser) {
+      setShowPrivyToast(true);
+      setTimeout(() => setShowPrivyToast(false), 8000);
+    }
+  };
+
+  const { openTransak, isLoading, error } = useTransak({
+    walletAddress,
+    email,
+    onOrderComplete: handleOrderComplete,
+    onError: message => {
+      // If the error looks like a configuration / network failure, show fallback
+      if (
+        message.includes("not configured") ||
+        message.includes("Failed to load") ||
+        message.includes("API key")
+      ) {
+        setShowFallback(true);
+      }
+    },
+  });
+
+  const handleCurrencySelect = (currency: TransakCryptoCurrency) => {
+    setShowCurrencyPicker(false);
+    if (currency === "USDC") {
+      setShowUsdcWarning(true);
+    } else {
+      openTransak("XLM");
+    }
+  };
+
+  const handleUsdcProceed = () => {
+    setShowUsdcWarning(false);
+    openTransak("USDC");
+  };
+
+  return (
+    <div className="relative">
+      {/* Main button */}
+      <Button
+        size="sm"
+        onClick={() => setShowCurrencyPicker(true)}
+        disabled={isLoading}
+        className={cn(
+          "flex items-center gap-1.5 bg-highlight hover:bg-highlight/90 text-white",
+          className
+        )}
+      >
+        {isLoading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <PlusCircle className="w-3.5 h-3.5" />
+        )}
+        Add Funds
+      </Button>
+
+      {/* Currency picker */}
+      {showCurrencyPicker && (
+        <div className="absolute top-full right-0 mt-2 z-50 w-48 bg-card border border-border rounded-xl shadow-lg p-2 flex flex-col gap-1">
+          <p className="text-xs text-muted-foreground px-2 py-1 font-medium">
+            Select currency
+          </p>
+          <button
+            onClick={() => handleCurrencySelect("XLM")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors text-sm text-left"
+          >
+            <span className="font-semibold text-highlight">XLM</span>
+            <span className="text-muted-foreground">Stellar Lumens</span>
+          </button>
+          <button
+            onClick={() => handleCurrencySelect("USDC")}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-muted transition-colors text-sm text-left"
+          >
+            <span className="font-semibold text-highlight">USDC</span>
+            <span className="text-muted-foreground">USD Coin</span>
+          </button>
+          <button
+            onClick={() => setShowCurrencyPicker(false)}
+            className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors text-left"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* USDC trustline warning dialog */}
+      {showUsdcWarning && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-card border border-border rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="flex items-start gap-3 mb-4">
+              <AlertTriangle className="w-5 h-5 text-yellow-500 shrink-0 mt-0.5" />
+              <div>
+                <h3 className="font-semibold text-foreground text-sm">
+                  USDC Trustline Required
+                </h3>
+                <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                  To receive USDC on Stellar, your wallet must first establish a
+                  trustline for the USDC asset. Without it, the deposit will
+                  fail.
+                </p>
+              </div>
+            </div>
+            <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 mb-4 text-xs text-yellow-700 dark:text-yellow-400 space-y-1">
+              <p className="font-medium">How to add the USDC trustline:</p>
+              <ol className="list-decimal list-inside space-y-0.5 text-muted-foreground">
+                <li>Open your Stellar wallet (e.g. Freighter)</li>
+                <li>Go to &quot;Manage Assets&quot;</li>
+                <li>Search for USDC (issued by Centre)</li>
+                <li>Click &quot;Add trustline&quot;</li>
+              </ol>
+              <a
+                href="https://stellar.expert/explorer/public/asset/USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 underline mt-1"
+              >
+                View USDC asset on Stellar Expert
+                <ExternalLink className="w-3 h-3 inline" />
+              </a>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowUsdcWarning(false)}
+                className="flex-1"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleUsdcProceed}
+                className="flex-1 bg-highlight hover:bg-highlight/90 text-white"
+              >
+                I have a trustline
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Fallback message (widget load failure / missing API key) */}
+      {(showFallback || error) && !showUsdcWarning && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="bg-card border border-border rounded-2xl p-6 max-w-sm w-full shadow-xl">
+            <div className="flex items-start justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="w-5 h-5 text-destructive" />
+                <h3 className="font-semibold text-foreground text-sm">
+                  Unable to open widget
+                </h3>
+              </div>
+              <button
+                onClick={() => {
+                  setShowFallback(false);
+                }}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground leading-relaxed mb-4">
+              The Transak widget could not be loaded. This may be due to a
+              network issue, an unsupported region, or a missing API key.
+            </p>
+            <p className="text-xs text-muted-foreground mb-3">
+              You can purchase XLM directly from an exchange and send it to your
+              wallet address:
+            </p>
+            <div className="flex flex-col gap-2">
+              <a
+                href="https://www.coinbase.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Buy on Coinbase <ExternalLink className="w-3 h-3" />
+              </a>
+              <a
+                href="https://www.kraken.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Buy on Kraken <ExternalLink className="w-3 h-3" />
+              </a>
+              <a
+                href="https://www.binance.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 text-xs text-highlight underline"
+              >
+                Buy on Binance <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full mt-4"
+              onClick={() => setShowFallback(false)}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Privy custodial wallet toast */}
+      {showPrivyToast && (
+        <div className="fixed bottom-6 right-6 z-50 max-w-xs bg-card border border-border rounded-xl shadow-xl p-4 flex items-start gap-3">
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-foreground">
+              Funds received!
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+              Your purchase landed in your StreamFi custodial wallet. To
+              withdraw, export your private key from{" "}
+              <a href="/settings/privacy" className="underline text-highlight">
+                Settings → Privacy &amp; Security
+              </a>
+              .
+            </p>
+          </div>
+          <button
+            onClick={() => setShowPrivyToast(false)}
+            className="text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/db/migrations/add-transak-orders.sql
+++ b/db/migrations/add-transak-orders.sql
@@ -1,0 +1,21 @@
+-- Migration: add transak_orders table
+-- Run this against the production database before deploying the Transak integration.
+
+CREATE TABLE IF NOT EXISTS transak_orders (
+  id              TEXT PRIMARY KEY,           -- Transak-assigned order ID
+  user_id         UUID REFERENCES users(id) ON DELETE SET NULL,
+  status          TEXT NOT NULL,
+  crypto_amount   NUMERIC,
+  crypto_currency TEXT,
+  fiat_amount     NUMERIC,
+  fiat_currency   TEXT,
+  wallet_address  TEXT,
+  tx_hash         TEXT,                        -- On-chain transaction hash (set when COMPLETED)
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transak_orders_user_id   ON transak_orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_transak_orders_status    ON transak_orders(status);
+CREATE INDEX IF NOT EXISTS idx_transak_orders_wallet    ON transak_orders(wallet_address);
+CREATE INDEX IF NOT EXISTS idx_transak_orders_created   ON transak_orders(created_at DESC);

--- a/hooks/useTransak.ts
+++ b/hooks/useTransak.ts
@@ -87,7 +87,7 @@ export function useTransak({
 
         // ── Event listeners ────────────────────────────────────────────────
 
-        Transak.on(Transak.EVENTS.TRANSAK_WIDGET_CLOSE, (_data: unknown) => {
+        Transak.on(Transak.EVENTS.TRANSAK_WIDGET_CLOSE, () => {
           transak.cleanup();
           transakRef.current = null;
           onClose?.();
@@ -99,7 +99,7 @@ export function useTransak({
             // The SDK types the callback param as `unknown`; cast safely.
             const event = data as { status: TransakOrderData };
             const order = event?.status;
-            if (!order) return;
+            if (!order) { return; }
 
             // 1. Notify caller
             onOrderComplete?.(order);

--- a/hooks/useTransak.ts
+++ b/hooks/useTransak.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { buildTransakWidgetUrl } from "@/lib/transak/config";
+import type { TransakCryptoCurrency, TransakOrderData } from "@/types/transak";
+
+/** Custom DOM event name dispatched on window after a completed Transak order */
+export const TRANSAK_ORDER_COMPLETE_EVENT = "transak-order-complete";
+
+interface UseTransakOptions {
+  walletAddress: string;
+  email?: string;
+  /** Called when the Transak widget is closed (any reason) */
+  onClose?: () => void;
+  /** Called when an order reaches COMPLETED status in the widget */
+  onOrderComplete?: (order: TransakOrderData) => void;
+  /** Called when the widget or order fails */
+  onError?: (message: string) => void;
+}
+
+interface UseTransakReturn {
+  openTransak: (cryptoCurrency?: TransakCryptoCurrency) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * useTransak — dynamically imports the Transak SDK (avoids SSR), opens the
+ * widget as a modal overlay, and manages event listeners for the full lifecycle.
+ *
+ * Uses @transak/transak-sdk v4 which accepts { widgetUrl, referrer } and
+ * renders the widget in an iframe.
+ *
+ * On a successful order it:
+ *  1. Calls `onOrderComplete` callback.
+ *  2. Dispatches `transak-order-complete` CustomEvent on `window` so any
+ *     listener (e.g. payout page) can react and refresh the balance.
+ *  3. POSTs the order to /api/wallet/onramp/order for DB persistence.
+ */
+export function useTransak({
+  walletAddress,
+  email,
+  onClose,
+  onOrderComplete,
+  onError,
+}: UseTransakOptions): UseTransakReturn {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const transakRef = useRef<{ cleanup: () => void; close: () => void } | null>(null);
+
+  const openTransak = useCallback(
+    async (cryptoCurrency: TransakCryptoCurrency = "XLM") => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // Dynamic import so the SDK never runs server-side
+        const { Transak } = await import("@transak/transak-sdk").catch(() => {
+          throw new Error(
+            "Failed to load Transak widget. Please check your connection."
+          );
+        });
+
+        let widgetUrl: string;
+        try {
+          widgetUrl = buildTransakWidgetUrl({
+            walletAddress,
+            cryptoCurrency,
+            email,
+          });
+        } catch (configErr) {
+          throw new Error(
+            configErr instanceof Error
+              ? configErr.message
+              : "Transak is not configured."
+          );
+        }
+
+        const referrer =
+          typeof window !== "undefined" ? window.location.origin : "";
+
+        const transak = new Transak({ widgetUrl, referrer });
+        transakRef.current = transak;
+
+        transak.init();
+        setIsLoading(false);
+
+        // ── Event listeners ────────────────────────────────────────────────
+
+        Transak.on(Transak.EVENTS.TRANSAK_WIDGET_CLOSE, (_data: unknown) => {
+          transak.cleanup();
+          transakRef.current = null;
+          onClose?.();
+        });
+
+        Transak.on(
+          Transak.EVENTS.TRANSAK_ORDER_SUCCESSFUL,
+          (data: unknown) => {
+            // The SDK types the callback param as `unknown`; cast safely.
+            const event = data as { status: TransakOrderData };
+            const order = event?.status;
+            if (!order) return;
+
+            // 1. Notify caller
+            onOrderComplete?.(order);
+
+            // 2. Broadcast to window so any listener can react (e.g. refresh balance)
+            window.dispatchEvent(
+              new CustomEvent(TRANSAK_ORDER_COMPLETE_EVENT, { detail: order })
+            );
+
+            // 3. Persist order to DB (fire-and-forget; failures are non-critical here)
+            fetch("/api/wallet/onramp/order", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                id: order.id,
+                status: order.status,
+                cryptoAmount: order.cryptoAmount,
+                cryptoCurrency: order.cryptoCurrency,
+                fiatAmount: order.fiatAmount,
+                fiatCurrency: order.fiatCurrency,
+                walletAddress: order.walletAddress,
+                txHash: order.transactionHash,
+              }),
+            }).catch(err =>
+              console.error("[useTransak] Failed to persist order:", err)
+            );
+          }
+        );
+
+        Transak.on(Transak.EVENTS.TRANSAK_ORDER_FAILED, (data: unknown) => {
+          const event = data as { status?: { id?: string } };
+          const msg = `Transak order failed (${event?.status?.id ?? "unknown"})`;
+          setError(msg);
+          onError?.(msg);
+        });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to open Transak widget.";
+        setError(message);
+        onError?.(message);
+        setIsLoading(false);
+      }
+    },
+    [walletAddress, email, onClose, onOrderComplete, onError]
+  );
+
+  return { openTransak, isLoading, error };
+}

--- a/lib/transak/config.ts
+++ b/lib/transak/config.ts
@@ -1,0 +1,67 @@
+import type { TransakCryptoCurrency, TransakEnvironment } from "@/types/transak";
+
+/**
+ * Returns the correct Transak environment based on NEXT_PUBLIC_STELLAR_NETWORK.
+ * testnet → STAGING, mainnet → PRODUCTION
+ */
+export function getTransakEnvironment(): TransakEnvironment {
+  return process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
+    ? "PRODUCTION"
+    : "STAGING";
+}
+
+/**
+ * The Transak widget base URLs for each environment.
+ */
+const TRANSAK_WIDGET_URLS: Record<TransakEnvironment, string> = {
+  STAGING: "https://global-stg.transak.com",
+  PRODUCTION: "https://global.transak.com",
+};
+
+interface BuildTransakUrlOptions {
+  walletAddress: string;
+  cryptoCurrency?: TransakCryptoCurrency;
+  /** User email for pre-filling KYC fields (optional) */
+  email?: string;
+}
+
+/**
+ * Build the full Transak widget URL with all query parameters.
+ *
+ * The @transak/transak-sdk v4 accepts `{ widgetUrl, referrer }` and renders
+ * an iframe. All configuration is encoded as query params in widgetUrl.
+ *
+ * - Defaults to XLM; pass `cryptoCurrency: "USDC"` for USDC purchases.
+ * - Brand colour is the StreamFi highlight (#7C3AED — purple).
+ * - apiKey must be set via NEXT_PUBLIC_TRANSAK_API_KEY.
+ */
+export function buildTransakWidgetUrl(options: BuildTransakUrlOptions): string {
+  const { walletAddress, cryptoCurrency = "XLM", email } = options;
+
+  const apiKey = process.env.NEXT_PUBLIC_TRANSAK_API_KEY;
+  if (!apiKey) {
+    throw new Error("NEXT_PUBLIC_TRANSAK_API_KEY is not set");
+  }
+
+  const environment = getTransakEnvironment();
+  const baseUrl = TRANSAK_WIDGET_URLS[environment];
+
+  const params = new URLSearchParams({
+    apiKey,
+    walletAddress,
+    cryptoCurrencyCode: cryptoCurrency,
+    // Allow user to switch between XLM and USDC in the widget
+    cryptoCurrencyList: "XLM,USDC",
+    network: "stellar",
+    themeColor: "7C3AED",
+    defaultFiatCurrency: "USD",
+    defaultFiatAmount: "50",
+  });
+
+  if (email) {
+    params.set("email", email);
+    params.set("isAutoFillUserData", "true");
+  }
+
+  return `${baseUrl}?${params.toString()}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.5.0",
         "@testing-library/dom": "^10.4.1",
+        "@transak/transak-sdk": "^4.0.2",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.36.4",
         "@vercel/postgres": "^0.10.0",
@@ -15795,6 +15796,70 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@transak/transak-sdk": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@transak/transak-sdk/-/transak-sdk-4.0.2.tgz",
+      "integrity": "sha512-+5Ybep3P7wI0P/+1v/NJBYYrC82dM+/BedfGhBg0m9Heb1klcrVGVRtHX2T+smxO40bc2QR5NfWLuC2IchL5Ig==",
+      "deprecated": "Please migrate to @transak/ui-js-sdk.",
+      "license": "ISC",
+      "dependencies": {
+        "events": "^3.3.0",
+        "query-string": "^9.3.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@transak/transak-sdk/node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@transak/transak-sdk/node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@transak/transak-sdk/node_modules/query-string": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
+      "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@transak/transak-sdk/node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@trezor/analytics": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.5.0",
     "@testing-library/dom": "^10.4.1",
+    "@transak/transak-sdk": "^4.0.2",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.4",
     "@vercel/postgres": "^0.10.0",

--- a/types/transak.ts
+++ b/types/transak.ts
@@ -1,0 +1,76 @@
+/**
+ * Transak on-ramp integration types.
+ * Covers widget config, lifecycle events, and webhook payloads.
+ *
+ * Note: @transak/transak-sdk v4 takes { widgetUrl, referrer } and appends
+ * all configuration as query params. The types here cover our app-level
+ * config building and the data returned by events / webhooks.
+ */
+
+export type TransakCryptoCurrency = "XLM" | "USDC";
+export type TransakFiatCurrency = string; // e.g. "USD", "EUR", "GBP"
+export type TransakEnvironment = "STAGING" | "PRODUCTION";
+
+export type TransakOrderStatus =
+  | "AWAITING_PAYMENT_FROM_USER"
+  | "PAYMENT_DONE_MARKED_BY_USER"
+  | "PROCESSING"
+  | "PENDING_DELIVERY_FROM_TRANSAK"
+  | "ON_HOLD_PENDING_DELIVERY_FROM_TRANSAK"
+  | "COMPLETED"
+  | "CANCELLED"
+  | "FAILED"
+  | "REFUNDED"
+  | "EXPIRED";
+
+/** Shape of order data included in Transak widget events */
+export interface TransakOrderData {
+  id: string;
+  status: TransakOrderStatus;
+  cryptoAmount: number | null;
+  cryptoCurrency: TransakCryptoCurrency;
+  fiatAmount: number;
+  fiatCurrency: TransakFiatCurrency;
+  walletAddress: string;
+  network: string;
+  transactionHash: string | null;
+  isBuyOrSell: "BUY" | "SELL";
+  createdAt: string;
+  updatedAt: string;
+  conversionPrice?: number;
+  totalFeeInFiat?: number;
+  partnerOrderId?: string;
+  partnerCustomerId?: string;
+}
+
+/** Webhook payload from Transak (server-side) */
+export interface TransakWebhookPayload {
+  webhookData: {
+    id: string;
+    status: TransakOrderStatus;
+    cryptoAmount: number | null;
+    cryptoCurrency: TransakCryptoCurrency;
+    fiatAmount: number;
+    fiatCurrency: TransakFiatCurrency;
+    walletAddress: string;
+    network: string;
+    transactionHash: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+/** Row stored in the transak_orders DB table */
+export interface TransakOrderRow {
+  id: string;
+  user_id: string;
+  status: TransakOrderStatus;
+  crypto_amount: number | null;
+  crypto_currency: TransakCryptoCurrency;
+  fiat_amount: number;
+  fiat_currency: TransakFiatCurrency;
+  wallet_address: string;
+  tx_hash: string | null;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary

Completes the Transak fiat → XLM/USDC on-ramp integration end-to-end, making it production-ready per the acceptance criteria in #364.

### What was built

**Foundation (new files)**
- `types/transak.ts` — TypeScript types for order data, events, webhook payload, and DB row shape
- `lib/transak/config.ts` — `buildTransakWidgetUrl()` wired to Stellar network, StreamFi brand colour, and `NEXT_PUBLIC_TRANSAK_API_KEY`
- `hooks/useTransak.ts` — dynamic import of `@transak/transak-sdk`, full widget lifecycle, event listeners for success/failure/close, `window` broadcast of `transak-order-complete`, and fire-and-forget DB persist
- `components/wallet/AddFundsButton.tsx` — reusable button with XLM/USDC currency picker, USDC trustline warning dialog, widget-load error fallback with exchange links, and Privy custodial wallet toast
- `app/api/wallet/onramp/order/route.ts` — `POST /api/wallet/onramp/order`, session-authenticated, upserts order on status change
- `app/api/webhooks/transak/route.ts` — `POST /api/webhooks/transak`, HMAC-SHA256 signature verification via `X-Transak-Signature`, wallet → user resolution, order upsert
- `db/migrations/add-transak-orders.sql` — `transak_orders` table with indexes

**Integration (modified files)**
- `app/dashboard/payout/page.tsx` — `AddFundsButton` added to balance card header; `useEffect` listens for `transak-order-complete` event and calls `refreshBalance()`
- `components/tipping/TipModal.tsx` — `isPrivyUser` prop, `isInsufficientBalance` state, "Add Funds" nudge rendered when the balance check fails

### Environment variables required
```env
NEXT_PUBLIC_TRANSAK_API_KEY=   # from https://dashboard.transak.com
TRANSAK_WEBHOOK_SECRET=        # for webhook HMAC verification
```

### Before deploying
Run the DB migration:
```sql
-- db/migrations/add-transak-orders.sql
```

## Test plan
- [ ] Click "Add Funds" on the payout page — currency picker appears (XLM / USDC)
- [ ] Select XLM → Transak widget opens with wallet pre-filled
- [ ] Select USDC → trustline warning dialog appears before opening widget
- [ ] Complete a test purchase (STAGING) — balance refreshes automatically on the payout page
- [ ] Order appears in `transak_orders` DB table
- [ ] Simulate a Transak webhook POST with a valid `X-Transak-Signature` — order upserted
- [ ] Simulate webhook with invalid/missing signature — returns 401
- [ ] Kill network before clicking "Add Funds" — fallback message with exchange links appears
- [ ] Privy user completes purchase — toast explains funds landed in custodial wallet
- [ ] Tip modal with zero balance — "Add Funds" nudge appears below the error

Closes #364
