### PR TITLE
Add live chat history API with cursor pagination and moderator …

### DIFF
--- a/app/api/routes-f/live/chat/[messageId]/route.ts
+++ b/app/api/routes-f/live/chat/[messageId]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+// ── DELETE /api/routes-f/live/chat/[messageId] ────────────────────────────────
+// Soft-deletes a chat message. Caller must be the stream owner or a moderator
+// (currently: stream owner only — moderator table can extend this later).
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { messageId: string } }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) return session.response;
+
+  const messageId = parseInt(params.messageId, 10);
+  if (isNaN(messageId)) {
+    return NextResponse.json({ error: "Invalid message ID" }, { status: 400 });
+  }
+
+  try {
+    // Fetch message + stream owner in one query
+    const result = await sql`
+      SELECT
+        cm.id,
+        cm.is_deleted,
+        ss.user_id AS stream_owner_id
+      FROM chat_messages cm
+      JOIN stream_sessions ss ON cm.stream_session_id = ss.id
+      WHERE cm.id = ${messageId}
+      LIMIT 1
+    `;
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Message not found" }, { status: 404 });
+    }
+
+    const msg = result.rows[0];
+
+    if (msg.is_deleted) {
+      return NextResponse.json(
+        { error: "Message already deleted" },
+        { status: 409 }
+      );
+    }
+
+    // Only stream owner (or the message author themselves) may delete
+    if (session.userId !== msg.stream_owner_id) {
+      // Allow self-delete
+      const authorCheck = await sql`
+        SELECT user_id FROM chat_messages WHERE id = ${messageId} LIMIT 1
+      `;
+      if (authorCheck.rows[0]?.user_id !== session.userId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
+    await sql`
+      UPDATE chat_messages SET
+        is_deleted   = true,
+        is_moderated = true,
+        moderated_by = ${session.userId}
+      WHERE id = ${messageId}
+    `;
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    console.error("[chat:DELETE] error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete message" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/live/chat/route.ts
+++ b/app/api/routes-f/live/chat/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createRateLimiter } from "@/lib/rate-limit";
+
+const isRateLimited = createRateLimiter(60_000, 60); // 60 reads/min per IP
+
+// ── GET /api/routes-f/live/chat?stream_id=&limit=50&cursor= ──────────────────
+// Returns paginated chat history in reverse-chronological order (newest first).
+// cursor = last message id from previous page (exclusive upper bound).
+export async function GET(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (await isRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const { searchParams } = req.nextUrl;
+  const streamId = searchParams.get("stream_id");
+  const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const cursor = searchParams.get("cursor"); // message id cursor
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const limit = Math.min(Math.max(1, isNaN(rawLimit) ? 50 : rawLimit), 100);
+
+  try {
+    // Resolve active stream session for this streamer
+    const sessionResult = await sql`
+      SELECT ss.id AS session_id
+      FROM stream_sessions ss
+      WHERE ss.user_id = ${streamId}
+        AND ss.ended_at IS NULL
+      ORDER BY ss.started_at DESC
+      LIMIT 1
+    `;
+
+    if (sessionResult.rows.length === 0) {
+      return NextResponse.json(
+        { messages: [], nextCursor: null },
+        { status: 200 }
+      );
+    }
+
+    const sessionId = sessionResult.rows[0].session_id;
+    const cursorId = cursor ? parseInt(cursor, 10) : null;
+
+    const rows = await sql`
+      SELECT
+        cm.id,
+        cm.username   AS sender_username,
+        cm.content    AS body,
+        cm.created_at AS sent_at,
+        cm.is_deleted
+      FROM chat_messages cm
+      WHERE cm.stream_session_id = ${sessionId}
+        AND (${cursorId}::int IS NULL OR cm.id < ${cursorId})
+      ORDER BY cm.id DESC
+      LIMIT ${limit}
+    `;
+
+    const messages = rows.rows.map(r => ({
+      id: r.id,
+      sender_username: r.sender_username,
+      body: r.body,
+      sent_at: r.sent_at,
+      is_deleted: r.is_deleted,
+    }));
+
+    // Provide next cursor if there may be more pages
+    const nextCursor =
+      messages.length === limit
+        ? String(messages[messages.length - 1].id)
+        : null;
+
+    return NextResponse.json({ messages, nextCursor }, { status: 200 });
+  } catch (error) {
+    console.error("[chat:GET] error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch messages" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements live chat history retrieval and moderated message deletion under app/api/routes-f/live/chat/.

this pr Closes #453 

## Endpoints

**GET** `/api/routes-f/live/chat?stream_id=&limit=50&cursor=`
- Resolves the active stream session for the given `stream_id` (user UUID)
- Returns messages in reverse-chronological order (newest first)
- Cursor-based pagination via message `id` — pass `nextCursor` from the previous response as `cursor` on the next request
- `limit` clamped between 1–100, defaults to 50
- Each message includes: `id`, `sender_username`, `body`, `sent_at`, `is_deleted`
- Returns `{ messages: [], nextCursor: null }` when no active session exists (stream offline)
- Rate limited to 60 requests/min per IP

**DELETE** `/api/routes-f/live/chat/[messageId]`
- Requires an authenticated session (cookie-based via `verifySession`)
- Authorized callers: stream owner or the message author (self-delete)
- Soft-deletes: sets `is_deleted = true`, `is_moderated = true`, `moderated_by = <caller_id>`
- Returns `409` if message is already deleted
- Returns `403` if caller is neither stream owner nor message author

## Notes
- Standalone — no dependency on other open issues
- Consistent with existing patterns (`verifySession`, `createRateLimiter`, `@vercel/postgres`)
- `is_deleted` messages are included in GET responses so clients can render tombstones if needed
