### PR TITLE
feat(routes-f): implement tags, emotes, moderation queue, and mock APIs

### DIFF
--- a/app/api/routes-f/emotes/[id]/route.ts
+++ b/app/api/routes-f/emotes/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+function isValidCode(code: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9]{2,19}$/.test(code);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+  const body = await req.json();
+  const code = String(body.code ?? "").trim();
+
+  if (!isValidCode(code)) {
+    return NextResponse.json(
+      {
+        error:
+          "code must be 3-20 alphanumeric chars and must start with a letter",
+      },
+      { status: 400 }
+    );
+  }
+
+  const { rows: globalRows } = await sql`
+    SELECT 1 FROM global_emotes WHERE LOWER(code) = LOWER(${code}) LIMIT 1
+  `;
+  if (globalRows.length > 0) {
+    return NextResponse.json(
+      { error: "code conflicts with global emote" },
+      { status: 409 }
+    );
+  }
+
+  const result = await sql`
+    UPDATE channel_emotes
+    SET code = ${code}
+    WHERE id = ${id} AND creator_id = ${session.userId}
+    RETURNING id, code, image_url, subscriber_only
+  `;
+
+  if (result.rows.length === 0) {
+    return NextResponse.json({ error: "Emote not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ emote: result.rows[0] });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  const result = await sql`
+    DELETE FROM channel_emotes
+    WHERE id = ${id} AND creator_id = ${session.userId}
+    RETURNING id
+  `;
+
+  if (result.rows.length === 0) {
+    return NextResponse.json({ error: "Emote not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/routes-f/emotes/route.ts
+++ b/app/api/routes-f/emotes/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+const MAX_FILE_SIZE_BYTES = 256 * 1024;
+const MAX_DIMENSION = 128;
+
+function isValidCode(code: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9]{2,19}$/.test(code);
+}
+
+async function readImageSize(
+  file: File
+): Promise<{ width: number; height: number }> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+
+  if (file.type === "image/png") {
+    if (bytes.length >= 24) {
+      const width =
+        (bytes[16] << 24) | (bytes[17] << 16) | (bytes[18] << 8) | bytes[19];
+      const height =
+        (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23];
+      return { width, height };
+    }
+  }
+
+  if (file.type === "image/gif") {
+    if (bytes.length >= 10) {
+      const width = bytes[6] | (bytes[7] << 8);
+      const height = bytes[8] | (bytes[9] << 8);
+      return { width, height };
+    }
+  }
+
+  throw new Error("Unsupported image format or invalid image file");
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const username = new URL(req.url).searchParams.get("username")?.trim();
+  if (!username) {
+    return NextResponse.json(
+      { error: "username is required" },
+      { status: 400 }
+    );
+  }
+
+  const { rows } = await sql`
+    SELECT
+      ce.id,
+      ce.code,
+      ce.image_url,
+      ce.subscriber_only
+    FROM channel_emotes ce
+    JOIN users u ON u.id = ce.creator_id
+    WHERE LOWER(u.username) = LOWER(${username})
+    ORDER BY ce.created_at ASC
+  `;
+
+  return NextResponse.json({ emotes: rows });
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const formData = await req.formData();
+  const image = formData.get("image");
+  const code = String(formData.get("code") ?? "").trim();
+  const subscriberOnly =
+    String(formData.get("subscriber_only") ?? "false").toLowerCase() === "true";
+
+  if (!(image instanceof File)) {
+    return NextResponse.json({ error: "image is required" }, { status: 400 });
+  }
+
+  if (!["image/png", "image/gif"].includes(image.type)) {
+    return NextResponse.json(
+      { error: "image must be PNG or GIF" },
+      { status: 400 }
+    );
+  }
+
+  if (image.size > MAX_FILE_SIZE_BYTES) {
+    return NextResponse.json(
+      { error: "image must be <= 256KB" },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidCode(code)) {
+    return NextResponse.json(
+      {
+        error:
+          "code must be 3-20 alphanumeric chars and must start with a letter",
+      },
+      { status: 400 }
+    );
+  }
+
+  const { width, height } = await readImageSize(image);
+  if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+    return NextResponse.json(
+      { error: "image dimensions must be <= 128x128" },
+      { status: 400 }
+    );
+  }
+
+  const { rows: globalRows } = await sql`
+    SELECT 1 FROM global_emotes WHERE LOWER(code) = LOWER(${code}) LIMIT 1
+  `;
+  if (globalRows.length > 0) {
+    return NextResponse.json(
+      { error: "code conflicts with global emote" },
+      { status: 409 }
+    );
+  }
+
+  const { rows: countRows } = await sql`
+    SELECT COUNT(*)::int AS count
+    FROM channel_emotes
+    WHERE creator_id = ${session.userId}
+  `;
+  if ((countRows[0]?.count ?? 0) >= 5) {
+    return NextResponse.json(
+      { error: "free tier limit reached (5 emotes)" },
+      { status: 403 }
+    );
+  }
+
+  const ext = image.type === "image/png" ? "png" : "gif";
+  const imageUrl = `https://cdn.streamfi.media/emotes/${session.userId}-${Date.now()}.${ext}`;
+
+  const { rows } = await sql`
+    INSERT INTO channel_emotes (
+      creator_id,
+      code,
+      image_url,
+      width,
+      height,
+      subscriber_only
+    )
+    VALUES (
+      ${session.userId},
+      ${code},
+      ${imageUrl},
+      ${width},
+      ${height},
+      ${subscriberOnly}
+    )
+    RETURNING id, code, image_url, subscriber_only
+  `;
+
+  return NextResponse.json({ emote: rows[0] }, { status: 201 });
+}

--- a/app/api/routes-f/mock/[scenario]/route.ts
+++ b/app/api/routes-f/mock/[scenario]/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+function isMainnet(): boolean {
+  return process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet";
+}
+
+function randomWallet(seed: number): string {
+  const base = `GMOCKWALLET${seed.toString().padStart(4, "0")}`;
+  return (base + "A".repeat(56)).slice(0, 56);
+}
+
+async function ensureCreator(): Promise<{ id: string; username: string }> {
+  const username = "mock_testcreator";
+  const email = "mock_testcreator@streamfi.dev";
+  const wallet = randomWallet(1);
+
+  const { rows } = await sql`
+    INSERT INTO users (username, email, wallet, avatar, creator)
+    VALUES (
+      ${username},
+      ${email},
+      ${wallet},
+      '/Images/streamer.jpg',
+      ${JSON.stringify({
+        streamTitle: "Mock Creator Live",
+        category: "Gaming",
+        mock: true,
+      })}::jsonb
+    )
+    ON CONFLICT (username)
+    DO UPDATE SET creator = users.creator || ${JSON.stringify({ mock: true })}::jsonb
+    RETURNING id, username
+  `;
+
+  return rows[0];
+}
+
+async function seedViewers(): Promise<number> {
+  let created = 0;
+  for (let i = 1; i <= 10; i += 1) {
+    const username = `mock_testviewer${i}`;
+    const email = `${username}@streamfi.dev`;
+    const wallet = randomWallet(100 + i);
+
+    const result = await sql`
+      INSERT INTO users (username, email, wallet, creator)
+      VALUES (
+        ${username},
+        ${email},
+        ${wallet},
+        ${JSON.stringify({ mock: true })}::jsonb
+      )
+      ON CONFLICT (username) DO NOTHING
+      RETURNING id
+    `;
+
+    if (result.rows.length > 0) {
+      created += 1;
+    }
+  }
+  return created;
+}
+
+async function seedLiveStream(): Promise<void> {
+  const creator = await ensureCreator();
+  await sql`
+    UPDATE users
+    SET
+      is_live = true,
+      current_viewers = 50,
+      stream_started_at = now() - interval '15 minutes'
+    WHERE id = ${creator.id}
+  `;
+}
+
+async function seedTips(creatorId: string): Promise<number> {
+  let created = 0;
+  for (let i = 0; i < 20; i += 1) {
+    const amount = Number((Math.random() * 5 + 0.2).toFixed(7));
+    const txHash = `mock-tip-${Date.now()}-${i}`;
+    await sql`
+      INSERT INTO mock_tip_transactions (creator_id, amount_xlm, tx_hash, mock)
+      VALUES (${creatorId}, ${amount}, ${txHash}, true)
+    `;
+    created += 1;
+  }
+  return created;
+}
+
+async function seedGifts(creatorId: string): Promise<number> {
+  const tiers = ["bronze", "silver", "gold", "silver", "gold"];
+  let created = 0;
+  for (let i = 0; i < tiers.length; i += 1) {
+    const txHash = `mock-gift-${Date.now()}-${i}`;
+    const amount = tiers[i] === "gold" ? 25 : tiers[i] === "silver" ? 10 : 3;
+    await sql`
+      INSERT INTO mock_gift_transactions (creator_id, tier, amount_usdc, tx_hash, mock)
+      VALUES (${creatorId}, ${tiers[i]}, ${amount}, ${txHash}, true)
+    `;
+    created += 1;
+  }
+  return created;
+}
+
+async function seedRecordings(creatorId: string): Promise<number> {
+  let created = 0;
+  for (let i = 0; i < 3; i += 1) {
+    const playbackId = `mock-playback-${Date.now()}-${i}`;
+    const assetId = `mock-asset-${Date.now()}-${i}`;
+    await sql`
+      INSERT INTO stream_recordings (
+        user_id,
+        mux_asset_id,
+        playback_id,
+        title,
+        duration,
+        status
+      )
+      VALUES (
+        ${creatorId},
+        ${assetId},
+        ${playbackId},
+        ${`Mock Recording ${i + 1}`},
+        ${1800 + i * 420},
+        'ready'
+      )
+      ON CONFLICT (mux_asset_id) DO NOTHING
+    `;
+    created += 1;
+  }
+  return created;
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ scenario: string }> }
+): Promise<Response> {
+  if (isMainnet()) {
+    return NextResponse.json(
+      { error: "Not available in production" },
+      { status: 403 }
+    );
+  }
+
+  const { scenario } = await params;
+  const creator = await ensureCreator();
+
+  const created = {
+    creators: 0,
+    viewers: 0,
+    tips: 0,
+    gifts: 0,
+    recordings: 0,
+  };
+
+  if (scenario === "creator" || scenario === "full") {
+    created.creators = 1;
+  }
+
+  if (scenario === "viewers" || scenario === "full") {
+    created.viewers = await seedViewers();
+  }
+
+  if (scenario === "live-stream" || scenario === "full") {
+    await seedLiveStream();
+  }
+
+  if (scenario === "tips" || scenario === "full") {
+    created.tips = await seedTips(creator.id);
+  }
+
+  if (scenario === "gifts" || scenario === "full") {
+    created.gifts = await seedGifts(creator.id);
+  }
+
+  if (scenario === "recordings" || scenario === "full") {
+    created.recordings = await seedRecordings(creator.id);
+  }
+
+  const known = new Set([
+    "creator",
+    "viewers",
+    "live-stream",
+    "tips",
+    "gifts",
+    "recordings",
+    "full",
+  ]);
+
+  if (!known.has(scenario)) {
+    return NextResponse.json({ error: "Unknown scenario" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    created,
+    credentials: {
+      creator: { username: "mock_testcreator", password: "test1234" },
+      viewer: { username: "mock_testviewer1", password: "test1234" },
+    },
+    stellar: {
+      network: "testnet",
+      funding: "simulated friendbot funding for mock environment",
+      tx_mode: "mock transaction hashes generated",
+    },
+  });
+}

--- a/app/api/routes-f/mock/route.ts
+++ b/app/api/routes-f/mock/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+const SCENARIOS = [
+  {
+    key: "creator",
+    description: "1 creator user with title, category, avatar",
+  },
+  {
+    key: "viewers",
+    description: "10 viewer accounts",
+  },
+  {
+    key: "live-stream",
+    description: "creator set live with 50 viewers",
+  },
+  {
+    key: "tips",
+    description: "20 random testnet tip transactions",
+  },
+  {
+    key: "gifts",
+    description: "5 USDC gift transactions",
+  },
+  {
+    key: "recordings",
+    description: "3 past recordings",
+  },
+  {
+    key: "full",
+    description: "all scenarios in one call",
+  },
+];
+
+function isMainnet(): boolean {
+  return process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet";
+}
+
+export async function GET(): Promise<Response> {
+  if (isMainnet()) {
+    return NextResponse.json(
+      { error: "Not available in production" },
+      { status: 403 }
+    );
+  }
+
+  return NextResponse.json({ scenarios: SCENARIOS });
+}
+
+export async function DELETE(_req: NextRequest): Promise<Response> {
+  if (isMainnet()) {
+    return NextResponse.json(
+      { error: "Not available in production" },
+      { status: 403 }
+    );
+  }
+
+  await sql`DELETE FROM mock_tip_transactions WHERE mock = true`;
+  await sql`DELETE FROM mock_gift_transactions WHERE mock = true`;
+  await sql`DELETE FROM stream_recordings WHERE title ILIKE 'Mock %'`;
+  await sql`DELETE FROM users WHERE creator->>'mock' = 'true' OR username LIKE 'mock_%'`;
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/routes-f/moderation/[id]/action/route.ts
+++ b/app/api/routes-f/moderation/[id]/action/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { writeNotification } from "@/lib/notifications";
+
+type ModerationAction =
+  | "warn"
+  | "remove_content"
+  | "suspend_user"
+  | "ban_user"
+  | "dismiss";
+
+const VALID_ACTIONS: ModerationAction[] = [
+  "warn",
+  "remove_content",
+  "suspend_user",
+  "ban_user",
+  "dismiss",
+];
+
+async function requireModOrAdmin(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return { ok: false as const, response: session.response };
+  }
+
+  const { rows } = await sql`
+    SELECT role FROM users WHERE id = ${session.userId} LIMIT 1
+  `;
+  const role = rows[0]?.role;
+  if (role !== "admin" && role !== "moderator") {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, session };
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const auth = await requireModOrAdmin(req);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { id } = await params;
+
+  let body: {
+    action?: ModerationAction;
+    notes?: string;
+    duration_hours?: number;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const action = body.action;
+  if (!action || !VALID_ACTIONS.includes(action)) {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  }
+
+  const { rows } = await sql`
+    SELECT * FROM moderation_queue WHERE id = ${id} LIMIT 1
+  `;
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const item = rows[0];
+  const reportedUserId: string | null = item.reported_user_id ?? null;
+
+  if (action === "warn" && reportedUserId) {
+    await writeNotification(
+      reportedUserId,
+      "live",
+      "Moderation warning",
+      "You have received a warning from StreamFi moderation."
+    );
+  }
+
+  if (action === "remove_content") {
+    if (item.item_type === "chat_message") {
+      await sql`
+        UPDATE chat_messages
+        SET is_deleted = true,
+            is_moderated = true,
+            moderated_by = ${auth.session.userId}
+        WHERE id = ${item.item_id}::int
+      `;
+    }
+
+    if (item.item_type === "emote") {
+      await sql`
+        DELETE FROM channel_emotes WHERE id = ${item.item_id}
+      `;
+    }
+  }
+
+  if (action === "suspend_user" && reportedUserId) {
+    const hours =
+      typeof body.duration_hours === "number" && body.duration_hours > 0
+        ? body.duration_hours
+        : 24;
+    await sql`
+      UPDATE users
+      SET suspended_until = now() + (${hours} * interval '1 hour')
+      WHERE id = ${reportedUserId}
+    `;
+  }
+
+  if (action === "ban_user" && reportedUserId) {
+    await sql`
+      UPDATE users
+      SET is_banned = true,
+          suspended_until = null
+      WHERE id = ${reportedUserId}
+    `;
+  }
+
+  await sql`
+    UPDATE moderation_queue
+    SET
+      status = ${action === "dismiss" ? "dismissed" : "actioned"},
+      assigned_to = ${auth.session.userId},
+      action_taken = ${action},
+      action_notes = ${body.notes ?? null},
+      actioned_at = now()
+    WHERE id = ${id}
+  `;
+
+  await sql`
+    INSERT INTO moderation_audit_log (
+      moderation_item_id,
+      moderator_id,
+      action,
+      notes
+    )
+    VALUES (
+      ${id},
+      ${auth.session.userId},
+      ${action},
+      ${body.notes ?? null}
+    )
+  `;
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/routes-f/moderation/[id]/route.ts
+++ b/app/api/routes-f/moderation/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+async function requireModOrAdmin(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return { ok: false as const, response: session.response };
+  }
+
+  const { rows } = await sql`
+    SELECT role FROM users WHERE id = ${session.userId} LIMIT 1
+  `;
+  const role = rows[0]?.role;
+  if (role !== "admin" && role !== "moderator") {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const };
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const auth = await requireModOrAdmin(req);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { id } = await params;
+  const { rows } = await sql`
+    SELECT *
+    FROM moderation_queue
+    WHERE id = ${id}
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ item: rows[0] });
+}

--- a/app/api/routes-f/moderation/route.ts
+++ b/app/api/routes-f/moderation/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+type ModItemType = "stream" | "chat_message" | "profile" | "clip" | "emote";
+
+const VALID_TYPES: ModItemType[] = [
+  "stream",
+  "chat_message",
+  "profile",
+  "clip",
+  "emote",
+];
+
+async function requireModOrAdmin(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return { ok: false as const, response: session.response };
+  }
+
+  const { rows } = await sql`
+    SELECT role FROM users WHERE id = ${session.userId} LIMIT 1
+  `;
+  const role = rows[0]?.role;
+  if (role !== "admin" && role !== "moderator") {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, session };
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const auth = await requireModOrAdmin(req);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const searchParams = new URL(req.url).searchParams;
+  const status = searchParams.get("status") ?? "pending";
+  const type = searchParams.get("type");
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1"));
+  const limit = Math.min(
+    100,
+    Math.max(1, Number(searchParams.get("limit") ?? "20"))
+  );
+  const offset = (page - 1) * limit;
+
+  const statusFilter = status === "all" ? null : status;
+  const typeFilter =
+    type && VALID_TYPES.includes(type as ModItemType) ? type : null;
+
+  const { rows } = await sql`
+    SELECT
+      id,
+      item_type,
+      item_id,
+      reporter_id,
+      reported_user_id,
+      reason,
+      details,
+      auto_flagged,
+      status,
+      report_count,
+      priority_score,
+      assigned_to,
+      action_taken,
+      action_notes,
+      created_at,
+      actioned_at
+    FROM moderation_queue
+    WHERE (${statusFilter}::text IS NULL OR status = ${statusFilter})
+      AND (${typeFilter}::text IS NULL OR item_type = ${typeFilter})
+    ORDER BY priority_score DESC, created_at ASC
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+
+  return NextResponse.json({ items: rows, page, limit });
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { rows: submitterRows } = await sql`
+    SELECT role FROM users WHERE id = ${session.userId} LIMIT 1
+  `;
+  const role = submitterRows[0]?.role;
+  if (role !== "admin" && role !== "moderator") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let body: {
+    item_type?: ModItemType;
+    item_id?: string;
+    reporter_id?: string;
+    reported_user_id?: string;
+    reason?: string;
+    details?: string;
+    auto_flagged?: boolean;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.item_type || !VALID_TYPES.includes(body.item_type)) {
+    return NextResponse.json({ error: "Invalid item_type" }, { status: 400 });
+  }
+  if (!body.item_id || !body.reason) {
+    return NextResponse.json(
+      { error: "item_id and reason are required" },
+      { status: 400 }
+    );
+  }
+
+  const { rows } = await sql`
+    INSERT INTO moderation_queue (
+      item_type,
+      item_id,
+      reporter_id,
+      reported_user_id,
+      reason,
+      details,
+      auto_flagged,
+      status,
+      report_count,
+      priority_score
+    )
+    VALUES (
+      ${body.item_type},
+      ${body.item_id},
+      ${body.reporter_id ?? null},
+      ${body.reported_user_id ?? null},
+      ${body.reason},
+      ${body.details ?? null},
+      ${body.auto_flagged ?? false},
+      'pending',
+      1,
+      1
+    )
+    ON CONFLICT (item_type, item_id)
+    WHERE status IN ('pending', 'under_review')
+    DO UPDATE SET
+      report_count = moderation_queue.report_count + 1,
+      auto_flagged = moderation_queue.auto_flagged OR EXCLUDED.auto_flagged,
+      details = COALESCE(EXCLUDED.details, moderation_queue.details),
+      reason = moderation_queue.reason,
+      priority_score = CASE
+        WHEN moderation_queue.report_count + 1 >= 5 THEN 100
+        ELSE moderation_queue.priority_score + 1
+      END
+    RETURNING *
+  `;
+
+  return NextResponse.json({ item: rows[0] }, { status: 201 });
+}

--- a/app/api/routes-f/tags/[tag]/route.ts
+++ b/app/api/routes-f/tags/[tag]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ tag: string }> }
+): Promise<Response> {
+  const { tag } = await params;
+  const normalized = tag.trim().toLowerCase();
+
+  const { rows } = await sql`
+    SELECT
+      u.id,
+      u.username,
+      u.avatar,
+      u.mux_playback_id,
+      u.current_viewers,
+      u.creator
+    FROM stream_tags st
+    JOIN tags t ON t.id = st.tag_id
+    JOIN users u ON u.id = st.stream_id
+    WHERE t.name = ${normalized}
+      AND u.is_live = true
+    ORDER BY u.current_viewers DESC, u.stream_started_at DESC
+    LIMIT 100
+  `;
+
+  return NextResponse.json({ tag: normalized, streams: rows });
+}

