### PR TITLE
feat(routes-f): add search, watchlist, and follows management APIs

### DIFF
--- a/app/api/routes-f/follows/[creatorId]/route.ts
+++ b/app/api/routes-f/follows/[creatorId]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ creatorId: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { creatorId } = await params;
+
+  if (creatorId === session.userId) {
+    return NextResponse.json(
+      { error: "Cannot unfollow yourself" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { rowCount } = await sql`
+      DELETE FROM user_follows
+      WHERE follower_id = ${session.userId}
+        AND followee_id = ${creatorId}
+    `;
+
+    if ((rowCount ?? 0) === 0) {
+      return NextResponse.json(
+        { error: "Follow relationship not found" },
+        { status: 404 }
+      );
+    }
+
+    const { rows } = await sql`
+      SELECT COUNT(*)::int AS follower_count
+      FROM user_follows
+      WHERE followee_id = ${creatorId}
+    `;
+
+    return NextResponse.json({
+      creator_id: creatorId,
+      follower_count: rows[0]?.follower_count ?? 0,
+      is_following: false,
+    });
+  } catch (err) {
+    console.error("[follows/:creatorId] DELETE error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/follows/followers/route.ts
+++ b/app/api/routes-f/follows/followers/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+});
+
+async function isFollowing(
+  followerId: string,
+  followeeId: string
+): Promise<boolean> {
+  const { rows } = await sql`
+    SELECT 1
+    FROM user_follows
+    WHERE follower_id = ${followerId}
+      AND followee_id = ${followeeId}
+    LIMIT 1
+  `;
+  return rows.length > 0;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { rows: creatorRows } = await sql`
+    SELECT id FROM users WHERE id = ${session.userId} LIMIT 1
+  `;
+  if (creatorRows.length === 0) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, listQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { limit, cursor } = queryResult.data;
+
+  try {
+    const { rows } = cursor
+      ? await sql`
+          SELECT u.id, u.username, u.avatar, u.bio, uf.created_at
+          FROM user_follows uf
+          JOIN users u ON u.id = uf.follower_id
+          WHERE uf.followee_id = ${session.userId}
+            AND uf.created_at < (
+              SELECT created_at
+              FROM user_follows
+              WHERE followee_id = ${session.userId}
+                AND follower_id = ${cursor}
+              LIMIT 1
+            )
+          ORDER BY uf.created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT u.id, u.username, u.avatar, u.bio, uf.created_at
+          FROM user_follows uf
+          JOIN users u ON u.id = uf.follower_id
+          WHERE uf.followee_id = ${session.userId}
+          ORDER BY uf.created_at DESC
+          LIMIT ${limit}
+        `;
+
+    const followers = await Promise.all(
+      rows.map(async row => ({
+        follower: {
+          id: row.id,
+          username: row.username,
+          avatar: row.avatar,
+          bio: row.bio,
+          is_following: await isFollowing(session.userId, row.id as string),
+        },
+        followed_at: row.created_at,
+      }))
+    );
+
+    const nextCursor =
+      rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+    return NextResponse.json({ followers, next_cursor: nextCursor });
+  } catch (err) {
+    console.error("[follows/followers] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/follows/route.ts
+++ b/app/api/routes-f/follows/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const createFollowSchema = z.object({
+  creator_id: z.string().uuid(),
+});
+
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+});
+
+type FollowerCountRow = { follower_count: number };
+
+async function getFollowerCount(userId: string): Promise<number> {
+  const { rows } = await sql<FollowerCountRow>`
+    SELECT COUNT(*)::int AS follower_count
+    FROM user_follows
+    WHERE followee_id = ${userId}
+  `;
+  return rows[0]?.follower_count ?? 0;
+}
+
+async function getIsFollowing(
+  followerId: string,
+  followeeId: string
+): Promise<boolean> {
+  const { rows } = await sql`
+    SELECT 1
+    FROM user_follows
+    WHERE follower_id = ${followerId}
+      AND followee_id = ${followeeId}
+    LIMIT 1
+  `;
+  return rows.length > 0;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, listQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { limit, cursor } = queryResult.data;
+
+  try {
+    const { rows } = cursor
+      ? await sql`
+          SELECT u.id, u.username, u.avatar, u.bio, uf.created_at
+          FROM user_follows uf
+          JOIN users u ON u.id = uf.followee_id
+          WHERE uf.follower_id = ${session.userId}
+            AND uf.created_at < (
+              SELECT created_at
+              FROM user_follows
+              WHERE follower_id = ${session.userId}
+                AND followee_id = ${cursor}
+              LIMIT 1
+            )
+          ORDER BY uf.created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT u.id, u.username, u.avatar, u.bio, uf.created_at
+          FROM user_follows uf
+          JOIN users u ON u.id = uf.followee_id
+          WHERE uf.follower_id = ${session.userId}
+          ORDER BY uf.created_at DESC
+          LIMIT ${limit}
+        `;
+
+    const enriched = await Promise.all(
+      rows.map(async row => {
+        const followerCount = await getFollowerCount(row.id as string);
+        return {
+          creator: {
+            id: row.id,
+            username: row.username,
+            avatar: row.avatar,
+            bio: row.bio,
+            follower_count: followerCount,
+            is_following: true,
+          },
+          followed_at: row.created_at,
+        };
+      })
+    );
+
+    const nextCursor =
+      rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+    return NextResponse.json({ follows: enriched, next_cursor: nextCursor });
+  } catch (err) {
+    console.error("[follows] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createFollowSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { creator_id } = bodyResult.data;
+
+  if (creator_id === session.userId) {
+    return NextResponse.json(
+      { error: "Cannot follow yourself" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { rows: creatorRows } = await sql`
+      SELECT id, username, avatar, bio
+      FROM users
+      WHERE id = ${creator_id}
+      LIMIT 1
+    `;
+
+    if (creatorRows.length === 0) {
+      return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+    }
+
+    const insertResult = await sql`
+      INSERT INTO user_follows (follower_id, followee_id)
+      VALUES (${session.userId}, ${creator_id})
+      ON CONFLICT DO NOTHING
+      RETURNING follower_id
+    `;
+
+    if ((insertResult.rowCount ?? 0) === 0) {
+      return NextResponse.json(
+        { error: "Already following creator" },
+        { status: 409 }
+      );
+    }
+
+    const followerCount = await getFollowerCount(creator_id);
+    const isFollowing = await getIsFollowing(session.userId, creator_id);
+
+    const creator = creatorRows[0];
+    return NextResponse.json(
+      {
+        creator: {
+          id: creator.id,
+          username: creator.username,
+          avatar: creator.avatar,
+          bio: creator.bio,
+          follower_count: followerCount,
+          is_following: isFollowing,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error("[follows] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/search/route.ts
+++ b/app/api/routes-f/search/route.ts
@@ -1,0 +1,280 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const searchTypeSchema = z.enum([
+  "all",
+  "users",
+  "streams",
+  "clips",
+  "categories",
+]);
+
+const searchQuerySchema = z.object({
+  q: z.string().trim().min(2).max(100),
+  type: searchTypeSchema.default("all"),
+  limit: z.coerce.number().int().min(1).max(20).default(20),
+  cursor: z.string().optional(),
+});
+
+type SearchType = z.infer<typeof searchTypeSchema>;
+
+function parseCursor(raw: string | undefined): Record<string, string> {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    if (typeof parsed !== "object" || parsed === null) {
+      return {};
+    }
+
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") {
+        out[key] = value;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function encodeCursor(value: Record<string, string | null>): string | null {
+  const normalized = Object.fromEntries(
+    Object.entries(value).filter(
+      ([, v]) => typeof v === "string" && v.length > 0
+    )
+  );
+
+  if (Object.keys(normalized).length === 0) {
+    return null;
+  }
+
+  return Buffer.from(JSON.stringify(normalized), "utf8").toString("base64url");
+}
+
+async function searchUsers(q: string, limit: number, cursor?: string) {
+  const term = `%${q}%`;
+  const { rows } = cursor
+    ? await sql`
+        SELECT id, username, avatar, bio
+        FROM users
+        WHERE id > ${cursor}
+          AND (username ILIKE ${term} OR COALESCE(bio, '') ILIKE ${term})
+        ORDER BY id ASC
+        LIMIT ${limit}
+      `
+    : await sql`
+        SELECT id, username, avatar, bio
+        FROM users
+        WHERE username ILIKE ${term} OR COALESCE(bio, '') ILIKE ${term}
+        ORDER BY id ASC
+        LIMIT ${limit}
+      `;
+
+  const items = rows.map(row => ({
+    type: "users" as const,
+    id: row.id,
+    username: row.username,
+    avatar: row.avatar,
+    bio: row.bio,
+  }));
+
+  const nextCursor =
+    rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+  return { items, nextCursor };
+}
+
+async function searchStreams(q: string, limit: number, cursor?: string) {
+  const term = `%${q}%`;
+  const { rows } = cursor
+    ? await sql`
+        SELECT id, username, avatar, is_live, mux_playback_id, creator
+        FROM users
+        WHERE id > ${cursor}
+          AND (
+            username ILIKE ${term}
+            OR COALESCE(creator->>'streamTitle', '') ILIKE ${term}
+            OR COALESCE(creator->>'title', '') ILIKE ${term}
+          )
+        ORDER BY id ASC
+        LIMIT ${limit}
+      `
+    : await sql`
+        SELECT id, username, avatar, is_live, mux_playback_id, creator
+        FROM users
+        WHERE username ILIKE ${term}
+          OR COALESCE(creator->>'streamTitle', '') ILIKE ${term}
+          OR COALESCE(creator->>'title', '') ILIKE ${term}
+        ORDER BY id ASC
+        LIMIT ${limit}
+      `;
+
+  const items = rows.map(row => ({
+    type: "streams" as const,
+    id: row.id,
+    username: row.username,
+    avatar: row.avatar,
+    is_live: row.is_live,
+    playback_id: row.mux_playback_id,
+    stream_title:
+      (row.creator as { streamTitle?: string; title?: string } | null)
+        ?.streamTitle ??
+      (row.creator as { streamTitle?: string; title?: string } | null)?.title ??
+      null,
+  }));
+
+  const nextCursor =
+    rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+  return { items, nextCursor };
+}
+
+async function searchCategories(q: string, limit: number, cursor?: string) {
+  const term = `%${q}%`;
+  const { rows } = cursor
+    ? await sql`
+        SELECT DISTINCT category
+        FROM (
+          SELECT COALESCE(creator->>'category', '') AS category
+          FROM users
+        ) c
+        WHERE category <> ''
+          AND category ILIKE ${term}
+          AND category > ${cursor}
+        ORDER BY category ASC
+        LIMIT ${limit}
+      `
+    : await sql`
+        SELECT DISTINCT category
+        FROM (
+          SELECT COALESCE(creator->>'category', '') AS category
+          FROM users
+        ) c
+        WHERE category <> ''
+          AND category ILIKE ${term}
+        ORDER BY category ASC
+        LIMIT ${limit}
+      `;
+
+  const items = rows.map(row => ({
+    type: "categories" as const,
+    id: row.category,
+    name: row.category,
+  }));
+
+  const nextCursor =
+    rows.length === limit ? (rows[rows.length - 1].category as string) : null;
+  return { items, nextCursor };
+}
+
+async function searchRecordingsAsClips(
+  q: string,
+  limit: number,
+  cursor?: string
+) {
+  const term = `%${q}%`;
+  const { rows } = cursor
+    ? await sql`
+        SELECT r.id, r.title, r.playback_id, r.created_at, u.username
+        FROM stream_recordings r
+        JOIN users u ON u.id = r.user_id
+        WHERE r.id > ${cursor}
+          AND r.status = 'ready'
+          AND (
+            COALESCE(r.title, '') ILIKE ${term}
+            OR u.username ILIKE ${term}
+          )
+        ORDER BY r.id ASC
+        LIMIT ${limit}
+      `
+    : await sql`
+        SELECT r.id, r.title, r.playback_id, r.created_at, u.username
+        FROM stream_recordings r
+        JOIN users u ON u.id = r.user_id
+        WHERE r.status = 'ready'
+          AND (
+            COALESCE(r.title, '') ILIKE ${term}
+            OR u.username ILIKE ${term}
+          )
+        ORDER BY r.id ASC
+        LIMIT ${limit}
+      `;
+
+  const items = rows.map(row => ({
+    type: "clips" as const,
+    id: row.id,
+    title: row.title,
+    playback_id: row.playback_id,
+    creator_username: row.username,
+    created_at: row.created_at,
+  }));
+
+  const nextCursor =
+    rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+  return { items, nextCursor };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, searchQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { q, type, limit, cursor } = queryResult.data;
+  const cursorMap = parseCursor(cursor);
+
+  try {
+    if (type !== "all") {
+      const byType: Record<
+        Exclude<SearchType, "all">,
+        () => Promise<{ items: unknown[]; nextCursor: string | null }>
+      > = {
+        users: () => searchUsers(q, limit, cursorMap.users),
+        streams: () => searchStreams(q, limit, cursorMap.streams),
+        clips: () => searchRecordingsAsClips(q, limit, cursorMap.clips),
+        categories: () => searchCategories(q, limit, cursorMap.categories),
+      };
+
+      const result = await byType[type]();
+      return NextResponse.json({
+        type,
+        items: result.items,
+        next_cursor: encodeCursor({ [type]: result.nextCursor }),
+      });
+    }
+
+    const [users, streams, clips, categories] = await Promise.all([
+      searchUsers(q, limit, cursorMap.users),
+      searchStreams(q, limit, cursorMap.streams),
+      searchRecordingsAsClips(q, limit, cursorMap.clips),
+      searchCategories(q, limit, cursorMap.categories),
+    ]);
+
+    return NextResponse.json({
+      type: "all",
+      results: {
+        users: users.items,
+        streams: streams.items,
+        clips: clips.items,
+        categories: categories.items,
+      },
+      next_cursor: encodeCursor({
+        users: users.nextCursor,
+        streams: streams.nextCursor,
+        clips: clips.nextCursor,
+        categories: categories.nextCursor,
+      }),
+    });
+  } catch (err) {
+    console.error("[search] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/watchlist/[id]/route.ts
+++ b/app/api/routes-f/watchlist/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const { rowCount } = await sql`
+      DELETE FROM user_watchlist
+      WHERE id = ${id}
+        AND user_id = ${session.userId}
+    `;
+
+    if ((rowCount ?? 0) === 0) {
+      return NextResponse.json(
+        { error: "Watchlist item not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ message: "Removed from watchlist" });
+  } catch (err) {
+    console.error("[watchlist/:id] DELETE error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/watchlist/route.ts
+++ b/app/api/routes-f/watchlist/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const itemTypeSchema = z.enum(["stream", "recording", "clip"]);
+
+const createWatchlistSchema = z.object({
+  item_id: z.string().min(1),
+  item_type: itemTypeSchema,
+});
+
+const listSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+});
+
+async function ensureWatchlistTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS user_watchlist (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      item_id TEXT NOT NULL,
+      item_type TEXT NOT NULL CHECK (item_type IN ('stream', 'recording', 'clip')),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (user_id, item_id, item_type)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_user_watchlist_user_created
+    ON user_watchlist (user_id, created_at DESC)
+  `;
+}
+
+async function itemExists(
+  itemId: string,
+  itemType: "stream" | "recording" | "clip"
+) {
+  if (itemType === "stream") {
+    const { rows } = await sql`
+      SELECT id FROM users WHERE id = ${itemId} LIMIT 1
+    `;
+    return rows.length > 0;
+  }
+
+  const { rows } = await sql`
+    SELECT id
+    FROM stream_recordings
+    WHERE id = ${itemId}
+      AND status = 'ready'
+    LIMIT 1
+  `;
+  return rows.length > 0;
+}
+
+async function enforceWatchlistLimit(userId: string) {
+  const { rows } = await sql`
+    SELECT COUNT(*)::int AS total
+    FROM user_watchlist
+    WHERE user_id = ${userId}
+  `;
+
+  const total = Number(rows[0]?.total ?? 0);
+  return total < 200;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, listSchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { limit, cursor } = queryResult.data;
+
+  try {
+    await ensureWatchlistTable();
+
+    const { rows } = cursor
+      ? await sql`
+          SELECT id, item_id, item_type, created_at
+          FROM user_watchlist
+          WHERE user_id = ${session.userId}
+            AND created_at < (SELECT created_at FROM user_watchlist WHERE id = ${cursor} LIMIT 1)
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT id, item_id, item_type, created_at
+          FROM user_watchlist
+          WHERE user_id = ${session.userId}
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `;
+
+    const itemChecks = await Promise.all(
+      rows.map(async row => ({
+        ...row,
+        exists: await itemExists(
+          row.item_id as string,
+          row.item_type as "stream" | "recording" | "clip"
+        ),
+      }))
+    );
+
+    const staleItems = itemChecks.filter(item => !item.exists);
+    if (staleItems.length > 0) {
+      const staleIds = staleItems.map(item => item.id as string);
+      await sql`DELETE FROM user_watchlist WHERE id = ANY(${staleIds}::uuid[])`;
+    }
+
+    const validItems = itemChecks
+      .filter(item => item.exists)
+      .map(item => ({
+        id: item.id,
+        item_id: item.item_id,
+        item_type: item.item_type,
+        created_at: item.created_at,
+      }));
+
+    const nextCursor =
+      validItems.length === limit
+        ? (validItems[validItems.length - 1].id as string)
+        : null;
+
+    return NextResponse.json({
+      watchlist: validItems,
+      next_cursor: nextCursor,
+    });
+  } catch (err) {
+    console.error("[watchlist] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createWatchlistSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { item_id, item_type } = bodyResult.data;
+
+  try {
+    await ensureWatchlistTable();
+
+    if (!(await enforceWatchlistLimit(session.userId))) {
+      return NextResponse.json(
+        { error: "Watchlist limit reached (max 200 items)" },
+        { status: 400 }
+      );
+    }
+
+    if (!(await itemExists(item_id, item_type))) {
+      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
+
+    const { rows } = await sql`
+      INSERT INTO user_watchlist (user_id, item_id, item_type)
+      VALUES (${session.userId}, ${item_id}, ${item_type})
+      ON CONFLICT (user_id, item_id, item_type) DO NOTHING
+      RETURNING id, item_id, item_type, created_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Item already in watchlist" },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (err) {
+    console.error("[watchlist] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `GET /api/routes-f/search` with grouped `type=all` search and per-type cursor pagination for users, streams, clips, and categories
- add watchlist APIs: `GET/POST /api/routes-f/watchlist` and `DELETE /api/routes-f/watchlist/[id]` with 200-item limit, duplicate protection, and stale item cleanup
- add follows APIs: `GET/POST /api/routes-f/follows`, `GET /api/routes-f/follows/followers`, and `DELETE /api/routes-f/follows/[creatorId]` with self-follow safeguards and enriched creator/follower response state

Closes #447
Closes #448
Closes #449