### PR TITLE
feat(routes-f): add queue, highlights, cache, and geo endpoints

### DIFF
--- a/app/api/routes-f/cache/purge/route.ts
+++ b/app/api/routes-f/cache/purge/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const purgeSchema = z
+  .object({
+    tag: z.string().min(1).max(200).optional(),
+    key: z.string().min(1).max(500).optional(),
+    prefix: z.string().min(1).max(500).optional(),
+  })
+  .refine(
+    body => Boolean(body.tag || body.key || body.prefix),
+    "At least one of tag, key, or prefix is required"
+  );
+
+async function verifyAdminSession(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return { ok: false as const, response: session.response };
+  }
+
+  const { rows } = await sql`
+    SELECT 1
+    FROM users
+    WHERE id = ${session.userId}
+      AND (
+        is_admin = TRUE
+        OR role = 'admin'
+      )
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, session };
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const auth = await verifyAdminSession(req);
+    if (!auth.ok) {
+      return auth.response;
+    }
+
+    const bodyResult = await validateBody(req, purgeSchema);
+    if (bodyResult instanceof Response) {
+      return bodyResult;
+    }
+
+    const invalidatedTags: string[] = [];
+    const invalidatedPaths: string[] = [];
+
+    if (bodyResult.data.tag) {
+      revalidateTag(bodyResult.data.tag);
+      invalidatedTags.push(bodyResult.data.tag);
+    }
+
+    if (bodyResult.data.key) {
+      const path = bodyResult.data.key.startsWith("/")
+        ? bodyResult.data.key
+        : `/${bodyResult.data.key}`;
+      revalidatePath(path);
+      invalidatedPaths.push(path);
+    }
+
+    if (bodyResult.data.prefix) {
+      const normalized = bodyResult.data.prefix.startsWith("/")
+        ? bodyResult.data.prefix
+        : `/${bodyResult.data.prefix}`;
+      revalidatePath(normalized, "layout");
+      invalidatedPaths.push(`${normalized}*`);
+    }
+
+    return NextResponse.json({
+      invalidated: {
+        tags: invalidatedTags,
+        paths: invalidatedPaths,
+      },
+    });
+  } catch (err) {
+    console.error("[cache/purge] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/cache/stats/route.ts
+++ b/app/api/routes-f/cache/stats/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+async function verifyAdminSession(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return { ok: false as const, response: session.response };
+  }
+
+  const { rows } = await sql`
+    SELECT 1
+    FROM users
+    WHERE id = ${session.userId}
+      AND (
+        is_admin = TRUE
+        OR role = 'admin'
+      )
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, session };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = await verifyAdminSession(req);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  return NextResponse.json({
+    namespaces: [
+      { namespace: "streams", hit_ratio: null, entries: null },
+      { namespace: "users", hit_ratio: null, entries: null },
+      { namespace: "search", hit_ratio: null, entries: null },
+    ],
+    note: "Runtime cache stats are not directly available in Next.js route handlers",
+  });
+}