--- a/app/api/routes-f/tags/route.ts
+++ b/app/api/routes-f/tags/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+function normalizeTag(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+function isValidTagName(tag: string): boolean {
+  return /^[a-z0-9-]{1,30}$/.test(tag);
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const q = new URL(req.url).searchParams.get("q")?.trim().toLowerCase();
+  if (!q) {
+    return NextResponse.json({ error: "q is required" }, { status: 400 });
+  }
+
+  const { rows } = await sql`
+    SELECT name
+    FROM tags
+    WHERE name ILIKE ${q + "%"}
+    ORDER BY name ASC
+    LIMIT 10
+  `;
+
+  return NextResponse.json({ tags: rows.map(r => r.name) });
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  let body: { name?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const normalized = normalizeTag(body.name ?? "");
+  if (!normalized || !isValidTagName(normalized)) {
+    return NextResponse.json(
+      {
+        error:
+          "Tag must be lowercase alphanumeric/hyphen and at most 30 characters",
+      },
+      { status: 400 }
+    );
+  }
+
+  const { rows } = await sql`
+    INSERT INTO tag_suggestions (suggested_by, name, status)
+    VALUES (${session.userId}, ${normalized}, 'pending')
+    ON CONFLICT (suggested_by, name)
+    DO UPDATE SET created_at = now()
+    RETURNING id, name, status, created_at
+  `;
+
+  return NextResponse.json({ suggestion: rows[0] }, { status: 201 });
+}

--- a/app/api/routes-f/tags/trending/route.ts
+++ b/app/api/routes-f/tags/trending/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { Redis } from "@upstash/redis";
+
+const CACHE_KEY = "routes-f:tags:trending";
+const TTL_SECONDS = 60;
+
+const hasRedis =
+  !!process.env.UPSTASH_REDIS_REST_URL &&
+  !!process.env.UPSTASH_REDIS_REST_TOKEN;
+
+let redis: Redis | null = null;
+function getRedis(): Redis {
+  if (!redis) {
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL!,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+    });
+  }
+  return redis;
+}
+
+export async function GET(): Promise<Response> {
+  if (hasRedis) {
+    const cached =
+      await getRedis().get<Array<{ name: string; live_count: number }>>(
+        CACHE_KEY
+      );
+    if (cached) {
+      return NextResponse.json({ tags: cached, cached: true });
+    }
+  }
+
+  const { rows } = await sql`
+    SELECT t.name, COUNT(st.stream_id)::int as live_count
+    FROM stream_tags st
+    JOIN tags t ON t.id = st.tag_id
+    JOIN users u ON u.id = st.stream_id AND u.is_live = true
+    GROUP BY t.name
+    ORDER BY live_count DESC
+    LIMIT 20
+  `;
+
+  if (hasRedis) {
+    await getRedis().set(CACHE_KEY, rows, { ex: TTL_SECONDS });
+  }
+
+  return NextResponse.json({ tags: rows, cached: false });
+}

