### PR TITLE
feat(routes-f): add creator earnings, payouts, schedule, and badges APIs

### DIFF
--- a/__tests__/lib/routes-f/badges.test.ts
+++ b/__tests__/lib/routes-f/badges.test.ts
@@ -1,0 +1,43 @@
+import { evaluateBadgeIds } from "@/lib/routes-f/badges";
+
+describe("evaluateBadgeIds", () => {
+  it("awards badges when thresholds are met", () => {
+    const badges = evaluateBadgeIds(
+      {
+        totalStreams: 1,
+        totalTipCount: 1,
+        totalGiftCount: 1,
+        followerCount: 1000,
+        totalStreamedSeconds: 100 * 60 * 60,
+        totalEarningsUsdc: 1200,
+      },
+      new Set(["first_tip"])
+    );
+
+    expect(badges).toEqual([
+      "first_stream",
+      "first_gift",
+      "hundred_followers",
+      "thousand_followers",
+      "ten_hours_streamed",
+      "hundred_hours_streamed",
+      "top_earner",
+    ]);
+  });
+
+  it("returns an empty list when nothing new qualifies", () => {
+    const badges = evaluateBadgeIds(
+      {
+        totalStreams: 0,
+        totalTipCount: 0,
+        totalGiftCount: 0,
+        followerCount: 5,
+        totalStreamedSeconds: 60,
+        totalEarningsUsdc: 5,
+      },
+      new Set()
+    );
+
+    expect(badges).toEqual([]);
+  });
+});

--- a/__tests__/lib/routes-f/format.test.ts
+++ b/__tests__/lib/routes-f/format.test.ts
@@ -1,0 +1,17 @@
+import { getPeriodKey } from "@/lib/routes-f/format";
+
+describe("getPeriodKey", () => {
+  it("groups by day", () => {
+    expect(getPeriodKey("2026-03-27T10:00:00.000Z", "day")).toBe("2026-03-27");
+  });
+
+  it("groups by week using monday as the start of the week", () => {
+    expect(getPeriodKey("2026-03-27T10:00:00.000Z", "week")).toBe("2026-03-23");
+  });
+
+  it("groups by month", () => {
+    expect(getPeriodKey("2026-03-27T10:00:00.000Z", "month")).toBe(
+      "2026-03-01"
+    );
+  });
+});

