### PR TITLE
feat(routes-f): add viewer stream report submission endpoint

### DIFF
--- a/app/api/routes-f/reports/__tests__/route.test.ts
+++ b/app/api/routes-f/reports/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+let mockRateLimited = false;
+jest.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => async () => mockRateLimited,
+}));
+
+import { sql } from "@vercel/postgres";
+import { POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+
+const makeRequest = (
+  body: object,
+  headers?: Record<string, string>
+): import("next/server").NextRequest =>
+  new Request("http://localhost/api/routes-f/reports", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(headers ?? {}) },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+
+describe("POST /api/routes-f/reports", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRateLimited = false;
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
+  });
+
+  it("returns 429 when IP exceeds rate limit", async () => {
+    mockRateLimited = true;
+
+    const req = makeRequest({
+      stream_id: "stream_123",
+      streamer: "alice",
+      reason: "spam",
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(body.error).toMatch(/Too many reports/i);
+  });
+
+  it("returns 400 for invalid reason", async () => {
+    const req = makeRequest({
+      stream_id: "stream_123",
+      streamer: "alice",
+      reason: "abuse",
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/reason must be one of/i);
+  });
+
+  it("stores report with hashed IP and returns 201 with confirmation ID", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE
+      .mockResolvedValueOnce({ rows: [{ id: "report-abc" }], rowCount: 1 }); // INSERT
+
+    const req = makeRequest(
+      {
+        stream_id: "stream_123",
+        streamer: "alice",
+        reason: "harassment",
+        details: "Viewer repeatedly posting abuse in chat",
+      },
+      { "x-forwarded-for": "198.51.100.22" }
+    );
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.confirmationId).toBe("report-abc");
+
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+    const insertArgs = sqlMock.mock.calls[1];
+    const insertValues = insertArgs.slice(1);
+
+    expect(insertValues).not.toContain("198.51.100.22");
+    const ipHash = insertValues[4];
+    expect(ipHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/app/api/routes-f/reports/route.ts
+++ b/app/api/routes-f/reports/route.ts
@@ -1,0 +1,149 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createRateLimiter } from "@/lib/rate-limit";
+
+const REPORT_REASONS = [
+  "spam",
+  "harassment",
+  "inappropriate_content",
+  "copyright",
+  "other",
+] as const;
+
+type ReportReason = (typeof REPORT_REASONS)[number];
+
+const isIpRateLimited = createRateLimiter(10 * 60 * 1000, 5); // 5 reports per 10 minutes per IP
+
+function getClientIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+function hashReporterIp(ip: string): string {
+  const salt =
+    process.env.REPORT_IP_HASH_SALT ??
+    process.env.SESSION_SECRET ??
+    "streamfi-report-ip-salt";
+
+  return createHash("sha256").update(`${salt}:${ip}`).digest("hex");
+}
+
+async function ensureReportsTable(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS stream_reports (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id TEXT NOT NULL,
+      streamer TEXT NOT NULL,
+      reason TEXT NOT NULL CHECK (reason IN ('spam', 'harassment', 'inappropriate_content', 'copyright', 'other')),
+      details TEXT,
+      reporter_ip_hash TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+function isValidReason(reason: unknown): reason is ReportReason {
+  return (
+    typeof reason === "string" &&
+    (REPORT_REASONS as readonly string[]).includes(reason)
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+
+  if (await isIpRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many reports. Please try again later." },
+      { status: 429, headers: { "Retry-After": "600" } }
+    );
+  }
+
+  let body: {
+    stream_id?: unknown;
+    streamer?: unknown;
+    reason?: unknown;
+    details?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const streamId =
+    typeof body.stream_id === "string" ? body.stream_id.trim() : "";
+  const streamer = typeof body.streamer === "string" ? body.streamer.trim() : "";
+  const reason = body.reason;
+  const details =
+    typeof body.details === "string" ? body.details.trim() : undefined;
+
+  if (!streamId) {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  if (!streamer) {
+    return NextResponse.json({ error: "streamer is required" }, { status: 400 });
+  }
+
+  if (!isValidReason(reason)) {
+    return NextResponse.json(
+      {
+        error:
+          "reason must be one of: spam, harassment, inappropriate_content, copyright, other",
+      },
+      { status: 400 }
+    );
+  }
+
+  if (details !== undefined && details.length > 2000) {
+    return NextResponse.json(
+      { error: "details must be 2000 characters or fewer" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureReportsTable();
+
+    const reporterIpHash = hashReporterIp(ip);
+
+    const { rows } = await sql`
+      INSERT INTO stream_reports (
+        stream_id,
+        streamer,
+        reason,
+        details,
+        reporter_ip_hash
+      )
+      VALUES (
+        ${streamId},
+        ${streamer},
+        ${reason},
+        ${details ?? null},
+        ${reporterIpHash}
+      )
+      RETURNING id
+    `;
+
+    return NextResponse.json(
+      {
+        message: "Report submitted successfully",
+        confirmationId: rows[0].id,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[reports] submit error:", error);
+    return NextResponse.json(
+      { error: "Failed to submit report" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Fixes #436

## Summary
- add POST /api/routes-f/reports for live stream report submissions
- validate payload fields and enforce reasons enum: spam, harassment, inappropriate_content, copyright, other
- add IP-based rate limit (5 reports / 10 minutes) with 429 handling
- store only hashed reporter IP (never raw IP) for privacy
- return 201 with confirmationId
- include route-level table bootstrap for stream_reports to keep this issue standalone

## Testing
- add route tests for: rate limit 429, invalid reason 400, success 201 + hashed IP storage