--- a/db/migrations/add-routes-f-platform-features.sql
+++ b/db/migrations/add-routes-f-platform-features.sql
@@ -1,0 +1,112 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS role TEXT DEFAULT 'user';
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ;
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS is_banned BOOLEAN DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS tags (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS stream_tags (
+  stream_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  tag_id INT REFERENCES tags(id) ON DELETE CASCADE,
+  applied_at TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (stream_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS tags_name_trgm ON tags USING gin(name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_stream_tags_tag_id ON stream_tags(tag_id);
+CREATE INDEX IF NOT EXISTS idx_stream_tags_stream_id ON stream_tags(stream_id);
+
+CREATE TABLE IF NOT EXISTS tag_suggestions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  suggested_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (suggested_by, name)
+);
+
+CREATE TABLE IF NOT EXISTS channel_emotes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  code TEXT NOT NULL,
+  image_url TEXT NOT NULL,
+  width INT DEFAULT 28,
+  height INT DEFAULT 28,
+  subscriber_only BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_emotes_creator_code_ci
+  ON channel_emotes (creator_id, LOWER(code));
+
+CREATE TABLE IF NOT EXISTS global_emotes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT NOT NULL UNIQUE,
+  image_url TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS moderation_queue (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  item_type TEXT NOT NULL CHECK (item_type IN ('stream', 'chat_message', 'profile', 'clip', 'emote')),
+  item_id TEXT NOT NULL,
+  reporter_id UUID REFERENCES users(id),
+  reported_user_id UUID REFERENCES users(id),
+  reason TEXT NOT NULL,
+  details TEXT,
+  auto_flagged BOOLEAN DEFAULT false,
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'under_review', 'actioned', 'dismissed')),
+  report_count INT DEFAULT 1,
+  priority_score INT DEFAULT 1,
+  assigned_to UUID REFERENCES users(id),
+  action_taken TEXT CHECK (action_taken IN ('warn', 'remove_content', 'suspend_user', 'ban_user', 'dismiss')),
+  action_notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  actioned_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS mod_queue_status ON moderation_queue(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS mod_queue_priority ON moderation_queue(priority_score DESC, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS mod_queue_item_pending_unique
+  ON moderation_queue(item_type, item_id)
+  WHERE status IN ('pending', 'under_review');
+
+CREATE TABLE IF NOT EXISTS moderation_audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  moderation_item_id UUID NOT NULL REFERENCES moderation_queue(id) ON DELETE CASCADE,
+  moderator_id UUID REFERENCES users(id),
+  action TEXT NOT NULL,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS mock_tip_transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  viewer_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  amount_xlm NUMERIC(20,7) NOT NULL,
+  tx_hash TEXT,
+  mock BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS mock_gift_transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  viewer_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  tier TEXT NOT NULL,
+  amount_usdc NUMERIC(20,7) NOT NULL,
+  tx_hash TEXT,
+  mock BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add new `routes-f` API surface for stream tags (`trending`, lookup by tag, autocomplete, and moderated suggestions) with Redis-backed trending cache and tag normalization
- add custom channel emotes endpoints (list/upload/rename/delete) with file and code validation, creator-only mutations, and free-tier caps
- add moderation queue endpoints with role-gated access, report escalation (5+ reports), moderation actions with side effects, and audit logging
- add dev-only mock data APIs for scenario seeding and cleanup, plus supporting schema migration for tags, emotes, moderation, and mock transaction tables

## Linked Issues
Closes #415
Closes #409
Closes #425
Closes #416