--- a/app/api/routes-f/badges/[username]/route.ts
+++ b/app/api/routes-f/badges/[username]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username } = await params;
+
+  try {
+    const result = await sql`
+      SELECT bd.id, bd.name, bd.description, bd.icon, bd.tier, ub.earned_at
+      FROM users u
+      INNER JOIN user_badges ub ON ub.user_id = u.id
+      INNER JOIN badge_definitions bd ON bd.id = ub.badge_id
+      WHERE LOWER(u.username) = ${username.toLowerCase()}
+      ORDER BY bd.sort_order ASC, ub.earned_at ASC
+    `;
+
+    return NextResponse.json({
+      badges: result.rows.map(row => ({
+        id: String(row.id),
+        name: String(row.name),
+        description: String(row.description),
+        icon: String(row.icon),
+        tier: String(row.tier),
+        earned_at: new Date(String(row.earned_at)).toISOString(),
+      })),
+      total: result.rows.length,
+    });
+  } catch (error) {
+    console.error("[routes-f badges by username GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch creator badges" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/badges/check/route.ts
+++ b/app/api/routes-f/badges/check/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { evaluateAndAwardBadges } from "@/lib/routes-f/badges";
+
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const newBadges = await evaluateAndAwardBadges(session.userId);
+    return NextResponse.json({
+      new_badges: newBadges,
+      total: newBadges.length,
+    });
+  } catch (error) {
+    console.error("[routes-f badges check POST]", error);
+    return NextResponse.json(
+      { error: "Failed to evaluate badges" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/badges/route.ts
+++ b/app/api/routes-f/badges/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+export async function GET() {
+  try {
+    const result = await sql`
+      SELECT id, name, description, icon, tier, sort_order
+      FROM badge_definitions
+      ORDER BY sort_order ASC, name ASC
+    `;
+
+    return NextResponse.json({
+      badges: result.rows.map(row => ({
+        id: String(row.id),
+        name: String(row.name),
+        description: String(row.description),
+        icon: String(row.icon),
+        tier: String(row.tier),
+        sort_order: Number.parseInt(String(row.sort_order), 10),
+      })),
+      total: result.rows.length,
+    });
+  } catch (error) {
+    console.error("[routes-f badges GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch badge definitions" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/earnings/route.ts
+++ b/app/api/routes-f/earnings/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCreatorEarningsSeries } from "@/lib/routes-f/earnings";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function GET(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+
+  try {
+    const payload = await getCreatorEarningsSeries({
+      creatorId: session.userId,
+      fromParam: searchParams.get("from"),
+      toParam: searchParams.get("to"),
+      groupByParam: searchParams.get("group_by"),
+    });
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to fetch earnings",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routes-f/earnings/summary/route.ts
+++ b/app/api/routes-f/earnings/summary/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCreatorEarningsSummary } from "@/lib/routes-f/earnings";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function GET(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const payload = await getCreatorEarningsSummary(session.userId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("[routes-f earnings summary]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch earnings summary" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/payouts/[id]/route.ts
+++ b/app/api/routes-f/payouts/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { getSinglePayout } from "@/lib/routes-f/payouts";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const payout = await getSinglePayout(session.userId, id);
+    if (!payout) {
+      return NextResponse.json({ error: "Payout not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ payout });
+  } catch (error) {
+    console.error("[routes-f payout by id GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch payout" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/payouts/route.ts
+++ b/app/api/routes-f/payouts/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import {
+  getPayoutHistory,
+  getUsdcBalance,
+  notifyAdminOfPayout,
+  PAYOUT_METHODS,
+  sendPayoutConfirmationEmail,
+} from "@/lib/routes-f/payouts";
+import { toFixedAmount } from "@/lib/routes-f/format";
+
+export async function GET(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const payload = await getPayoutHistory(session.userId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("[routes-f payouts GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch payout history" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const body = await req.json();
+    const amountUsdc = Number.parseFloat(String(body.amount_usdc ?? 0));
+    const method = String(body.method ?? "");
+    const destination = String(body.destination ?? "").trim();
+
+    if (!Number.isFinite(amountUsdc)) {
+      return NextResponse.json(
+        { error: "amount_usdc must be a valid number" },
+        { status: 400 }
+      );
+    }
+
+    if (amountUsdc < 10) {
+      return NextResponse.json(
+        { error: "Minimum payout is 10.00 USDC" },
+        { status: 400 }
+      );
+    }
+
+    if (!PAYOUT_METHODS.includes(method as (typeof PAYOUT_METHODS)[number])) {
+      return NextResponse.json(
+        {
+          error:
+            "method must be bank_transfer, stellar_wallet, or mobile_money",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!destination) {
+      return NextResponse.json(
+        { error: "destination is required" },
+        { status: 400 }
+      );
+    }
+
+    const userResult = await sql`
+      SELECT id, username, email, wallet
+      FROM users
+      WHERE id = ${session.userId}
+      LIMIT 1
+    `;
+
+    const user = userResult.rows[0];
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const balance = await getUsdcBalance(String(user.wallet));
+    if (balance < amountUsdc) {
+      return NextResponse.json(
+        { error: "Insufficient USDC balance" },
+        { status: 400 }
+      );
+    }
+
+    const feeUsdc = 0;
+    const netUsdc = amountUsdc - feeUsdc;
+
+    const payoutResult = await sql`
+      INSERT INTO payouts (
+        user_id,
+        amount_usdc,
+        method,
+        destination,
+        status,
+        provider,
+        fee_usdc,
+        net_usdc
+      )
+      VALUES (
+        ${session.userId},
+        ${toFixedAmount(amountUsdc)},
+        ${method}::payout_method,
+        ${destination},
+        'pending'::payout_status,
+        'manual',
+        ${toFixedAmount(feeUsdc)},
+        ${toFixedAmount(netUsdc)}
+      )
+      RETURNING id, amount_usdc, fee_usdc, net_usdc, method, destination, status, initiated_at
+    `;
+
+    await Promise.all([
+      sendPayoutConfirmationEmail({
+        email: String(user.email ?? ""),
+        username: user.username ? String(user.username) : null,
+        amountUsdc: toFixedAmount(amountUsdc),
+        method: method as (typeof PAYOUT_METHODS)[number],
+        destination,
+      }),
+      notifyAdminOfPayout({
+        username: user.username ? String(user.username) : null,
+        userId: session.userId,
+        amountUsdc: toFixedAmount(amountUsdc),
+        method: method as (typeof PAYOUT_METHODS)[number],
+        destination,
+      }),
+    ]);
+
+    const payout = payoutResult.rows[0];
+    return NextResponse.json(
+      {
+        payout: {
+          id: String(payout.id),
+          amount_usdc: toFixedAmount(
+            Number.parseFloat(String(payout.amount_usdc))
+          ),
+          fee_usdc: toFixedAmount(Number.parseFloat(String(payout.fee_usdc))),
+          net_usdc: toFixedAmount(Number.parseFloat(String(payout.net_usdc))),
+          method: String(payout.method),
+          destination: String(payout.destination),
+          status: String(payout.status),
+          initiated_at: new Date(String(payout.initiated_at)).toISOString(),
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f payouts POST]", error);
+    return NextResponse.json(
+      { error: "Failed to initiate payout" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/schedule/[id]/remind/route.ts
+++ b/app/api/routes-f/schedule/[id]/remind/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { upsertReminder } from "@/lib/routes-f/schedule";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const payload = await upsertReminder(id, session.userId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to update reminder",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routes-f/schedule/[id]/route.ts
+++ b/app/api/routes-f/schedule/[id]/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await req.json();
+    const existing = await sql`
+      SELECT creator_id FROM stream_schedule WHERE id = ${id}::uuid LIMIT 1
+    `;
+
+    if (existing.rows.length === 0) {
+      return NextResponse.json(
+        { error: "Scheduled stream not found" },
+        { status: 404 }
+      );
+    }
+
+    if (String(existing.rows[0].creator_id) !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const scheduledAt = body.scheduled_at
+      ? new Date(String(body.scheduled_at))
+      : null;
+
+    if (scheduledAt && Number.isNaN(scheduledAt.getTime())) {
+      return NextResponse.json(
+        { error: "scheduled_at must be a valid ISO timestamp" },
+        { status: 400 }
+      );
+    }
+
+    const result = await sql`
+      UPDATE stream_schedule
+      SET title = COALESCE(${body.title ? String(body.title).trim() : null}, title),
+          description = COALESCE(${body.description ? String(body.description) : null}, description),
+          category = COALESCE(${body.category ? String(body.category) : null}, category),
+          scheduled_at = COALESCE(${scheduledAt?.toISOString() ?? null}, scheduled_at),
+          duration_mins = COALESCE(${body.duration_mins ? Number.parseInt(String(body.duration_mins), 10) : null}, duration_mins),
+          status = COALESCE(${body.status ? String(body.status) : null}, status),
+          updated_at = NOW()
+      WHERE id = ${id}::uuid
+      RETURNING id, title, description, category, scheduled_at, duration_mins, status, created_at, updated_at
+    `;
+
+    return NextResponse.json({ schedule: result.rows[0] });
+  } catch (error) {
+    console.error("[routes-f schedule PATCH]", error);
+    return NextResponse.json(
+      { error: "Failed to update scheduled stream" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const existing = await sql`
+      SELECT creator_id FROM stream_schedule WHERE id = ${id}::uuid LIMIT 1
+    `;
+
+    if (existing.rows.length === 0) {
+      return NextResponse.json(
+        { error: "Scheduled stream not found" },
+        { status: 404 }
+      );
+    }
+
+    if (String(existing.rows[0].creator_id) !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`
+      UPDATE stream_schedule
+      SET status = 'cancelled', updated_at = NOW()
+      WHERE id = ${id}::uuid
+    `;
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[routes-f schedule DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to cancel scheduled stream" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/schedule/reminders/route.ts
+++ b/app/api/routes-f/schedule/reminders/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { sendDueScheduleReminders } from "@/lib/routes-f/schedule";
+
+export async function GET() {
+  try {
+    const processed = await sendDueScheduleReminders();
+    return NextResponse.json({ processed });
+  } catch (error) {
+    console.error("[routes-f schedule reminders GET]", error);
+    return NextResponse.json(
+      { error: "Failed to process reminders" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/schedule/route.ts
+++ b/app/api/routes-f/schedule/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get("username")?.trim().toLowerCase();
+
+  if (!username) {
+    return NextResponse.json(
+      { error: "username is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await sql`
+      SELECT ss.id, ss.title, ss.description, ss.category, ss.scheduled_at,
+             ss.duration_mins, ss.status, ss.created_at,
+             COUNT(sr.viewer_id) AS reminder_count
+      FROM stream_schedule ss
+      INNER JOIN users u ON u.id = ss.creator_id
+      LEFT JOIN stream_reminders sr ON sr.schedule_id = ss.id
+      WHERE LOWER(u.username) = ${username}
+        AND ss.status IN ('upcoming', 'live')
+        AND ss.scheduled_at >= NOW()
+      GROUP BY ss.id
+      ORDER BY ss.scheduled_at ASC
+      LIMIT 10
+    `;
+
+    let viewerId: string | null = null;
+    const session = await verifySession(req);
+    if (session.ok) {
+      viewerId = session.userId;
+    }
+
+    const reminders = viewerId
+      ? await sql`
+          SELECT schedule_id FROM stream_reminders WHERE viewer_id = ${viewerId}
+        `
+      : { rows: [] as Array<{ schedule_id: string }> };
+
+    const reminderIds = new Set(
+      reminders.rows.map(row => String(row.schedule_id))
+    );
+
+    return NextResponse.json({
+      schedule: result.rows.map(row => ({
+        id: String(row.id),
+        title: String(row.title),
+        description: row.description ? String(row.description) : null,
+        category: row.category ? String(row.category) : null,
+        scheduled_at: new Date(String(row.scheduled_at)).toISOString(),
+        duration_mins: Number.parseInt(String(row.duration_mins), 10),
+        status: String(row.status),
+        reminder_count: Number.parseInt(String(row.reminder_count), 10),
+        viewer_has_reminder: reminderIds.has(String(row.id)),
+      })),
+    });
+  } catch (error) {
+    console.error("[routes-f schedule GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch schedule" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    const body = await req.json();
+    const title = String(body.title ?? "").trim();
+    const description = body.description ? String(body.description) : null;
+    const category = body.category ? String(body.category) : null;
+    const durationMins = Number.parseInt(String(body.duration_mins ?? 120), 10);
+    const scheduledAt = new Date(String(body.scheduled_at ?? ""));
+
+    if (!title) {
+      return NextResponse.json({ error: "title is required" }, { status: 400 });
+    }
+
+    if (Number.isNaN(scheduledAt.getTime())) {
+      return NextResponse.json(
+        { error: "scheduled_at must be a valid ISO timestamp" },
+        { status: 400 }
+      );
+    }
+
+    const countResult = await sql`
+      SELECT COUNT(*) AS count
+      FROM stream_schedule
+      WHERE creator_id = ${session.userId}
+        AND status = 'upcoming'
+        AND scheduled_at >= NOW()
+    `;
+
+    if (Number.parseInt(String(countResult.rows[0]?.count ?? 0), 10) >= 10) {
+      return NextResponse.json(
+        { error: "Creators can only have 10 upcoming events at a time" },
+        { status: 400 }
+      );
+    }
+
+    const insertResult = await sql`
+      INSERT INTO stream_schedule (
+        creator_id, title, description, category, scheduled_at, duration_mins, status
+      )
+      VALUES (
+        ${session.userId},
+        ${title},
+        ${description},
+        ${category},
+        ${scheduledAt.toISOString()},
+        ${durationMins},
+        'upcoming'
+      )
+      RETURNING id, title, description, category, scheduled_at, duration_mins, status, created_at
+    `;
+
+    return NextResponse.json(
+      { schedule: insertResult.rows[0] },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f schedule POST]", error);
+    return NextResponse.json(
+      { error: "Failed to create scheduled stream" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/streams/start/route.ts
+++ b/app/api/streams/start/route.ts
@@ -3,6 +3,8 @@ import { sql } from "@vercel/postgres";
 import { getMuxStreamHealth } from "@/lib/mux/server";
 import { verifySession } from "@/lib/auth/verify-session";
 import { writeNotification } from "@/lib/notifications";
+import { evaluateAndAwardBadges } from "@/lib/routes-f/badges";
+import { syncScheduleLiveStatusForCreator } from "@/lib/routes-f/schedule";
 
 export async function POST(req: NextRequest) {
   // Verify the caller is logged in
@@ -63,6 +65,7 @@ export async function POST(req: NextRequest) {
         INSERT INTO stream_sessions (user_id, mux_session_id, playback_id, started_at)
         VALUES (${updatedUser.id}, ${updatedUser.mux_stream_id}, ${updatedUser.mux_playback_id}, CURRENT_TIMESTAMP)
       `;
+      await syncScheduleLiveStatusForCreator(String(updatedUser.id));
     } catch (sessionError) {
       console.error("Failed to create stream session record:", sessionError);
     }
@@ -144,6 +147,7 @@ export async function DELETE(req: NextRequest) {
           ended_at = CURRENT_TIMESTAMP
         WHERE user_id = ${user.id} AND ended_at IS NULL
       `;
+      await evaluateAndAwardBadges(String(user.id));
     } catch (sessionError) {
       console.error("Failed to end stream session:", sessionError);
     }

--- a/app/api/tips/refresh-total/route.ts
+++ b/app/api/tips/refresh-total/route.ts
@@ -2,6 +2,8 @@
 import { NextResponse } from "next/server";
 import { sql } from "@vercel/postgres";
 import { fetchPaymentsReceived } from "@/lib/stellar/horizon";
+import { evaluateAndAwardBadges } from "@/lib/routes-f/badges";
+import { getXlmUsdPrice } from "@/lib/routes-f/price";
 
 export async function POST(request: Request) {
   try {
@@ -19,9 +21,9 @@ export async function POST(request: Request) {
 
     // 1. Fetch user from database
     const userResult = await sql`
-      SELECT id, username, stellar_public_key
+      SELECT id, username, wallet AS stellar_public_key
       FROM users
-      WHERE username = ${username}
+      WHERE LOWER(username) = ${username.toLowerCase()}
     `;
 
     if (userResult.rows.length === 0) {
@@ -66,6 +68,38 @@ export async function POST(request: Request) {
 
     const totalCount = allTips.length;
     const lastTipAt = allTips.length > 0 ? allTips[0].timestamp : null;
+    const xlmUsdPrice = await getXlmUsdPrice();
+
+    for (const tip of allTips) {
+      const supporterResult = await sql`
+        SELECT id
+        FROM users
+        WHERE wallet = ${tip.sender}
+        LIMIT 1
+      `;
+
+      await sql`
+        INSERT INTO tip_transactions (
+          creator_id,
+          supporter_id,
+          amount_xlm,
+          price_usd,
+          tx_hash,
+          memo,
+          created_at
+        )
+        VALUES (
+          ${user.id},
+          ${supporterResult.rows[0]?.id ?? null},
+          ${tip.amount},
+          ${xlmUsdPrice},
+          ${tip.txHash},
+          'StreamFi Tip',
+          ${tip.timestamp}
+        )
+        ON CONFLICT (tx_hash) DO NOTHING
+      `;
+    }
 
     // 4. Update database
     await sql`
@@ -77,6 +111,8 @@ export async function POST(request: Request) {
         updated_at = CURRENT_TIMESTAMP
       WHERE id = ${user.id}
     `;
+
+    await evaluateAndAwardBadges(String(user.id));
 
     // 5. Return updated statistics
     return NextResponse.json({

--- a/app/api/users/follow/route.ts
+++ b/app/api/users/follow/route.ts
@@ -3,6 +3,7 @@ import { sql } from "@vercel/postgres";
 import { verifySession } from "@/lib/auth/verify-session";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { writeNotification } from "@/lib/notifications";
+import { evaluateAndAwardBadges } from "@/lib/routes-f/badges";
 
 // 30 follow/unfollow actions per IP per minute
 const isRateLimited = createRateLimiter(60_000, 30);
@@ -65,6 +66,12 @@ export async function POST(req: NextRequest) {
         VALUES (${callerId}, ${receiverId})
         ON CONFLICT DO NOTHING
       `;
+
+      try {
+        await evaluateAndAwardBadges(receiverId);
+      } catch (badgeErr) {
+        console.error("[follow] badge evaluation failed:", badgeErr);
+      }
 
       // Write notification — awaited so it completes before response is sent
       try {

--- a/db/migrations/20260327_routes_f_creator_finance_and_badges.sql
+++ b/db/migrations/20260327_routes_f_creator_finance_and_badges.sql
@@ -1,0 +1,150 @@
+-- routes-f creator earnings, payouts, schedules, and badges support
+
+DO $$ BEGIN
+  CREATE TYPE payout_status AS ENUM ('pending', 'processing', 'completed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE payout_method AS ENUM ('bank_transfer', 'stellar_wallet', 'mobile_money');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS user_follows (
+  follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  followee_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (follower_id, followee_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_follows_followee_id ON user_follows(followee_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_user_follows_follower_id ON user_follows(follower_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS tip_transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  supporter_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  amount_xlm NUMERIC(20,7) NOT NULL,
+  price_usd NUMERIC(20,7),
+  tx_hash TEXT,
+  memo TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tip_transactions_creator_id ON tip_transactions(creator_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tip_transactions_supporter_id ON tip_transactions(supporter_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tip_transactions_tx_hash_unique
+  ON tip_transactions(tx_hash)
+  WHERE tx_hash IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS gift_transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  supporter_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  gift_type TEXT,
+  amount_usdc NUMERIC(10,2) NOT NULL,
+  tx_hash TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gift_transactions_creator_id ON gift_transactions(creator_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gift_transactions_supporter_id ON gift_transactions(supporter_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  supporter_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  amount_usdc NUMERIC(10,2) NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  interval_label TEXT NOT NULL DEFAULT 'monthly',
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_charged_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_creator_id ON subscriptions(creator_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_supporter_id ON subscriptions(supporter_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS payouts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount_usdc NUMERIC(10,2) NOT NULL,
+  method payout_method NOT NULL,
+  destination TEXT NOT NULL,
+  status payout_status NOT NULL DEFAULT 'pending',
+  provider TEXT,
+  provider_ref TEXT,
+  fee_usdc NUMERIC(10,2) NOT NULL DEFAULT 0,
+  net_usdc NUMERIC(10,2) NOT NULL,
+  initiated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_payouts_user_id ON payouts(user_id, initiated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_payouts_status ON payouts(status, initiated_at DESC);
+
+CREATE TABLE IF NOT EXISTS stream_schedule (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  category TEXT,
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  duration_mins INT NOT NULL DEFAULT 120,
+  status TEXT NOT NULL DEFAULT 'upcoming',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_schedule_creator_id ON stream_schedule(creator_id, scheduled_at ASC);
+CREATE INDEX IF NOT EXISTS idx_stream_schedule_status ON stream_schedule(status, scheduled_at ASC);
+
+CREATE TABLE IF NOT EXISTS stream_reminders (
+  schedule_id UUID NOT NULL REFERENCES stream_schedule(id) ON DELETE CASCADE,
+  viewer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  remind_at TIMESTAMPTZ NOT NULL,
+  sent BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (schedule_id, viewer_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_reminders_due ON stream_reminders(sent, remind_at);
+
+CREATE TABLE IF NOT EXISTS badge_definitions (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  tier TEXT NOT NULL,
+  sort_order INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_badges (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  badge_id TEXT NOT NULL REFERENCES badge_definitions(id) ON DELETE CASCADE,
+  earned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, badge_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_badges_user_id ON user_badges(user_id, earned_at DESC);
+
+INSERT INTO badge_definitions (id, name, description, icon, tier, sort_order)
+VALUES
+  ('first_stream', 'First Broadcast', 'Completed first live stream', 'broadcast', 'bronze', 1),
+  ('first_tip', 'First Tip', 'Received first XLM tip', 'tip', 'bronze', 2),
+  ('first_gift', 'Gift Received', 'Received first Dragon or Lion gift', 'gift', 'silver', 3),
+  ('hundred_followers', 'Rising Star', 'Reached 100 followers', 'followers', 'silver', 4),
+  ('thousand_followers', 'Community Builder', 'Reached 1,000 followers', 'community', 'gold', 5),
+  ('ten_hours_streamed', 'Marathon Streamer', 'Streamed for 10 hours total', 'clock-10', 'silver', 6),
+  ('hundred_hours_streamed', 'Veteran Broadcaster', 'Streamed for 100 hours total', 'clock-100', 'gold', 7),
+  ('top_earner', 'Top Earner', 'Earned 1,000 USDC total', 'diamond', 'diamond', 8)
+ON CONFLICT (id) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    icon = EXCLUDED.icon,
+    tier = EXCLUDED.tier,
+    sort_order = EXCLUDED.sort_order;

--- a/lib/routes-f/badges.ts
+++ b/lib/routes-f/badges.ts
@@ -1,0 +1,241 @@
+import { sql } from "@vercel/postgres";
+import { writeNotification } from "@/lib/notifications";
+
+export const BADGE_DEFINITIONS = [
+  {
+    id: "first_stream",
+    name: "First Broadcast",
+    description: "Completed first live stream",
+    icon: "broadcast",
+    tier: "bronze",
+    sort_order: 1,
+  },
+  {
+    id: "first_tip",
+    name: "First Tip",
+    description: "Received first XLM tip",
+    icon: "tip",
+    tier: "bronze",
+    sort_order: 2,
+  },
+  {
+    id: "first_gift",
+    name: "Gift Received",
+    description: "Received first Dragon or Lion gift",
+    icon: "gift",
+    tier: "silver",
+    sort_order: 3,
+  },
+  {
+    id: "hundred_followers",
+    name: "Rising Star",
+    description: "Reached 100 followers",
+    icon: "followers",
+    tier: "silver",
+    sort_order: 4,
+  },
+  {
+    id: "thousand_followers",
+    name: "Community Builder",
+    description: "Reached 1,000 followers",
+    icon: "community",
+    tier: "gold",
+    sort_order: 5,
+  },
+  {
+    id: "ten_hours_streamed",
+    name: "Marathon Streamer",
+    description: "Streamed for 10 hours total",
+    icon: "clock-10",
+    tier: "silver",
+    sort_order: 6,
+  },
+  {
+    id: "hundred_hours_streamed",
+    name: "Veteran Broadcaster",
+    description: "Streamed for 100 hours total",
+    icon: "clock-100",
+    tier: "gold",
+    sort_order: 7,
+  },
+  {
+    id: "top_earner",
+    name: "Top Earner",
+    description: "Earned 1,000 USDC total",
+    icon: "diamond",
+    tier: "diamond",
+    sort_order: 8,
+  },
+] as const;
+
+export type BadgeStatSnapshot = {
+  totalStreams: number;
+  totalTipCount: number;
+  totalGiftCount: number;
+  followerCount: number;
+  totalStreamedSeconds: number;
+  totalEarningsUsdc: number;
+};
+
+export function evaluateBadgeIds(
+  stats: BadgeStatSnapshot,
+  earnedBadgeIds: Set<string>
+): string[] {
+  const newBadges: string[] = [];
+
+  const maybeAdd = (badgeId: string, condition: boolean) => {
+    if (condition && !earnedBadgeIds.has(badgeId)) {
+      newBadges.push(badgeId);
+    }
+  };
+
+  maybeAdd("first_stream", stats.totalStreams > 0);
+  maybeAdd("first_tip", stats.totalTipCount > 0);
+  maybeAdd("first_gift", stats.totalGiftCount > 0);
+  maybeAdd("hundred_followers", stats.followerCount >= 100);
+  maybeAdd("thousand_followers", stats.followerCount >= 1000);
+  maybeAdd("ten_hours_streamed", stats.totalStreamedSeconds >= 10 * 60 * 60);
+  maybeAdd(
+    "hundred_hours_streamed",
+    stats.totalStreamedSeconds >= 100 * 60 * 60
+  );
+  maybeAdd("top_earner", stats.totalEarningsUsdc >= 1000);
+
+  return newBadges;
+}
+
+export async function getBadgeStats(
+  userId: string
+): Promise<BadgeStatSnapshot> {
+  const [streamRows, tipRows, giftRows, followRows, earningsRows] =
+    await Promise.all([
+      sql`
+      SELECT COUNT(*) AS total_streams,
+             COALESCE(SUM(COALESCE(duration_seconds, 0)), 0) AS total_streamed_seconds
+      FROM stream_sessions
+      WHERE user_id = ${userId}
+        AND ended_at IS NOT NULL
+    `,
+      sql`
+      SELECT COUNT(*) AS total_tip_count
+      FROM tip_transactions
+      WHERE creator_id = ${userId}
+    `,
+      sql`
+      SELECT COUNT(*) AS total_gift_count
+      FROM gift_transactions
+      WHERE creator_id = ${userId}
+    `,
+      sql`
+      SELECT COUNT(*) AS follower_count
+      FROM user_follows
+      WHERE followee_id = ${userId}
+    `,
+      sql`
+      SELECT (
+        COALESCE((SELECT SUM(amount_usdc) FROM gift_transactions WHERE creator_id = ${userId}), 0) +
+        COALESCE((SELECT SUM(amount_usdc) FROM subscriptions WHERE creator_id = ${userId} AND status IN ('active', 'completed', 'cancelled')), 0)
+      ) AS usdc_earnings
+    `,
+    ]);
+
+  const xlmRows = await sql`
+    SELECT COALESCE(SUM(amount_xlm), 0) AS total_tip_xlm
+    FROM tip_transactions
+    WHERE creator_id = ${userId}
+  `;
+
+  const xlmPriceRows = await sql`
+    SELECT price_usd
+    FROM tip_transactions
+    WHERE creator_id = ${userId}
+      AND price_usd IS NOT NULL
+    ORDER BY created_at DESC
+    LIMIT 1
+  `;
+
+  const latestXlmPrice = Number.parseFloat(
+    String(xlmPriceRows.rows[0]?.price_usd ?? 0.08)
+  );
+
+  const xlmEarnings =
+    Number.parseFloat(String(xlmRows.rows[0]?.total_tip_xlm ?? 0)) *
+    latestXlmPrice;
+
+  return {
+    totalStreams: Number.parseInt(
+      String(streamRows.rows[0]?.total_streams ?? 0),
+      10
+    ),
+    totalTipCount: Number.parseInt(
+      String(tipRows.rows[0]?.total_tip_count ?? 0),
+      10
+    ),
+    totalGiftCount: Number.parseInt(
+      String(giftRows.rows[0]?.total_gift_count ?? 0),
+      10
+    ),
+    followerCount: Number.parseInt(
+      String(followRows.rows[0]?.follower_count ?? 0),
+      10
+    ),
+    totalStreamedSeconds: Number.parseInt(
+      String(streamRows.rows[0]?.total_streamed_seconds ?? 0),
+      10
+    ),
+    totalEarningsUsdc:
+      Number.parseFloat(String(earningsRows.rows[0]?.usdc_earnings ?? 0)) +
+      xlmEarnings,
+  };
+}
+
+export async function evaluateAndAwardBadges(userId: string) {
+  const [stats, earnedRows] = await Promise.all([
+    getBadgeStats(userId),
+    sql`
+      SELECT badge_id FROM user_badges WHERE user_id = ${userId}
+    `,
+  ]);
+
+  const earnedBadgeIds = new Set(
+    earnedRows.rows.map(row => String(row.badge_id))
+  );
+  const newBadges = evaluateBadgeIds(stats, earnedBadgeIds);
+
+  if (newBadges.length === 0) {
+    return [];
+  }
+
+  await Promise.all(
+    newBadges.map(
+      badgeId =>
+        sql`
+        INSERT INTO user_badges (user_id, badge_id)
+        VALUES (${userId}, ${badgeId})
+        ON CONFLICT DO NOTHING
+      `
+    )
+  );
+
+  const userRow =
+    await sql`SELECT username FROM users WHERE id = ${userId} LIMIT 1`;
+  const username = String(userRow.rows[0]?.username ?? "creator");
+
+  await Promise.all(
+    newBadges.map(async badgeId => {
+      const definition = BADGE_DEFINITIONS.find(badge => badge.id === badgeId);
+      if (!definition) {
+        return;
+      }
+
+      await writeNotification(
+        userId,
+        "live",
+        `Badge earned: ${definition.name}`,
+        `${username} unlocked the ${definition.name} badge`
+      );
+    })
+  );
+
+  return newBadges;
+}

--- a/lib/routes-f/cache.ts
+++ b/lib/routes-f/cache.ts
@@ -1,0 +1,64 @@
+import { Redis } from "@upstash/redis";
+
+type CacheRecord<T> = {
+  expiresAt: number;
+  value: T;
+};
+
+const memoryCache = new Map<string, CacheRecord<unknown>>();
+
+function getRedisClient(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    return null;
+  }
+
+  return new Redis({ url, token });
+}
+
+export async function getCachedJson<T>(key: string): Promise<T | null> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const value = await redis.get<T>(key);
+      return value ?? null;
+    } catch (error) {
+      console.warn(`[routes-f cache] Redis GET failed for ${key}:`, error);
+    }
+  }
+
+  const fallback = memoryCache.get(key);
+  if (!fallback || fallback.expiresAt <= Date.now()) {
+    if (fallback) {
+      memoryCache.delete(key);
+    }
+    return null;
+  }
+
+  return fallback.value as T;
+}
+
+export async function setCachedJson<T>(
+  key: string,
+  value: T,
+  ttlSeconds: number
+): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.set(key, value, { ex: ttlSeconds });
+      return;
+    } catch (error) {
+      console.warn(`[routes-f cache] Redis SET failed for ${key}:`, error);
+    }
+  }
+
+  memoryCache.set(key, {
+    value,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  });
+}

--- a/lib/routes-f/earnings.ts
+++ b/lib/routes-f/earnings.ts
@@ -1,0 +1,458 @@
+import { sql } from "@vercel/postgres";
+import { addMonths } from "date-fns";
+import { getCachedJson, setCachedJson } from "@/lib/routes-f/cache";
+import {
+  clampNumber,
+  getInclusiveRange,
+  getMonthRange,
+  getPeriodKey,
+  GroupBy,
+  parseDateParam,
+  toFixedAmount,
+  toFixedXlm,
+} from "@/lib/routes-f/format";
+import { getXlmUsdPrice } from "@/lib/routes-f/price";
+
+type SupportedSource = "tips" | "gifts" | "subscriptions";
+
+type EarningTransaction = {
+  id: string;
+  source: SupportedSource;
+  amount: number;
+  asset: string;
+  usdEquivalent: number;
+  occurredAt: string;
+  supporterUsername: string | null;
+};
+
+type SummaryBucket = {
+  tips: { xlm: string; usd_equivalent: string };
+  gifts: { usdc: string };
+  subscriptions: { usdc: string };
+  total_usd: string;
+};
+
+export type EarningsSeriesResponse = {
+  series: Array<{
+    period: string;
+    tips_xlm: string;
+    gifts_usdc: string;
+    subscriptions_usdc: string;
+    total_usd_equivalent: string;
+  }>;
+  totals: {
+    tips_xlm: string;
+    gifts_usdc: string;
+    subscriptions_usdc: string;
+    total_usd_equivalent: string;
+  };
+  transactions: Array<{
+    id: string;
+    source: SupportedSource;
+    amount: string;
+    asset: string;
+    usd_equivalent: string;
+    occurred_at: string;
+    supporter_username: string | null;
+  }>;
+};
+
+export type EarningsSummaryResponse = {
+  all_time: SummaryBucket;
+  this_month: SummaryBucket;
+  last_month: SummaryBucket;
+  top_supporters: Array<{
+    username: string;
+    total_usd: string;
+    last_at: string;
+  }>;
+  cached: boolean;
+};
+
+async function fetchTipTransactions(
+  creatorId: string,
+  from?: Date,
+  to?: Date
+): Promise<Array<Record<string, unknown>>> {
+  if (from && to) {
+    const result = await sql`
+      SELECT tt.id, tt.amount_xlm, tt.created_at, u.username AS supporter_username
+      FROM tip_transactions tt
+      LEFT JOIN users u ON u.id = tt.supporter_id
+      WHERE tt.creator_id = ${creatorId}
+        AND tt.created_at BETWEEN ${from.toISOString()} AND ${to.toISOString()}
+      ORDER BY tt.created_at DESC
+    `;
+    return result.rows;
+  }
+
+  const result = await sql`
+    SELECT tt.id, tt.amount_xlm, tt.created_at, u.username AS supporter_username
+    FROM tip_transactions tt
+    LEFT JOIN users u ON u.id = tt.supporter_id
+    WHERE tt.creator_id = ${creatorId}
+    ORDER BY tt.created_at DESC
+  `;
+  return result.rows;
+}
+
+async function fetchGiftTransactions(
+  creatorId: string,
+  from?: Date,
+  to?: Date
+): Promise<Array<Record<string, unknown>>> {
+  if (from && to) {
+    const result = await sql`
+      SELECT gt.id, gt.amount_usdc, gt.created_at, u.username AS supporter_username
+      FROM gift_transactions gt
+      LEFT JOIN users u ON u.id = gt.supporter_id
+      WHERE gt.creator_id = ${creatorId}
+        AND gt.created_at BETWEEN ${from.toISOString()} AND ${to.toISOString()}
+      ORDER BY gt.created_at DESC
+    `;
+    return result.rows;
+  }
+
+  const result = await sql`
+    SELECT gt.id, gt.amount_usdc, gt.created_at, u.username AS supporter_username
+    FROM gift_transactions gt
+    LEFT JOIN users u ON u.id = gt.supporter_id
+    WHERE gt.creator_id = ${creatorId}
+    ORDER BY gt.created_at DESC
+  `;
+  return result.rows;
+}
+
+async function fetchSubscriptionTransactions(
+  creatorId: string,
+  from?: Date,
+  to?: Date
+): Promise<Array<Record<string, unknown>>> {
+  if (from && to) {
+    const result = await sql`
+      SELECT s.id, s.amount_usdc, COALESCE(s.last_charged_at, s.created_at) AS created_at,
+             u.username AS supporter_username
+      FROM subscriptions s
+      LEFT JOIN users u ON u.id = s.supporter_id
+      WHERE s.creator_id = ${creatorId}
+        AND COALESCE(s.last_charged_at, s.created_at)
+          BETWEEN ${from.toISOString()} AND ${to.toISOString()}
+        AND s.status IN ('active', 'completed', 'cancelled')
+      ORDER BY COALESCE(s.last_charged_at, s.created_at) DESC
+    `;
+    return result.rows;
+  }
+
+  const result = await sql`
+    SELECT s.id, s.amount_usdc, COALESCE(s.last_charged_at, s.created_at) AS created_at,
+           u.username AS supporter_username
+    FROM subscriptions s
+    LEFT JOIN users u ON u.id = s.supporter_id
+    WHERE s.creator_id = ${creatorId}
+      AND s.status IN ('active', 'completed', 'cancelled')
+    ORDER BY COALESCE(s.last_charged_at, s.created_at) DESC
+  `;
+  return result.rows;
+}
+
+function buildSummaryBucket(
+  tipsXlm: number,
+  giftsUsdc: number,
+  subscriptionsUsdc: number,
+  xlmUsdPrice: number
+): SummaryBucket {
+  const tipsUsd = clampNumber(tipsXlm * xlmUsdPrice);
+  const totalUsd = tipsUsd + giftsUsdc + subscriptionsUsdc;
+
+  return {
+    tips: {
+      xlm: toFixedXlm(tipsXlm),
+      usd_equivalent: toFixedAmount(tipsUsd),
+    },
+    gifts: { usdc: toFixedAmount(giftsUsdc) },
+    subscriptions: { usdc: toFixedAmount(subscriptionsUsdc) },
+    total_usd: toFixedAmount(totalUsd),
+  };
+}
+
+function mapToTransactions(
+  rows: Array<Record<string, unknown>>,
+  source: SupportedSource,
+  asset: string,
+  amountField: "amount_xlm" | "amount_usdc",
+  xlmUsdPrice: number
+): EarningTransaction[] {
+  return rows.map(row => {
+    const amount = Number.parseFloat(String(row[amountField] ?? 0));
+    const usdEquivalent = source === "tips" ? amount * xlmUsdPrice : amount;
+
+    return {
+      id: String(row.id),
+      source,
+      amount,
+      asset,
+      usdEquivalent,
+      occurredAt: new Date(String(row.created_at)).toISOString(),
+      supporterUsername:
+        row.supporter_username === null ? null : String(row.supporter_username),
+    };
+  });
+}
+
+export async function getCreatorEarningsSeries(params: {
+  creatorId: string;
+  fromParam: string | null;
+  toParam: string | null;
+  groupByParam: string | null;
+}): Promise<EarningsSeriesResponse> {
+  const groupBy = (params.groupByParam ?? "day") as GroupBy;
+  if (!["day", "week", "month"].includes(groupBy)) {
+    throw new Error("group_by must be one of day, week, or month");
+  }
+
+  const fromDate = parseDateParam(params.fromParam, "from");
+  const toDate = parseDateParam(params.toParam, "to");
+  const { from, to } = getInclusiveRange(fromDate, toDate);
+  const xlmUsdPrice = await getXlmUsdPrice();
+
+  const [tipRows, giftRows, subscriptionRows] = await Promise.all([
+    fetchTipTransactions(params.creatorId, from, to),
+    fetchGiftTransactions(params.creatorId, from, to),
+    fetchSubscriptionTransactions(params.creatorId, from, to),
+  ]);
+
+  const transactions = [
+    ...mapToTransactions(tipRows, "tips", "XLM", "amount_xlm", xlmUsdPrice),
+    ...mapToTransactions(giftRows, "gifts", "USDC", "amount_usdc", xlmUsdPrice),
+    ...mapToTransactions(
+      subscriptionRows,
+      "subscriptions",
+      "USDC",
+      "amount_usdc",
+      xlmUsdPrice
+    ),
+  ].sort((left, right) => right.occurredAt.localeCompare(left.occurredAt));
+
+  const seriesMap = new Map<
+    string,
+    {
+      tipsXlm: number;
+      giftsUsdc: number;
+      subscriptionsUsdc: number;
+      totalUsdEquivalent: number;
+    }
+  >();
+
+  for (const transaction of transactions) {
+    const period = getPeriodKey(transaction.occurredAt, groupBy);
+    const bucket = seriesMap.get(period) ?? {
+      tipsXlm: 0,
+      giftsUsdc: 0,
+      subscriptionsUsdc: 0,
+      totalUsdEquivalent: 0,
+    };
+
+    if (transaction.source === "tips") {
+      bucket.tipsXlm += transaction.amount;
+    } else if (transaction.source === "gifts") {
+      bucket.giftsUsdc += transaction.amount;
+    } else {
+      bucket.subscriptionsUsdc += transaction.amount;
+    }
+
+    bucket.totalUsdEquivalent += transaction.usdEquivalent;
+    seriesMap.set(period, bucket);
+  }
+
+  const sortedPeriods = Array.from(seriesMap.keys()).sort();
+  const series = sortedPeriods.map(period => {
+    const bucket = seriesMap.get(period)!;
+    return {
+      period,
+      tips_xlm: toFixedXlm(bucket.tipsXlm),
+      gifts_usdc: toFixedAmount(bucket.giftsUsdc),
+      subscriptions_usdc: toFixedAmount(bucket.subscriptionsUsdc),
+      total_usd_equivalent: toFixedAmount(bucket.totalUsdEquivalent),
+    };
+  });
+
+  const totals = transactions.reduce(
+    (accumulator, transaction) => {
+      if (transaction.source === "tips") {
+        accumulator.tipsXlm += transaction.amount;
+      } else if (transaction.source === "gifts") {
+        accumulator.giftsUsdc += transaction.amount;
+      } else {
+        accumulator.subscriptionsUsdc += transaction.amount;
+      }
+
+      accumulator.totalUsdEquivalent += transaction.usdEquivalent;
+      return accumulator;
+    },
+    {
+      tipsXlm: 0,
+      giftsUsdc: 0,
+      subscriptionsUsdc: 0,
+      totalUsdEquivalent: 0,
+    }
+  );
+
+  return {
+    series,
+    totals: {
+      tips_xlm: toFixedXlm(totals.tipsXlm),
+      gifts_usdc: toFixedAmount(totals.giftsUsdc),
+      subscriptions_usdc: toFixedAmount(totals.subscriptionsUsdc),
+      total_usd_equivalent: toFixedAmount(totals.totalUsdEquivalent),
+    },
+    transactions: transactions.map(transaction => ({
+      id: transaction.id,
+      source: transaction.source,
+      amount:
+        transaction.asset === "XLM"
+          ? toFixedXlm(transaction.amount)
+          : toFixedAmount(transaction.amount),
+      asset: transaction.asset,
+      usd_equivalent: toFixedAmount(transaction.usdEquivalent),
+      occurred_at: transaction.occurredAt,
+      supporter_username: transaction.supporterUsername,
+    })),
+  };
+}
+
+async function getSummaryWindowTotals(
+  creatorId: string,
+  from?: Date,
+  to?: Date
+): Promise<{ tipsXlm: number; giftsUsdc: number; subscriptionsUsdc: number }> {
+  const [tipRows, giftRows, subscriptionRows] = await Promise.all([
+    fetchTipTransactions(creatorId, from, to),
+    fetchGiftTransactions(creatorId, from, to),
+    fetchSubscriptionTransactions(creatorId, from, to),
+  ]);
+
+  return {
+    tipsXlm: tipRows.reduce(
+      (sum, row) => sum + Number.parseFloat(String(row.amount_xlm ?? 0)),
+      0
+    ),
+    giftsUsdc: giftRows.reduce(
+      (sum, row) => sum + Number.parseFloat(String(row.amount_usdc ?? 0)),
+      0
+    ),
+    subscriptionsUsdc: subscriptionRows.reduce(
+      (sum, row) => sum + Number.parseFloat(String(row.amount_usdc ?? 0)),
+      0
+    ),
+  };
+}
+
+async function getTopSupporters(
+  creatorId: string,
+  xlmUsdPrice: number
+): Promise<EarningsSummaryResponse["top_supporters"]> {
+  const result = await sql`
+    WITH supporter_totals AS (
+      SELECT tt.supporter_id,
+             COALESCE(u.username, 'unknown') AS username,
+             SUM(tt.amount_xlm::numeric * ${xlmUsdPrice}) AS total_usd,
+             MAX(tt.created_at) AS last_at
+      FROM tip_transactions tt
+      LEFT JOIN users u ON u.id = tt.supporter_id
+      WHERE tt.creator_id = ${creatorId}
+      GROUP BY tt.supporter_id, u.username
+
+      UNION ALL
+
+      SELECT gt.supporter_id,
+             COALESCE(u.username, 'unknown') AS username,
+             SUM(gt.amount_usdc::numeric) AS total_usd,
+             MAX(gt.created_at) AS last_at
+      FROM gift_transactions gt
+      LEFT JOIN users u ON u.id = gt.supporter_id
+      WHERE gt.creator_id = ${creatorId}
+      GROUP BY gt.supporter_id, u.username
+
+      UNION ALL
+
+      SELECT s.supporter_id,
+             COALESCE(u.username, 'unknown') AS username,
+             SUM(s.amount_usdc::numeric) AS total_usd,
+             MAX(COALESCE(s.last_charged_at, s.created_at)) AS last_at
+      FROM subscriptions s
+      LEFT JOIN users u ON u.id = s.supporter_id
+      WHERE s.creator_id = ${creatorId}
+        AND s.status IN ('active', 'completed', 'cancelled')
+      GROUP BY s.supporter_id, u.username
+    )
+    SELECT username,
+           SUM(total_usd) AS total_usd,
+           MAX(last_at) AS last_at
+    FROM supporter_totals
+    GROUP BY username
+    ORDER BY SUM(total_usd) DESC, MAX(last_at) DESC
+    LIMIT 10
+  `;
+
+  return result.rows.map(row => ({
+    username: String(row.username),
+    total_usd: toFixedAmount(Number.parseFloat(String(row.total_usd ?? 0))),
+    last_at: new Date(String(row.last_at)).toISOString(),
+  }));
+}
+
+export async function getCreatorEarningsSummary(
+  creatorId: string
+): Promise<EarningsSummaryResponse> {
+  const cacheKey = `routes-f:earnings:summary:${creatorId}`;
+  const cached =
+    await getCachedJson<Omit<EarningsSummaryResponse, "cached">>(cacheKey);
+
+  if (cached) {
+    return {
+      ...cached,
+      cached: true,
+    };
+  }
+
+  const xlmUsdPrice = await getXlmUsdPrice();
+  const now = new Date();
+  const currentMonth = getMonthRange(now);
+  const previousMonth = getMonthRange(addMonths(now, -1));
+
+  const [allTime, thisMonth, lastMonth, topSupporters] = await Promise.all([
+    getSummaryWindowTotals(creatorId),
+    getSummaryWindowTotals(creatorId, currentMonth.from, currentMonth.to),
+    getSummaryWindowTotals(creatorId, previousMonth.from, previousMonth.to),
+    getTopSupporters(creatorId, xlmUsdPrice),
+  ]);
+
+  const payload = {
+    all_time: buildSummaryBucket(
+      allTime.tipsXlm,
+      allTime.giftsUsdc,
+      allTime.subscriptionsUsdc,
+      xlmUsdPrice
+    ),
+    this_month: buildSummaryBucket(
+      thisMonth.tipsXlm,
+      thisMonth.giftsUsdc,
+      thisMonth.subscriptionsUsdc,
+      xlmUsdPrice
+    ),
+    last_month: buildSummaryBucket(
+      lastMonth.tipsXlm,
+      lastMonth.giftsUsdc,
+      lastMonth.subscriptionsUsdc,
+      xlmUsdPrice
+    ),
+    top_supporters: topSupporters,
+  };
+
+  await setCachedJson(cacheKey, payload, 300);
+
+  return {
+    ...payload,
+    cached: false,
+  };
+}

--- a/lib/routes-f/format.ts
+++ b/lib/routes-f/format.ts
@@ -1,0 +1,115 @@
+import {
+  endOfMonth,
+  endOfWeek,
+  format,
+  parseISO,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+
+export type GroupBy = "day" | "week" | "month";
+
+export function toFixedAmount(value: number, digits = 2): string {
+  return value.toFixed(digits);
+}
+
+export function toFixedXlm(value: number): string {
+  return value.toFixed(7).replace(/0+$/, "").replace(/\.$/, ".0");
+}
+
+export function clampNumber(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return value;
+}
+
+export function parseDateParam(value: string | null, label: string): Date {
+  if (!value) {
+    throw new Error(`${label} is required`);
+  }
+
+  const parsed = parseISO(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${label} must be a valid ISO date`);
+  }
+
+  return parsed;
+}
+
+export function getPeriodKey(
+  dateValue: string | Date,
+  groupBy: GroupBy
+): string {
+  const date = typeof dateValue === "string" ? parseISO(dateValue) : dateValue;
+
+  if (groupBy === "day") {
+    return format(startOfDay(date), "yyyy-MM-dd");
+  }
+
+  if (groupBy === "week") {
+    return format(startOfWeek(date, { weekStartsOn: 1 }), "yyyy-MM-dd");
+  }
+
+  return format(startOfMonth(date), "yyyy-MM-dd");
+}
+
+export function getMonthRange(baseDate: Date): { from: Date; to: Date } {
+  return {
+    from: startOfMonth(baseDate),
+    to: endOfMonth(baseDate),
+  };
+}
+
+export function getInclusiveRange(
+  from: Date,
+  to: Date
+): { from: Date; to: Date } {
+  if (from > to) {
+    throw new Error("from must be before or equal to to");
+  }
+
+  return { from: startOfDay(from), to: endOfDaySafe(to) };
+}
+
+export function endOfDaySafe(date: Date): Date {
+  const nextDay = new Date(date);
+  nextDay.setHours(23, 59, 59, 999);
+  return nextDay;
+}
+
+export function getNextReminderTime(scheduledAt: Date): Date {
+  return new Date(scheduledAt.getTime() - 15 * 60 * 1000);
+}
+
+export function getUpcomingWindowKey(dateValue: string | Date): string {
+  const date = typeof dateValue === "string" ? parseISO(dateValue) : dateValue;
+  return format(startOfWeek(date, { weekStartsOn: 1 }), "yyyy-MM-dd");
+}
+
+export function getRangeLabel(
+  dateValue: string | Date,
+  groupBy: GroupBy
+): string {
+  const date = typeof dateValue === "string" ? parseISO(dateValue) : dateValue;
+  if (groupBy === "week") {
+    return format(startOfWeek(date, { weekStartsOn: 1 }), "yyyy-MM-dd");
+  }
+  if (groupBy === "month") {
+    return format(startOfMonth(date), "yyyy-MM-01");
+  }
+  return format(startOfDay(date), "yyyy-MM-dd");
+}
+
+export function getWindowEnd(dateValue: string | Date, groupBy: GroupBy): Date {
+  const date = typeof dateValue === "string" ? parseISO(dateValue) : dateValue;
+  if (groupBy === "week") {
+    return endOfWeek(date, { weekStartsOn: 1 });
+  }
+  if (groupBy === "month") {
+    return endOfMonth(date);
+  }
+  return endOfDaySafe(date);
+}

--- a/lib/routes-f/payouts.ts
+++ b/lib/routes-f/payouts.ts
@@ -1,0 +1,172 @@
+import { sql } from "@vercel/postgres";
+import nodemailer from "nodemailer";
+import { Horizon } from "@stellar/stellar-sdk";
+import { getHorizonUrl, getStellarNetwork } from "@/lib/stellar/config";
+import { toFixedAmount } from "@/lib/routes-f/format";
+
+export const PAYOUT_METHODS = [
+  "bank_transfer",
+  "stellar_wallet",
+  "mobile_money",
+] as const;
+
+export type PayoutMethod = (typeof PAYOUT_METHODS)[number];
+
+function createTransporter() {
+  return nodemailer.createTransport({
+    service: "Gmail",
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  });
+}
+
+export async function getUsdcBalance(walletAddress: string): Promise<number> {
+  const server = new Horizon.Server(getHorizonUrl(getStellarNetwork()));
+  const account = await server.loadAccount(walletAddress);
+
+  const usdcBalance = account.balances.find(balance => {
+    return (
+      balance.asset_type === "credit_alphanum4" && balance.asset_code === "USDC"
+    );
+  });
+
+  return Number.parseFloat(usdcBalance?.balance ?? "0");
+}
+
+export async function sendPayoutConfirmationEmail(params: {
+  email: string;
+  username: string | null;
+  amountUsdc: string;
+  method: PayoutMethod;
+  destination: string;
+}): Promise<void> {
+  if (!params.email || !process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
+    return;
+  }
+
+  const transporter = createTransporter();
+  await transporter.sendMail({
+    from: {
+      name: "StreamFi",
+      address: process.env.EMAIL_USER,
+    },
+    to: params.email,
+    subject: "StreamFi payout request received",
+    html: `
+      <p>Hello ${params.username ?? "creator"},</p>
+      <p>We received your payout request for <strong>${params.amountUsdc} USDC</strong>.</p>
+      <p>Method: ${params.method}</p>
+      <p>Destination: ${params.destination}</p>
+      <p>Our team has been notified and will process it shortly.</p>
+    `,
+  });
+}
+
+export async function notifyAdminOfPayout(params: {
+  username: string | null;
+  userId: string;
+  amountUsdc: string;
+  method: PayoutMethod;
+  destination: string;
+}): Promise<void> {
+  const adminEmail = process.env.ADMIN_EMAIL ?? process.env.EMAIL_USER;
+  if (!adminEmail || !process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
+    return;
+  }
+
+  const transporter = createTransporter();
+  await transporter.sendMail({
+    from: {
+      name: "StreamFi",
+      address: process.env.EMAIL_USER,
+    },
+    to: adminEmail,
+    subject: "New StreamFi payout request",
+    html: `
+      <p>A new payout request is pending manual processing.</p>
+      <ul>
+        <li>User: ${params.username ?? "unknown"}</li>
+        <li>User ID: ${params.userId}</li>
+        <li>Amount: ${params.amountUsdc} USDC</li>
+        <li>Method: ${params.method}</li>
+        <li>Destination: ${params.destination}</li>
+      </ul>
+    `,
+  });
+}
+
+export async function getPayoutHistory(userId: string) {
+  const [{ rows: payouts }, { rows: totalRows }] = await Promise.all([
+    sql`
+      SELECT id, amount_usdc, fee_usdc, net_usdc, method, destination, status,
+             initiated_at, completed_at, provider, provider_ref, notes
+      FROM payouts
+      WHERE user_id = ${userId}
+      ORDER BY initiated_at DESC
+    `,
+    sql`
+      SELECT COALESCE(SUM(net_usdc), 0) AS total_paid_out_usdc
+      FROM payouts
+      WHERE user_id = ${userId}
+        AND status = 'completed'
+    `,
+  ]);
+
+  return {
+    payouts: payouts.map(row => ({
+      id: String(row.id),
+      amount_usdc: toFixedAmount(
+        Number.parseFloat(String(row.amount_usdc ?? 0))
+      ),
+      fee_usdc: toFixedAmount(Number.parseFloat(String(row.fee_usdc ?? 0))),
+      net_usdc: toFixedAmount(Number.parseFloat(String(row.net_usdc ?? 0))),
+      method: String(row.method),
+      destination: String(row.destination),
+      status: String(row.status),
+      initiated_at: new Date(String(row.initiated_at)).toISOString(),
+      completed_at: row.completed_at
+        ? new Date(String(row.completed_at)).toISOString()
+        : null,
+      provider: row.provider ?? null,
+      provider_ref: row.provider_ref ?? null,
+      notes: row.notes ?? null,
+    })),
+    total_paid_out_usdc: toFixedAmount(
+      Number.parseFloat(String(totalRows[0]?.total_paid_out_usdc ?? 0))
+    ),
+  };
+}
+
+export async function getSinglePayout(userId: string, payoutId: string) {
+  const result = await sql`
+    SELECT id, amount_usdc, fee_usdc, net_usdc, method, destination, status,
+           initiated_at, completed_at, provider, provider_ref, notes
+    FROM payouts
+    WHERE id = ${payoutId}::uuid AND user_id = ${userId}
+    LIMIT 1
+  `;
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const row = result.rows[0];
+  return {
+    id: String(row.id),
+    amount_usdc: toFixedAmount(Number.parseFloat(String(row.amount_usdc ?? 0))),
+    fee_usdc: toFixedAmount(Number.parseFloat(String(row.fee_usdc ?? 0))),
+    net_usdc: toFixedAmount(Number.parseFloat(String(row.net_usdc ?? 0))),
+    method: String(row.method),
+    destination: String(row.destination),
+    status: String(row.status),
+    initiated_at: new Date(String(row.initiated_at)).toISOString(),
+    completed_at: row.completed_at
+      ? new Date(String(row.completed_at)).toISOString()
+      : null,
+    provider: row.provider ?? null,
+    provider_ref: row.provider_ref ?? null,
+    notes: row.notes ?? null,
+  };
+}

--- a/lib/routes-f/price.ts
+++ b/lib/routes-f/price.ts
@@ -1,0 +1,36 @@
+let cachedPrice: { price: number; fetchedAt: number } | null = null;
+const PRICE_TTL_MS = 60_000;
+
+export async function getXlmUsdPrice(): Promise<number> {
+  const now = Date.now();
+  if (cachedPrice && now - cachedPrice.fetchedAt < PRICE_TTL_MS) {
+    return cachedPrice.price;
+  }
+
+  try {
+    const response = await fetch(
+      "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT",
+      {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(5000),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Price provider returned ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const price = Number.parseFloat(payload?.price);
+
+    if (!Number.isFinite(price)) {
+      throw new Error("Price payload was invalid");
+    }
+
+    cachedPrice = { price, fetchedAt: now };
+    return price;
+  } catch (error) {
+    console.warn("[routes-f price] Falling back to cached XLM price:", error);
+    return cachedPrice?.price ?? 0.08;
+  }
+}

--- a/lib/routes-f/schedule.ts
+++ b/lib/routes-f/schedule.ts
@@ -1,0 +1,98 @@
+import { sql } from "@vercel/postgres";
+import { writeNotification } from "@/lib/notifications";
+import { getNextReminderTime } from "@/lib/routes-f/format";
+
+export async function syncScheduleLiveStatusForCreator(
+  creatorId: string
+): Promise<void> {
+  await sql`
+    UPDATE stream_schedule
+    SET status = 'live'
+    WHERE id IN (
+      SELECT id
+      FROM stream_schedule
+      WHERE creator_id = ${creatorId}
+        AND status = 'upcoming'
+        AND ABS(EXTRACT(EPOCH FROM (scheduled_at - NOW()))) <= 1800
+      ORDER BY ABS(EXTRACT(EPOCH FROM (scheduled_at - NOW())))
+      LIMIT 1
+    )
+  `;
+}
+
+export async function sendDueScheduleReminders(): Promise<number> {
+  const result = await sql`
+    SELECT sr.schedule_id, sr.viewer_id, ss.title, ss.scheduled_at, u.username AS creator_username
+    FROM stream_reminders sr
+    INNER JOIN stream_schedule ss ON ss.id = sr.schedule_id
+    INNER JOIN users u ON u.id = ss.creator_id
+    WHERE sr.sent = false
+      AND sr.remind_at <= NOW()
+      AND ss.status = 'upcoming'
+  `;
+
+  await Promise.all(
+    result.rows.map(async row => {
+      await writeNotification(
+        String(row.viewer_id),
+        "live",
+        `Reminder: ${String(row.title)}`,
+        `${String(row.creator_username)} goes live at ${new Date(String(row.scheduled_at)).toISOString()}`
+      );
+
+      await sql`
+        UPDATE stream_reminders
+        SET sent = true
+        WHERE schedule_id = ${String(row.schedule_id)}::uuid
+          AND viewer_id = ${String(row.viewer_id)}::uuid
+      `;
+    })
+  );
+
+  return result.rows.length;
+}
+
+export async function upsertReminder(scheduleId: string, viewerId: string) {
+  const scheduleResult = await sql`
+    SELECT id, scheduled_at, status
+    FROM stream_schedule
+    WHERE id = ${scheduleId}::uuid
+    LIMIT 1
+  `;
+
+  if (scheduleResult.rows.length === 0) {
+    throw new Error("Scheduled stream not found");
+  }
+
+  const schedule = scheduleResult.rows[0];
+  if (String(schedule.status) === "cancelled") {
+    throw new Error("Cannot set a reminder on a cancelled stream");
+  }
+
+  const remindAt = getNextReminderTime(new Date(String(schedule.scheduled_at)));
+
+  const existing = await sql`
+    SELECT sent
+    FROM stream_reminders
+    WHERE schedule_id = ${scheduleId}::uuid AND viewer_id = ${viewerId}
+    LIMIT 1
+  `;
+
+  if (existing.rows.length > 0) {
+    await sql`
+      DELETE FROM stream_reminders
+      WHERE schedule_id = ${scheduleId}::uuid AND viewer_id = ${viewerId}
+    `;
+
+    return { reminder_set: false };
+  }
+
+  await sql`
+    INSERT INTO stream_reminders (schedule_id, viewer_id, remind_at)
+    VALUES (${scheduleId}::uuid, ${viewerId}, ${remindAt.toISOString()})
+    ON CONFLICT (schedule_id, viewer_id)
+    DO UPDATE SET remind_at = EXCLUDED.remind_at, sent = false
+  `;
+
+  return { reminder_set: true, remind_at: remindAt.toISOString() };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/routes-f/schedule/reminders",
+      "schedule": "* * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Implements the missing creator-facing `routes-f` APIs for earnings, payouts, stream scheduling, reminders, badges, and the supporting schema/helpers needed to make those flows work together.

Closes #407
Closes #408
Closes #411
Closes #420

## Changes proposed

### What were you told to do?
Build the `routes-f` APIs for creator earnings breakdown and summary caching, payout history/initiation/status, stream scheduling and reminders, and creator badges/achievement evaluation, then ship the work as one PR linked to all four issues.

### What did I do?
#### Creator finance APIs
- Added earnings time-series and lifetime summary endpoints with creator-scoped auth, date filtering, day/week/month grouping, XLM-to-USD conversion, and top supporter aggregation.
- Added payout history, payout initiation, and per-payout status endpoints with minimum payout validation, Stellar USDC balance checks, creator confirmation email, and admin notification.
- Added shared helpers for Redis-backed summary caching with an in-memory fallback, XLM price lookup, payout formatting, and creator earnings aggregation.

#### Scheduling and reminders
- Added schedule listing, create, update, cancel, and reminder toggle endpoints for scheduled streams.
- Added a reminder processing endpoint plus Vercel cron config for minute-level reminder dispatch.
- Hooked stream start into schedule auto-status syncing so near-term scheduled streams flip to `live` automatically.

#### Badges and event hooks
- Added public badge definition listing, creator badge lookup, and authenticated badge evaluation endpoints.
- Added badge evaluation helpers and wired them into follow milestones, stream completion, and tip refresh persistence.
- Normalized Horizon tip refreshes into `tip_transactions` so badge checks and earnings reporting have persisted tip data to aggregate.

#### Database support and tests
- Added a migration for payout, schedule, reminder, badge, follow, tip, gift, and subscription tables plus indexes and seeded badge definitions.
- Added Jest coverage for badge threshold evaluation and time-period grouping helpers.
- Verified the change set with targeted Jest tests, `npm run type-check`, and `npm run build`.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --runInBand __tests__/lib/routes-f/badges.test.ts __tests__/lib/routes-f/format.test.ts`
- `npm run type-check`
- `npm run build`
- Build completed successfully; existing app warnings about missing local Mux/Upstash/Postgres env vars remained non-blocking for this PR.