--- a/app/api/routes-f/clips/highlights/[id]/route.ts
+++ b/app/api/routes-f/clips/highlights/[id]/route.ts
@@ -1,0 +1,215 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const updateHighlightSchema = z
+  .object({
+    title: z.string().min(1).max(160).optional(),
+    clip_ids: z.array(z.string().uuid()).min(1).max(20).optional(),
+    cover_clip_id: z.string().uuid().optional(),
+  })
+  .refine(
+    body =>
+      body.title !== undefined ||
+      body.clip_ids !== undefined ||
+      body.cover_clip_id !== undefined,
+    "At least one field is required"
+  )
+  .refine(
+    body =>
+      body.cover_clip_id === undefined ||
+      body.clip_ids === undefined ||
+      body.clip_ids.includes(body.cover_clip_id),
+    {
+      message:
+        "cover_clip_id must be included in clip_ids when clip_ids is provided",
+      path: ["cover_clip_id"],
+    }
+  );
+
+async function ensureHighlightsTables() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS clip_highlight_collections (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      cover_clip_id UUID NOT NULL,
+      is_public BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS clip_highlight_items (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      collection_id UUID NOT NULL REFERENCES clip_highlight_collections(id) ON DELETE CASCADE,
+      clip_id UUID NOT NULL,
+      position INTEGER NOT NULL CHECK (position >= 0),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (collection_id, clip_id),
+      UNIQUE (collection_id, position)
+    )
+  `;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+  const bodyResult = await validateBody(req, updateHighlightSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensureHighlightsTables();
+
+    const { rows: collectionRows } = await sql`
+      SELECT id, title, cover_clip_id
+      FROM clip_highlight_collections
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (collectionRows.length === 0) {
+      return NextResponse.json(
+        { error: "Highlight collection not found" },
+        { status: 404 }
+      );
+    }
+
+    const current = collectionRows[0];
+
+    await sql`BEGIN`;
+    try {
+      let nextCover =
+        bodyResult.data.cover_clip_id ?? (current.cover_clip_id as string);
+
+      if (bodyResult.data.clip_ids) {
+        if (!bodyResult.data.clip_ids.includes(nextCover)) {
+          throw new Error("cover_clip_not_in_clip_ids");
+        }
+
+        await sql`
+          DELETE FROM clip_highlight_items
+          WHERE collection_id = ${id}
+        `;
+
+        for (let i = 0; i < bodyResult.data.clip_ids.length; i += 1) {
+          await sql`
+            INSERT INTO clip_highlight_items (collection_id, clip_id, position)
+            VALUES (${id}, ${bodyResult.data.clip_ids[i]}, ${i})
+          `;
+        }
+      }
+
+      if (bodyResult.data.cover_clip_id && !bodyResult.data.clip_ids) {
+        const { rows: exists } = await sql`
+          SELECT 1
+          FROM clip_highlight_items
+          WHERE collection_id = ${id}
+            AND clip_id = ${bodyResult.data.cover_clip_id}
+          LIMIT 1
+        `;
+        if (exists.length === 0) {
+          throw new Error("cover_clip_not_in_clip_ids");
+        }
+        nextCover = bodyResult.data.cover_clip_id;
+      }
+
+      const { rows: updatedRows } = await sql`
+        UPDATE clip_highlight_collections
+        SET
+          title = ${bodyResult.data.title ?? (current.title as string)},
+          cover_clip_id = ${nextCover},
+          updated_at = NOW()
+        WHERE id = ${id}
+          AND creator_id = ${session.userId}
+        RETURNING id, title, cover_clip_id, created_at, updated_at
+      `;
+
+      const { rows: itemRows } = await sql`
+        SELECT clip_id, position
+        FROM clip_highlight_items
+        WHERE collection_id = ${id}
+        ORDER BY position ASC
+      `;
+
+      await sql`COMMIT`;
+
+      return NextResponse.json({
+        id: updatedRows[0].id,
+        title: updatedRows[0].title,
+        cover_clip_id: updatedRows[0].cover_clip_id,
+        clips: itemRows.map(row => ({
+          clip_id: row.clip_id,
+          position: Number(row.position),
+        })),
+        created_at: updatedRows[0].created_at,
+        updated_at: updatedRows[0].updated_at,
+      });
+    } catch (txErr) {
+      await sql`ROLLBACK`;
+      throw txErr;
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message === "cover_clip_not_in_clip_ids") {
+      return NextResponse.json(
+        { error: "cover_clip_id must be included in clip_ids" },
+        { status: 400 }
+      );
+    }
+    console.error("[clips/highlights/:id] PATCH error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    await ensureHighlightsTables();
+
+    const { rowCount } = await sql`
+      DELETE FROM clip_highlight_collections
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+    `;
+
+    if ((rowCount ?? 0) === 0) {
+      return NextResponse.json(
+        { error: "Highlight collection not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ message: "Highlight collection removed" });
+  } catch (err) {
+    console.error("[clips/highlights/:id] DELETE error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/clips/highlights/route.ts
+++ b/app/api/routes-f/clips/highlights/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const listHighlightsSchema = z.object({
+  creator: z.string().uuid("creator must be a valid UUID"),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  cursor: z.string().uuid().optional(),
+});
+
+const createHighlightsSchema = z
+  .object({
+    title: z.string().min(1).max(160),
+    clip_ids: z.array(z.string().uuid()).min(1).max(20),
+    cover_clip_id: z.string().uuid(),
+  })
+  .refine(body => body.clip_ids.includes(body.cover_clip_id), {
+    message: "cover_clip_id must be included in clip_ids",
+    path: ["cover_clip_id"],
+  });
+
+async function ensureHighlightsTables() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS clip_highlight_collections (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      cover_clip_id UUID NOT NULL,
+      is_public BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS clip_highlight_items (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      collection_id UUID NOT NULL REFERENCES clip_highlight_collections(id) ON DELETE CASCADE,
+      clip_id UUID NOT NULL,
+      position INTEGER NOT NULL CHECK (position >= 0),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (collection_id, clip_id),
+      UNIQUE (collection_id, position)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_clip_highlight_creator_created
+    ON clip_highlight_collections (creator_id, created_at DESC)
+  `;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    listHighlightsSchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { creator, limit, cursor } = queryResult.data;
+
+  try {
+    await ensureHighlightsTables();
+
+    const { rows: collections } = cursor
+      ? await sql`
+          SELECT id, title, cover_clip_id, created_at, updated_at
+          FROM clip_highlight_collections
+          WHERE creator_id = ${creator}
+            AND is_public = TRUE
+            AND created_at < (
+              SELECT created_at
+              FROM clip_highlight_collections
+              WHERE id = ${cursor}
+              LIMIT 1
+            )
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT id, title, cover_clip_id, created_at, updated_at
+          FROM clip_highlight_collections
+          WHERE creator_id = ${creator}
+            AND is_public = TRUE
+          ORDER BY created_at DESC
+          LIMIT ${limit}
+        `;
+
+    if (collections.length === 0) {
+      return NextResponse.json({ collections: [], next_cursor: null });
+    }
+
+    const ids = collections.map(row => row.id as string);
+    const { rows: items } = await sql`
+      SELECT collection_id, clip_id, position
+      FROM clip_highlight_items
+      WHERE collection_id = ANY(${ids}::uuid[])
+      ORDER BY collection_id ASC, position ASC
+    `;
+
+    const grouped = new Map<
+      string,
+      Array<{ clip_id: string; position: number }>
+    >();
+    for (const item of items) {
+      const collectionId = item.collection_id as string;
+      if (!grouped.has(collectionId)) {
+        grouped.set(collectionId, []);
+      }
+      grouped.get(collectionId)?.push({
+        clip_id: item.clip_id as string,
+        position: Number(item.position),
+      });
+    }
+
+    const payload = collections.map(row => ({
+      id: row.id,
+      title: row.title,
+      cover_clip_id: row.cover_clip_id,
+      clips: grouped.get(row.id as string) ?? [],
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    }));
+
+    const nextCursor =
+      payload.length === limit
+        ? (payload[payload.length - 1].id as string)
+        : null;
+
+    return NextResponse.json({ collections: payload, next_cursor: nextCursor });
+  } catch (err) {
+    console.error("[clips/highlights] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createHighlightsSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { title, clip_ids, cover_clip_id } = bodyResult.data;
+
+  try {
+    await ensureHighlightsTables();
+
+    await sql`BEGIN`;
+    try {
+      const { rows: collectionRows } = await sql`
+        INSERT INTO clip_highlight_collections (creator_id, title, cover_clip_id)
+        VALUES (${session.userId}, ${title}, ${cover_clip_id})
+        RETURNING id, title, cover_clip_id, created_at, updated_at
+      `;
+
+      const collection = collectionRows[0];
+      for (let i = 0; i < clip_ids.length; i += 1) {
+        await sql`
+          INSERT INTO clip_highlight_items (collection_id, clip_id, position)
+          VALUES (${collection.id}, ${clip_ids[i]}, ${i})
+        `;
+      }
+
+      await sql`COMMIT`;
+
+      return NextResponse.json(
+        {
+          id: collection.id,
+          title: collection.title,
+          cover_clip_id: collection.cover_clip_id,
+          clips: clip_ids.map((clipId, idx) => ({
+            clip_id: clipId,
+            position: idx,
+          })),
+          created_at: collection.created_at,
+          updated_at: collection.updated_at,
+        },
+        { status: 201 }
+      );
+    } catch (txErr) {
+      await sql`ROLLBACK`;
+      throw txErr;
+    }
+  } catch (err) {
+    console.error("[clips/highlights] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/geo/route.ts
+++ b/app/api/routes-f/geo/route.ts
@@ -1,0 +1,227 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const countryCodeSchema = z
+  .string()
+  .regex(/^[A-Z]{2}$/, "Country codes must be ISO 3166-1 alpha-2")
+  .transform(v => v.toUpperCase());
+
+const updateGeoSchema = z.object({
+  allowed_countries: z.array(countryCodeSchema).max(250).optional(),
+  blocked_countries: z.array(countryCodeSchema).max(250).optional(),
+});
+
+const checkQuerySchema = z.object({
+  creator: z.string().uuid("creator must be a valid UUID"),
+});
+
+async function ensureGeoTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS creator_geo_restrictions (
+      creator_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      allowed_countries TEXT[] NOT NULL DEFAULT '{}',
+      blocked_countries TEXT[] NOT NULL DEFAULT '{}',
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+function normalizeCodes(codes?: string[]) {
+  if (!codes) {
+    return undefined;
+  }
+  return [...new Set(codes.map(code => code.toUpperCase()))];
+}
+
+function requestCountry(req: NextRequest): string | null {
+  const candidate =
+    req.headers.get("CF-IPCountry") ?? req.headers.get("X-Vercel-IP-Country");
+
+  if (!candidate) {
+    return null;
+  }
+
+  const upper = candidate.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) {
+    return null;
+  }
+
+  return upper;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  if (url.searchParams.has("creator")) {
+    const queryResult = validateQuery(url.searchParams, checkQuerySchema);
+    if (queryResult instanceof Response) {
+      return queryResult;
+    }
+
+    try {
+      await ensureGeoTable();
+      const viewerCountry = requestCountry(req);
+      const { creator } = queryResult.data;
+
+      const { rows } = await sql`
+        SELECT allowed_countries, blocked_countries
+        FROM creator_geo_restrictions
+        WHERE creator_id = ${creator}
+        LIMIT 1
+      `;
+
+      const allowed =
+        (rows[0]?.allowed_countries as string[] | undefined) ?? [];
+      const blocked =
+        (rows[0]?.blocked_countries as string[] | undefined) ?? [];
+
+      if (!viewerCountry) {
+        return NextResponse.json({
+          creator_id: creator,
+          viewer_country: null,
+          allowed: true,
+          reason: "viewer_country_unknown",
+        });
+      }
+
+      if (blocked.includes(viewerCountry)) {
+        return NextResponse.json(
+          {
+            creator_id: creator,
+            viewer_country: viewerCountry,
+            allowed: false,
+            reason: "blocked_country",
+          },
+          { status: 451 }
+        );
+      }
+
+      if (allowed.length > 0 && !allowed.includes(viewerCountry)) {
+        return NextResponse.json(
+          {
+            creator_id: creator,
+            viewer_country: viewerCountry,
+            allowed: false,
+            reason: "not_in_allowed_list",
+          },
+          { status: 451 }
+        );
+      }
+
+      return NextResponse.json({
+        creator_id: creator,
+        viewer_country: viewerCountry,
+        allowed: true,
+      });
+    } catch (err) {
+      console.error("[geo/check] GET error:", err);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureGeoTable();
+
+    const { rows } = await sql`
+      SELECT allowed_countries, blocked_countries, updated_at
+      FROM creator_geo_restrictions
+      WHERE creator_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    return NextResponse.json({
+      creator_id: session.userId,
+      allowed_countries:
+        (rows[0]?.allowed_countries as string[] | undefined) ?? [],
+      blocked_countries:
+        (rows[0]?.blocked_countries as string[] | undefined) ?? [],
+      updated_at: rows[0]?.updated_at ?? null,
+    });
+  } catch (err) {
+    console.error("[geo] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updateGeoSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const allowed = normalizeCodes(bodyResult.data.allowed_countries);
+  const blocked = normalizeCodes(bodyResult.data.blocked_countries);
+
+  if (allowed && blocked) {
+    const conflict = allowed.find(code => blocked.includes(code));
+    if (conflict) {
+      return NextResponse.json(
+        { error: `Country ${conflict} cannot be both allowed and blocked` },
+        { status: 400 }
+      );
+    }
+  }
+
+  try {
+    await ensureGeoTable();
+
+    const { rows: existing } = await sql`
+      SELECT allowed_countries, blocked_countries
+      FROM creator_geo_restrictions
+      WHERE creator_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    const nextAllowed =
+      allowed ?? (existing[0]?.allowed_countries as string[] | undefined) ?? [];
+    const nextBlocked =
+      blocked ?? (existing[0]?.blocked_countries as string[] | undefined) ?? [];
+
+    const { rows } = await sql`
+      INSERT INTO creator_geo_restrictions (
+        creator_id,
+        allowed_countries,
+        blocked_countries,
+        updated_at
+      )
+      VALUES (
+        ${session.userId},
+        ${nextAllowed}::text[],
+        ${nextBlocked}::text[],
+        NOW()
+      )
+      ON CONFLICT (creator_id)
+      DO UPDATE SET
+        allowed_countries = EXCLUDED.allowed_countries,
+        blocked_countries = EXCLUDED.blocked_countries,
+        updated_at = NOW()
+      RETURNING creator_id, allowed_countries, blocked_countries, updated_at
+    `;
+
+    return NextResponse.json(rows[0]);
+  } catch (err) {
+    console.error("[geo] PATCH error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/queue/[id]/route.ts
+++ b/app/api/routes-f/queue/[id]/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const updateQueueSchema = z
+  .object({
+    title: z.string().min(1).max(160).optional(),
+    scheduled_at: z.coerce.date().optional(),
+    category: z.string().min(1).max(80).optional(),
+    description: z.string().max(2000).nullable().optional(),
+  })
+  .refine(
+    body =>
+      body.title !== undefined ||
+      body.scheduled_at !== undefined ||
+      body.category !== undefined ||
+      body.description !== undefined,
+    "At least one field is required"
+  );
+
+async function ensureQueueTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS creator_stream_queue (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      scheduled_at TIMESTAMPTZ NOT NULL,
+      category TEXT NOT NULL,
+      description TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+async function hasOverlap(
+  creatorId: string,
+  scheduledAt: Date,
+  excludeId: string
+) {
+  const { rows } = await sql`
+    SELECT 1
+    FROM creator_stream_queue
+    WHERE creator_id = ${creatorId}
+      AND id != ${excludeId}
+      AND ABS(EXTRACT(EPOCH FROM (scheduled_at - ${scheduledAt.toISOString()}::timestamptz))) < 1800
+    LIMIT 1
+  `;
+
+  return rows.length > 0;
+}
+
+async function upcomingCount(creatorId: string, excludeId: string) {
+  const { rows } = await sql`
+    SELECT COUNT(*)::int AS total
+    FROM creator_stream_queue
+    WHERE creator_id = ${creatorId}
+      AND id != ${excludeId}
+      AND scheduled_at > NOW()
+  `;
+
+  return Number(rows[0]?.total ?? 0);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+  const bodyResult = await validateBody(req, updateQueueSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensureQueueTable();
+
+    const { rows: existingRows } = await sql`
+      SELECT id, title, scheduled_at, category, description
+      FROM creator_stream_queue
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (existingRows.length === 0) {
+      return NextResponse.json(
+        { error: "Scheduled stream not found" },
+        { status: 404 }
+      );
+    }
+
+    const current = existingRows[0];
+    const scheduledAt =
+      bodyResult.data.scheduled_at ?? new Date(current.scheduled_at as string);
+
+    if (scheduledAt.getTime() <= Date.now()) {
+      return NextResponse.json(
+        { error: "scheduled_at must be in the future" },
+        { status: 400 }
+      );
+    }
+
+    const nextCount = await upcomingCount(session.userId, id);
+    if (nextCount >= 10) {
+      return NextResponse.json(
+        { error: "Maximum of 10 upcoming scheduled streams reached" },
+        { status: 400 }
+      );
+    }
+
+    if (await hasOverlap(session.userId, scheduledAt, id)) {
+      return NextResponse.json(
+        { error: "Scheduled stream overlaps with an existing slot" },
+        { status: 409 }
+      );
+    }
+
+    const title = bodyResult.data.title ?? (current.title as string);
+    const category = bodyResult.data.category ?? (current.category as string);
+    const description =
+      bodyResult.data.description !== undefined
+        ? bodyResult.data.description
+        : (current.description as string | null);
+
+    const { rows } = await sql`
+      UPDATE creator_stream_queue
+      SET
+        title = ${title},
+        scheduled_at = ${scheduledAt.toISOString()},
+        category = ${category},
+        description = ${description},
+        updated_at = NOW()
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      RETURNING id, title, scheduled_at, category, description, created_at, updated_at
+    `;
+
+    return NextResponse.json(rows[0]);
+  } catch (err) {
+    console.error("[queue/:id] PATCH error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    await ensureQueueTable();
+
+    const { rowCount } = await sql`
+      DELETE FROM creator_stream_queue
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+    `;
+
+    if ((rowCount ?? 0) === 0) {
+      return NextResponse.json(
+        { error: "Scheduled stream not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ message: "Scheduled stream cancelled" });
+  } catch (err) {
+    console.error("[queue/:id] DELETE error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/queue/route.ts
+++ b/app/api/routes-f/queue/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+
+const createQueueSchema = z.object({
+  title: z.string().min(1).max(160),
+  scheduled_at: z.coerce.date(),
+  category: z.string().min(1).max(80),
+  description: z.string().max(2000).optional(),
+});
+
+const listQueueSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  cursor: uuidSchema.optional(),
+});
+
+async function ensureQueueTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS creator_stream_queue (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      scheduled_at TIMESTAMPTZ NOT NULL,
+      category TEXT NOT NULL,
+      description TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_creator_stream_queue_creator_scheduled
+    ON creator_stream_queue (creator_id, scheduled_at ASC)
+  `;
+}
+
+async function hasOverlap(
+  creatorId: string,
+  scheduledAt: Date,
+  excludeId?: string
+) {
+  const { rows } = excludeId
+    ? await sql`
+        SELECT 1
+        FROM creator_stream_queue
+        WHERE creator_id = ${creatorId}
+          AND id != ${excludeId}
+          AND ABS(EXTRACT(EPOCH FROM (scheduled_at - ${scheduledAt.toISOString()}::timestamptz))) < 1800
+        LIMIT 1
+      `
+    : await sql`
+        SELECT 1
+        FROM creator_stream_queue
+        WHERE creator_id = ${creatorId}
+          AND ABS(EXTRACT(EPOCH FROM (scheduled_at - ${scheduledAt.toISOString()}::timestamptz))) < 1800
+        LIMIT 1
+      `;
+
+  return rows.length > 0;
+}
+
+async function upcomingCount(creatorId: string, excludeId?: string) {
+  const { rows } = excludeId
+    ? await sql`
+        SELECT COUNT(*)::int AS total
+        FROM creator_stream_queue
+        WHERE creator_id = ${creatorId}
+          AND id != ${excludeId}
+          AND scheduled_at > NOW()
+      `
+    : await sql`
+        SELECT COUNT(*)::int AS total
+        FROM creator_stream_queue
+        WHERE creator_id = ${creatorId}
+          AND scheduled_at > NOW()
+      `;
+
+  return Number(rows[0]?.total ?? 0);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    listQueueSchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { limit, cursor } = queryResult.data;
+
+  try {
+    await ensureQueueTable();
+
+    const { rows } = cursor
+      ? await sql`
+          SELECT id, title, scheduled_at, category, description, created_at, updated_at
+          FROM creator_stream_queue
+          WHERE creator_id = ${session.userId}
+            AND scheduled_at > NOW()
+            AND scheduled_at > (
+              SELECT scheduled_at
+              FROM creator_stream_queue
+              WHERE id = ${cursor}
+              LIMIT 1
+            )
+          ORDER BY scheduled_at ASC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT id, title, scheduled_at, category, description, created_at, updated_at
+          FROM creator_stream_queue
+          WHERE creator_id = ${session.userId}
+            AND scheduled_at > NOW()
+          ORDER BY scheduled_at ASC
+          LIMIT ${limit}
+        `;
+
+    const nextCursor =
+      rows.length === limit ? (rows[rows.length - 1].id as string) : null;
+    return NextResponse.json({ queue: rows, next_cursor: nextCursor });
+  } catch (err) {
+    console.error("[queue] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createQueueSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { title, scheduled_at, category, description } = bodyResult.data;
+
+  if (scheduled_at.getTime() <= Date.now()) {
+    return NextResponse.json(
+      { error: "scheduled_at must be in the future" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureQueueTable();
+
+    const count = await upcomingCount(session.userId);
+    if (count >= 10) {
+      return NextResponse.json(
+        { error: "Maximum of 10 upcoming scheduled streams reached" },
+        { status: 400 }
+      );
+    }
+
+    if (await hasOverlap(session.userId, scheduled_at)) {
+      return NextResponse.json(
+        { error: "Scheduled stream overlaps with an existing slot" },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO creator_stream_queue (creator_id, title, scheduled_at, category, description)
+      VALUES (
+        ${session.userId},
+        ${title},
+        ${scheduled_at.toISOString()},
+        ${category},
+        ${description ?? null}
+      )
+      RETURNING id, title, scheduled_at, category, description, created_at, updated_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (err) {
+    console.error("[queue] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Implement creator stream scheduling queue endpoints under `app/api/routes-f/queue/` with future-date validation, overlap prevention (30-minute window), and a max of 10 upcoming streams per creator.
- Implement clip highlight collection endpoints under `app/api/routes-f/clips/highlights/` with max 20 clips per collection, cover clip validation, and position-ordered clip items.
- Implement admin-only cache routes under `app/api/routes-f/cache/` for purge and stats, including invalidated tags/paths in purge responses.
- Implement geolocation restriction endpoints under `app/api/routes-f/geo/` with ISO alpha-2 validation and viewer checks using `CF-IPCountry`/`X-Vercel-IP-Country` returning 451 when blocked.

Closes #432
Closes #446
Closes #443
Closes #439