### PR TITLE
feat: add routes-f alerts, milestones, reactions, and collections

### DIFF
--- a/app/api/routes-f/alerts/__tests__/route.test.ts
+++ b/app/api/routes-f/alerts/__tests__/route.test.ts
@@ -1,0 +1,139 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureAlertSchema: jest.fn().mockResolvedValue(undefined),
+  ALERT_TYPES: ["tip", "subscription", "gift", "raid", "follow"],
+  DEFAULT_ALERT_CONFIG: {
+    enabled_types: ["tip", "subscription", "gift", "raid", "follow"],
+    display_duration_ms: 5000,
+    sound_enabled: true,
+    custom_message_template: null,
+  },
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, PATCH } from "../route";
+import { POST } from "../test/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const AUTHED_SESSION = {
+  ok: true as const,
+  userId: "user-id",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "alice",
+  email: "alice@example.com",
+};
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f alerts", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(AUTHED_SESSION);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("returns the default alert config when none exists", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/alerts"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.display_duration_ms).toBe(5000);
+    expect(json.enabled_types).toContain("tip");
+  });
+
+  it("rejects an out-of-range display duration", async () => {
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/routes-f/alerts", {
+        display_duration_ms: 20000,
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("updates and returns the alert config", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          enabled_types: ["tip", "follow"],
+          display_duration_ms: 4000,
+          sound_enabled: false,
+          custom_message_template: "{viewer} triggered {type}",
+        },
+      ],
+    });
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/routes-f/alerts", {
+        enabled_types: ["tip", "follow"],
+        display_duration_ms: 4000,
+        sound_enabled: false,
+        custom_message_template: "{viewer} triggered {type}",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.display_duration_ms).toBe(4000);
+    expect(json.sound_enabled).toBe(false);
+  });
+
+  it("stores a test alert event for polling", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "alert-event-1",
+          alert_type: "raid",
+          message: "Test viewer triggered a test raid",
+          payload: { actor_username: "Test viewer" },
+          is_test: true,
+          created_at: "2026-03-27T00:00:00Z",
+        },
+      ],
+    });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/alerts/test", {
+        type: "raid",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.delivery).toBe("stored_for_polling");
+    expect(json.event.alert_type).toBe("raid");
+  });
+});

--- a/app/api/routes-f/alerts/_lib/db.ts
+++ b/app/api/routes-f/alerts/_lib/db.ts
@@ -1,0 +1,49 @@
+import { sql } from "@vercel/postgres";
+
+export const ALERT_TYPES = [
+  "tip",
+  "subscription",
+  "gift",
+  "raid",
+  "follow",
+] as const;
+
+export type AlertType = (typeof ALERT_TYPES)[number];
+
+export const DEFAULT_ALERT_CONFIG = {
+  enabled_types: [...ALERT_TYPES],
+  display_duration_ms: 5000,
+  sound_enabled: true,
+  custom_message_template: null as string | null,
+};
+
+export async function ensureAlertSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_alert_configs (
+      user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      enabled_types TEXT[] NOT NULL DEFAULT ARRAY['tip', 'subscription', 'gift', 'raid', 'follow']::TEXT[],
+      display_duration_ms INT NOT NULL DEFAULT 5000,
+      sound_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+      custom_message_template TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_alert_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      alert_type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      is_test BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_alert_events_user_created
+      ON route_f_alert_events (user_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/alerts/route.ts
+++ b/app/api/routes-f/alerts/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import {
+  ALERT_TYPES,
+  DEFAULT_ALERT_CONFIG,
+  type AlertType,
+  ensureAlertSchema,
+} from "./_lib/db";
+
+const alertTypeSchema = z.enum(ALERT_TYPES);
+
+const updateAlertConfigSchema = z
+  .object({
+    enabled_types: z.array(alertTypeSchema).max(ALERT_TYPES.length).optional(),
+    display_duration_ms: z.number().int().min(1000).max(15000).optional(),
+    sound_enabled: z.boolean().optional(),
+    custom_message_template: z.string().trim().max(280).nullable().optional(),
+  })
+  .refine(body => Object.keys(body).length > 0, {
+    message: "At least one field is required",
+    path: ["body"],
+  });
+
+function toPgTextArray(values: AlertType[]) {
+  return `{${values.map(value => `"${value}"`).join(",")}}`;
+}
+
+function mapConfigRow(row?: Record<string, unknown>) {
+  const duration =
+    typeof row?.display_duration_ms === "number"
+      ? row.display_duration_ms
+      : typeof row?.display_duration_ms === "string"
+        ? Number(row.display_duration_ms)
+        : null;
+
+  return {
+    enabled_types:
+      (row?.enabled_types as AlertType[] | undefined) ??
+      DEFAULT_ALERT_CONFIG.enabled_types,
+    display_duration_ms:
+      Number.isFinite(duration) && duration !== null
+        ? duration
+        : DEFAULT_ALERT_CONFIG.display_duration_ms,
+    sound_enabled:
+      typeof row?.sound_enabled === "boolean"
+        ? row.sound_enabled
+        : DEFAULT_ALERT_CONFIG.sound_enabled,
+    custom_message_template:
+      typeof row?.custom_message_template === "string"
+        ? row.custom_message_template
+        : null,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const includeEvents = searchParams.get("include_events") === "true";
+
+  try {
+    await ensureAlertSchema();
+
+    const { rows } = await sql`
+      SELECT enabled_types, display_duration_ms, sound_enabled, custom_message_template
+      FROM route_f_alert_configs
+      WHERE user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    const config = mapConfigRow(rows[0]);
+
+    if (!includeEvents) {
+      return NextResponse.json(config);
+    }
+
+    const { rows: eventRows } = await sql`
+      SELECT id, alert_type, message, payload, is_test, created_at
+      FROM route_f_alert_events
+      WHERE user_id = ${session.userId}
+      ORDER BY created_at DESC
+      LIMIT 20
+    `;
+
+    return NextResponse.json({
+      ...config,
+      recent_events: eventRows,
+    });
+  } catch (error) {
+    console.error("[alerts] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updateAlertConfigSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const {
+    enabled_types,
+    display_duration_ms,
+    sound_enabled,
+    custom_message_template,
+  } = bodyResult.data;
+
+  try {
+    await ensureAlertSchema();
+
+    const nextEnabledTypes =
+      enabled_types ?? DEFAULT_ALERT_CONFIG.enabled_types;
+    const nextDuration =
+      display_duration_ms ?? DEFAULT_ALERT_CONFIG.display_duration_ms;
+    const nextSoundEnabled =
+      sound_enabled ?? DEFAULT_ALERT_CONFIG.sound_enabled;
+    const nextTemplate =
+      custom_message_template === undefined
+        ? DEFAULT_ALERT_CONFIG.custom_message_template
+        : custom_message_template;
+
+    const { rows } = await sql`
+      INSERT INTO route_f_alert_configs (
+        user_id,
+        enabled_types,
+        display_duration_ms,
+        sound_enabled,
+        custom_message_template,
+        updated_at
+      )
+      VALUES (
+        ${session.userId},
+        ${toPgTextArray(nextEnabledTypes)}::text[],
+        ${nextDuration},
+        ${nextSoundEnabled},
+        ${nextTemplate},
+        now()
+      )
+      ON CONFLICT (user_id) DO UPDATE
+      SET enabled_types = COALESCE(${enabled_types ? toPgTextArray(enabled_types) : null}::text[], route_f_alert_configs.enabled_types),
+          display_duration_ms = COALESCE(${display_duration_ms ?? null}, route_f_alert_configs.display_duration_ms),
+          sound_enabled = COALESCE(${sound_enabled ?? null}, route_f_alert_configs.sound_enabled),
+          custom_message_template = CASE
+            WHEN ${custom_message_template !== undefined} THEN ${custom_message_template ?? null}
+            ELSE route_f_alert_configs.custom_message_template
+          END,
+          updated_at = now()
+      RETURNING enabled_types, display_duration_ms, sound_enabled, custom_message_template
+    `;
+
+    return NextResponse.json(mapConfigRow(rows[0]));
+  } catch (error) {
+    console.error("[alerts] PATCH error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/alerts/test/route.ts
+++ b/app/api/routes-f/alerts/test/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ALERT_TYPES, type AlertType, ensureAlertSchema } from "../_lib/db";
+
+const testAlertBodySchema = z.object({
+  type: z.enum(ALERT_TYPES).default("tip"),
+  actor_username: z.string().trim().min(1).max(50).optional(),
+  custom_message: z.string().trim().min(1).max(280).optional(),
+  payload: z.record(z.unknown()).optional(),
+});
+
+function buildMessage(
+  type: AlertType,
+  actorUsername?: string,
+  customMessage?: string
+) {
+  if (customMessage) {
+    return customMessage;
+  }
+
+  const actor = actorUsername ?? "Test viewer";
+
+  switch (type) {
+    case "tip":
+      return `${actor} sent a test tip`;
+    case "subscription":
+      return `${actor} started a test subscription`;
+    case "gift":
+      return `${actor} sent a test gift`;
+    case "raid":
+      return `${actor} triggered a test raid`;
+    case "follow":
+      return `${actor} followed the channel in a test alert`;
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, testAlertBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const type = bodyResult.data.type ?? "tip";
+  const { actor_username, custom_message, payload = {} } = bodyResult.data;
+
+  try {
+    await ensureAlertSchema();
+
+    const message = buildMessage(type, actor_username, custom_message);
+
+    const { rows } = await sql`
+      INSERT INTO route_f_alert_events (user_id, alert_type, message, payload, is_test)
+      VALUES (
+        ${session.userId},
+        ${type},
+        ${message},
+        ${JSON.stringify({ actor_username, ...payload })},
+        TRUE
+      )
+      RETURNING id, alert_type, message, payload, is_test, created_at
+    `;
+
+    return NextResponse.json(
+      {
+        delivery: "stored_for_polling",
+        event: rows[0],
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[alerts/test] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/clips/reactions/__tests__/route.test.ts
+++ b/app/api/routes-f/clips/reactions/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureClipReactionSchema: jest.fn().mockResolvedValue(undefined),
+  REACTION_EMOJIS: ["🔥", "❤️", "😂", "👏", "💜", "😮", "💯", "🎉"],
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST, DELETE } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const CLIP_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f clip reactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "user-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "alice",
+      email: "alice@example.com",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns grouped reactions for a clip", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        { emoji: "🔥", count: 2 },
+        { emoji: "🎉", count: 1 },
+      ],
+    });
+
+    const res = await GET(
+      makeRequest("GET", `/api/routes-f/clips/reactions?clip_id=${CLIP_ID}`)
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.total_count).toBe(3);
+    expect(json.breakdown).toHaveLength(2);
+  });
+
+  it("rejects unsupported emoji", async () => {
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/clips/reactions", {
+        clip_id: CLIP_ID,
+        emoji: "🙂",
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects duplicate reactions for the same emoji", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: CLIP_ID }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/clips/reactions", {
+        clip_id: CLIP_ID,
+        emoji: "🔥",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("removes a reaction and returns the new summary", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ emoji: "🔥", count: 1 }] });
+
+    const res = await DELETE(
+      makeRequest("DELETE", "/api/routes-f/clips/reactions", {
+        clip_id: CLIP_ID,
+        emoji: "🔥",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.total_count).toBe(1);
+  });
+});

--- a/app/api/routes-f/clips/reactions/_lib/db.ts
+++ b/app/api/routes-f/clips/reactions/_lib/db.ts
@@ -1,0 +1,32 @@
+import { sql } from "@vercel/postgres";
+
+export const REACTION_EMOJIS = [
+  "🔥",
+  "❤️",
+  "😂",
+  "👏",
+  "💜",
+  "😮",
+  "💯",
+  "🎉",
+] as const;
+
+export type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
+
+export async function ensureClipReactionSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_clip_reactions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      clip_id UUID NOT NULL REFERENCES stream_recordings(id) ON DELETE CASCADE,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      emoji TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (clip_id, user_id, emoji)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_clip_reactions_clip
+      ON route_f_clip_reactions (clip_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/clips/reactions/route.ts
+++ b/app/api/routes-f/clips/reactions/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { REACTION_EMOJIS, ensureClipReactionSchema } from "./_lib/db";
+
+const reactionBodySchema = z.object({
+  clip_id: uuidSchema,
+  emoji: z.enum(REACTION_EMOJIS),
+});
+
+const reactionQuerySchema = z.object({
+  clip_id: uuidSchema,
+});
+
+async function getReactionSummary(clipId: string) {
+  const { rows } = await sql`
+    SELECT emoji, COUNT(*)::int AS count
+    FROM route_f_clip_reactions
+    WHERE clip_id = ${clipId}
+    GROUP BY emoji
+    ORDER BY emoji ASC
+  `;
+
+  return {
+    total_count: rows.reduce((total, row) => total + Number(row.count), 0),
+    breakdown: rows,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, reactionQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    await ensureClipReactionSchema();
+
+    return NextResponse.json(
+      await getReactionSummary(queryResult.data.clip_id)
+    );
+  } catch (error) {
+    console.error("[clips/reactions] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, reactionBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { clip_id, emoji } = bodyResult.data;
+
+  try {
+    await ensureClipReactionSchema();
+
+    const { rows: clipRows } = await sql`
+      SELECT id
+      FROM stream_recordings
+      WHERE id = ${clip_id}
+      LIMIT 1
+    `;
+
+    if (clipRows.length === 0) {
+      return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_clip_reactions (clip_id, user_id, emoji)
+      VALUES (${clip_id}, ${session.userId}, ${emoji})
+      ON CONFLICT (clip_id, user_id, emoji) DO NOTHING
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Reaction already exists for this emoji" },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(await getReactionSummary(clip_id), {
+      status: 201,
+    });
+  } catch (error) {
+    console.error("[clips/reactions] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, reactionBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { clip_id, emoji } = bodyResult.data;
+
+  try {
+    await ensureClipReactionSchema();
+
+    await sql`
+      DELETE FROM route_f_clip_reactions
+      WHERE clip_id = ${clip_id}
+        AND user_id = ${session.userId}
+        AND emoji = ${emoji}
+    `;
+
+    return NextResponse.json(await getReactionSummary(clip_id));
+  } catch (error) {
+    console.error("[clips/reactions] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/collections/[id]/items/[itemId]/route.ts
+++ b/app/api/routes-f/collections/[id]/items/[itemId]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { ensureCollectionsSchema } from "../../../_lib/db";
+
+interface RouteParams {
+  params:
+    | Promise<{ id: string; itemId: string }>
+    | { id: string; itemId: string };
+}
+
+function validateId(id: string, label: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json({ error: `Invalid ${label}` }, { status: 400 });
+  }
+  return null;
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id, itemId } = await context.params;
+
+  const collectionIdError = validateId(id, "collection id");
+  if (collectionIdError) {
+    return collectionIdError;
+  }
+
+  const itemIdError = validateId(itemId, "item id");
+  if (itemIdError) {
+    return itemIdError;
+  }
+
+  try {
+    await ensureCollectionsSchema();
+
+    const { rows: ownerRows } = await sql`
+      SELECT id
+      FROM route_f_collections
+      WHERE id = ${id}
+        AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (ownerRows.length === 0) {
+      return NextResponse.json(
+        { error: "Collection not found" },
+        { status: 404 }
+      );
+    }
+
+    const { rows } = await sql`
+      DELETE FROM route_f_collection_items
+      WHERE collection_id = ${id}
+        AND item_id = ${itemId}
+      RETURNING item_id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Collection item not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ item_id: rows[0].item_id, deleted: true });
+  } catch (error) {
+    console.error("[collections/[id]/items/[itemId]] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/collections/[id]/items/route.ts
+++ b/app/api/routes-f/collections/[id]/items/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { COLLECTION_ITEM_TYPES, ensureCollectionsSchema } from "../../_lib/db";
+
+interface RouteParams {
+  params: Promise<{ id: string }> | { id: string };
+}
+
+const addCollectionItemSchema = z.object({
+  item_id: uuidSchema,
+  item_type: z.enum(COLLECTION_ITEM_TYPES),
+});
+
+function validateId(id: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Invalid collection id" },
+      { status: 400 }
+    );
+  }
+  return null;
+}
+
+export async function POST(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  const bodyResult = await validateBody(req, addCollectionItemSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { item_id, item_type } = bodyResult.data;
+
+  try {
+    await ensureCollectionsSchema();
+
+    const { rows: ownerRows } = await sql`
+      SELECT id
+      FROM route_f_collections
+      WHERE id = ${id}
+        AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (ownerRows.length === 0) {
+      return NextResponse.json(
+        { error: "Collection not found" },
+        { status: 404 }
+      );
+    }
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS item_count
+      FROM route_f_collection_items
+      WHERE collection_id = ${id}
+    `;
+
+    if (Number(countRows[0]?.item_count ?? 0) >= 50) {
+      return NextResponse.json(
+        { error: "Collections may only contain 50 items" },
+        { status: 409 }
+      );
+    }
+
+    const { rows: itemRows } = await sql`
+      SELECT id, title, playback_id, status
+      FROM stream_recordings
+      WHERE id = ${item_id}
+      LIMIT 1
+    `;
+
+    if (itemRows.length === 0) {
+      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_collection_items (collection_id, item_id, item_type)
+      VALUES (${id}, ${item_id}, ${item_type})
+      ON CONFLICT (collection_id, item_id, item_type) DO NOTHING
+      RETURNING collection_id, item_id, item_type, created_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Item already exists in this collection" },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[collections/[id]/items] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/collections/[id]/route.ts
+++ b/app/api/routes-f/collections/[id]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { ensureCollectionsSchema } from "../_lib/db";
+
+interface RouteParams {
+  params: Promise<{ id: string }> | { id: string };
+}
+
+function validateId(id: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Invalid collection id" },
+      { status: 400 }
+    );
+  }
+  return null;
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  try {
+    await ensureCollectionsSchema();
+
+    const { rows } = await sql`
+      DELETE FROM route_f_collections
+      WHERE id = ${id}
+        AND user_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Collection not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ id: rows[0].id, deleted: true });
+  } catch (error) {
+    console.error("[collections/[id]] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/collections/__tests__/route.test.ts
+++ b/app/api/routes-f/collections/__tests__/route.test.ts
@@ -1,0 +1,206 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureCollectionsSchema: jest.fn().mockResolvedValue(undefined),
+  COLLECTION_VISIBILITIES: ["public", "private"],
+  COLLECTION_ITEM_TYPES: ["clip", "recording"],
+}));
+
+jest.mock("../../collections/_lib/db", () => ({
+  ensureCollectionsSchema: jest.fn().mockResolvedValue(undefined),
+  COLLECTION_VISIBILITIES: ["public", "private"],
+  COLLECTION_ITEM_TYPES: ["clip", "recording"],
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { DELETE as DELETE_COLLECTION } from "../[id]/route";
+import { POST as ADD_ITEM } from "../[id]/items/route";
+import { DELETE as DELETE_ITEM } from "../[id]/items/[itemId]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const COLLECTION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const ITEM_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f collections", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "user-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "alice",
+      email: "alice@example.com",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lists public collections for a creator profile", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: COLLECTION_ID,
+          name: "Best moments",
+          visibility: "public",
+          username: "alice",
+          item_count: 4,
+        },
+      ],
+    });
+
+    const res = await GET(
+      makeRequest("GET", "/api/routes-f/collections?creator=alice")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.collections).toHaveLength(1);
+    expect(json.collections[0].visibility).toBe("public");
+  });
+
+  it("rejects creating more than 20 collections", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [{ collection_count: 20 }] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/collections", {
+        name: "Playlist",
+        visibility: "private",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("creates a collection", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ collection_count: 2 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: COLLECTION_ID,
+            user_id: "user-id",
+            name: "Playlist",
+            visibility: "public",
+            created_at: "2026-03-27T00:00:00Z",
+            updated_at: "2026-03-27T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/collections", {
+        name: "Playlist",
+        visibility: "public",
+      })
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects adding items once a collection has 50 items", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: COLLECTION_ID }] })
+      .mockResolvedValueOnce({ rows: [{ item_count: 50 }] });
+
+    const res = await ADD_ITEM(
+      makeRequest("POST", `/api/routes-f/collections/${COLLECTION_ID}/items`, {
+        item_id: ITEM_ID,
+        item_type: "clip",
+      }),
+      { params: { id: COLLECTION_ID } }
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("adds an item to a collection", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: COLLECTION_ID }] })
+      .mockResolvedValueOnce({ rows: [{ item_count: 3 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { id: ITEM_ID, title: "Clip", playback_id: "p", status: "ready" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            collection_id: COLLECTION_ID,
+            item_id: ITEM_ID,
+            item_type: "clip",
+            created_at: "2026-03-27T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await ADD_ITEM(
+      makeRequest("POST", `/api/routes-f/collections/${COLLECTION_ID}/items`, {
+        item_id: ITEM_ID,
+        item_type: "clip",
+      }),
+      { params: { id: COLLECTION_ID } }
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("removes an item from a collection", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: COLLECTION_ID }] })
+      .mockResolvedValueOnce({ rows: [{ item_id: ITEM_ID }] });
+
+    const res = await DELETE_ITEM(
+      makeRequest(
+        "DELETE",
+        `/api/routes-f/collections/${COLLECTION_ID}/items/${ITEM_ID}`
+      ),
+      { params: { id: COLLECTION_ID, itemId: ITEM_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+
+  it("deletes a collection", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: COLLECTION_ID }] });
+
+    const res = await DELETE_COLLECTION(
+      makeRequest("DELETE", `/api/routes-f/collections/${COLLECTION_ID}`),
+      { params: { id: COLLECTION_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/routes-f/collections/_lib/db.ts
+++ b/app/api/routes-f/collections/_lib/db.ts
@@ -1,0 +1,37 @@
+import { sql } from "@vercel/postgres";
+
+export const COLLECTION_VISIBILITIES = ["public", "private"] as const;
+export const COLLECTION_ITEM_TYPES = ["clip", "recording"] as const;
+
+export async function ensureCollectionsSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_collections (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name VARCHAR(120) NOT NULL,
+      visibility TEXT NOT NULL DEFAULT 'private',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_collection_items (
+      collection_id UUID NOT NULL REFERENCES route_f_collections(id) ON DELETE CASCADE,
+      item_id UUID NOT NULL REFERENCES stream_recordings(id) ON DELETE CASCADE,
+      item_type TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      PRIMARY KEY (collection_id, item_id, item_type)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_collections_user_visibility
+      ON route_f_collections (user_id, visibility, created_at DESC)
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_collection_items_collection
+      ON route_f_collection_items (collection_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/collections/route.ts
+++ b/app/api/routes-f/collections/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { usernameSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { COLLECTION_VISIBILITIES, ensureCollectionsSchema } from "./_lib/db";
+
+const createCollectionSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  visibility: z.enum(COLLECTION_VISIBILITIES),
+});
+
+const publicCollectionsQuerySchema = z.object({
+  creator: usernameSchema.optional(),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, publicCollectionsQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    await ensureCollectionsSchema();
+
+    if (queryResult.data.creator) {
+      const { rows } = await sql`
+        SELECT
+          c.id,
+          c.name,
+          c.visibility,
+          c.created_at,
+          c.updated_at,
+          u.username,
+          COUNT(ci.item_id)::int AS item_count
+        FROM route_f_collections c
+        JOIN users u ON u.id = c.user_id
+        LEFT JOIN route_f_collection_items ci ON ci.collection_id = c.id
+        WHERE LOWER(u.username) = LOWER(${queryResult.data.creator})
+          AND c.visibility = 'public'
+        GROUP BY c.id, u.username
+        ORDER BY c.created_at DESC
+      `;
+
+      return NextResponse.json({ collections: rows });
+    }
+
+    const session = await verifySession(req);
+    if (!session.ok) {
+      return session.response;
+    }
+
+    const { rows } = await sql`
+      SELECT
+        c.id,
+        c.name,
+        c.visibility,
+        c.created_at,
+        c.updated_at,
+        COUNT(ci.item_id)::int AS item_count
+      FROM route_f_collections c
+      LEFT JOIN route_f_collection_items ci ON ci.collection_id = c.id
+      WHERE c.user_id = ${session.userId}
+      GROUP BY c.id
+      ORDER BY c.created_at DESC
+    `;
+
+    return NextResponse.json({ collections: rows });
+  } catch (error) {
+    console.error("[collections] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createCollectionSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { name, visibility } = bodyResult.data;
+
+  try {
+    await ensureCollectionsSchema();
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS collection_count
+      FROM route_f_collections
+      WHERE user_id = ${session.userId}
+    `;
+
+    if (Number(countRows[0]?.collection_count ?? 0) >= 20) {
+      return NextResponse.json(
+        { error: "Users may only have 20 collections" },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_collections (user_id, name, visibility)
+      VALUES (${session.userId}, ${name}, ${visibility})
+      RETURNING id, user_id, name, visibility, created_at, updated_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[collections] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/jobs/[id]/route.ts
+++ b/app/api/routes-f/jobs/[id]/route.ts
@@ -10,7 +10,7 @@ import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
 import { ensureJobsSchema } from "../_lib/db";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }> | { id: string };
 }
 
 function validateId(id: string): NextResponse | null {
@@ -25,14 +25,16 @@ function validateId(id: string): NextResponse | null {
 
 export async function GET(
   req: NextRequest,
-  { params }: RouteParams
+  context: RouteParams
 ): Promise<NextResponse> {
   const session = await verifySession(req);
   if (!session.ok) {
     return session.response;
   }
 
-  const idError = validateId(params.id);
+  const { id } = await context.params;
+
+  const idError = validateId(id);
   if (idError) {
     return idError;
   }
@@ -44,7 +46,7 @@ export async function GET(
       SELECT id, type, status, payload, result, error, attempts,
              max_attempts, created_at, started_at, completed_at
       FROM jobs
-      WHERE id = ${params.id} AND user_id = ${session.userId}
+      WHERE id = ${id} AND user_id = ${session.userId}
       LIMIT 1
     `;
 
@@ -66,14 +68,16 @@ export async function GET(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: RouteParams
+  context: RouteParams
 ): Promise<NextResponse> {
   const session = await verifySession(req);
   if (!session.ok) {
     return session.response;
   }
 
-  const idError = validateId(params.id);
+  const { id } = await context.params;
+
+  const idError = validateId(id);
   if (idError) {
     return idError;
   }
@@ -85,7 +89,7 @@ export async function DELETE(
     const { rows } = await sql`
       UPDATE jobs
       SET status = 'cancelled'
-      WHERE id = ${params.id}
+      WHERE id = ${id}
         AND user_id = ${session.userId}
         AND status = 'pending'
       RETURNING id, status
@@ -95,7 +99,7 @@ export async function DELETE(
       // Either job doesn't exist, doesn't belong to user, or isn't pending
       const { rows: existing } = await sql`
         SELECT id, status FROM jobs
-        WHERE id = ${params.id} AND user_id = ${session.userId}
+        WHERE id = ${id} AND user_id = ${session.userId}
         LIMIT 1
       `;
 

--- a/app/api/routes-f/milestones/[id]/route.ts
+++ b/app/api/routes-f/milestones/[id]/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureMilestonesSchema } from "../_lib/db";
+
+interface RouteParams {
+  params: Promise<{ id: string }> | { id: string };
+}
+
+const updateMilestoneSchema = z
+  .object({
+    target: z.number().positive().optional(),
+    title: z.string().trim().min(1).max(255).optional(),
+    reward_description: z.string().trim().max(500).nullable().optional(),
+  })
+  .refine(body => Object.keys(body).length > 0, {
+    message: "At least one field is required",
+    path: ["body"],
+  });
+
+function validateId(id: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Invalid milestone id" },
+      { status: 400 }
+    );
+  }
+  return null;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  const bodyResult = await validateBody(req, updateMilestoneSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { target, title, reward_description } = bodyResult.data;
+
+  try {
+    await ensureMilestonesSchema();
+
+    const { rows } = await sql`
+      UPDATE route_f_milestones
+      SET target = COALESCE(${target ?? null}, target),
+          title = COALESCE(${title ?? null}, title),
+          reward_description = CASE
+            WHEN ${reward_description !== undefined} THEN ${reward_description ?? null}
+            ELSE reward_description
+          END,
+          updated_at = now()
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      RETURNING id, creator_id, type, target, title, reward_description, completed_at, created_at, updated_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Milestone not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      ...rows[0],
+      target: Number(rows[0].target),
+    });
+  } catch (error) {
+    console.error("[milestones/[id]] PATCH error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  try {
+    await ensureMilestonesSchema();
+
+    const { rows } = await sql`
+      DELETE FROM route_f_milestones
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Milestone not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ id: rows[0].id, deleted: true });
+  } catch (error) {
+    console.error("[milestones/[id]] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/milestones/__tests__/route.test.ts
+++ b/app/api/routes-f/milestones/__tests__/route.test.ts
@@ -1,0 +1,190 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureMilestonesSchema: jest.fn().mockResolvedValue(undefined),
+  MILESTONE_TYPES: ["sub_count", "tip_amount", "viewer_count"],
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { PATCH, DELETE } from "../[id]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const AUTHED_SESSION = {
+  ok: true as const,
+  userId: "creator-id",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "alice",
+  email: "alice@example.com",
+};
+
+const VALID_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f milestones", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(AUTHED_SESSION);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("lists milestones with live progress and stamps completion", async () => {
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "creator-id",
+            username: "alice",
+            total_tips_received: "120",
+            current_viewers: 42,
+            follower_count: 15,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: VALID_ID,
+            creator_id: "creator-id",
+            type: "tip_amount",
+            target: "100",
+            title: "Reach first 100 USDC",
+            reward_description: null,
+            completed_at: null,
+            created_at: "2026-03-27T00:00:00Z",
+            updated_at: "2026-03-27T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(
+      makeRequest("GET", "/api/routes-f/milestones?creator=alice")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.metrics.tip_amount).toBe(120);
+    expect(json.completed).toHaveLength(1);
+    expect(sqlMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects creating more than 5 active milestones", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [{ active_count: 5 }] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/milestones", {
+        type: "sub_count",
+        target: 20,
+        title: "20 followers",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("creates a milestone", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ active_count: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: VALID_ID,
+            creator_id: "creator-id",
+            type: "viewer_count",
+            target: "100",
+            title: "100 viewers",
+            reward_description: "Giveaway",
+            completed_at: null,
+            created_at: "2026-03-27T00:00:00Z",
+            updated_at: "2026-03-27T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/milestones", {
+        type: "viewer_count",
+        target: 100,
+        title: "100 viewers",
+        reward_description: "Giveaway",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.target).toBe(100);
+  });
+
+  it("updates a milestone", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_ID,
+          creator_id: "creator-id",
+          type: "sub_count",
+          target: "25",
+          title: "25 supporters",
+          reward_description: null,
+          completed_at: null,
+          created_at: "2026-03-27T00:00:00Z",
+          updated_at: "2026-03-27T00:00:00Z",
+        },
+      ],
+    });
+
+    const res = await PATCH(
+      makeRequest("PATCH", `/api/routes-f/milestones/${VALID_ID}`, {
+        target: 25,
+        title: "25 supporters",
+      }),
+      { params: { id: VALID_ID } }
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("deletes a milestone", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: VALID_ID }] });
+
+    const res = await DELETE(
+      makeRequest("DELETE", `/api/routes-f/milestones/${VALID_ID}`),
+      { params: { id: VALID_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/routes-f/milestones/_lib/db.ts
+++ b/app/api/routes-f/milestones/_lib/db.ts
@@ -1,0 +1,30 @@
+import { sql } from "@vercel/postgres";
+
+export const MILESTONE_TYPES = [
+  "sub_count",
+  "tip_amount",
+  "viewer_count",
+] as const;
+
+export type MilestoneType = (typeof MILESTONE_TYPES)[number];
+
+export async function ensureMilestonesSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_milestones (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      type TEXT NOT NULL,
+      target NUMERIC(20, 7) NOT NULL,
+      title VARCHAR(255) NOT NULL,
+      reward_description TEXT,
+      completed_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_milestones_creator_created
+      ON route_f_milestones (creator_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/milestones/route.ts
+++ b/app/api/routes-f/milestones/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { usernameSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import {
+  MILESTONE_TYPES,
+  type MilestoneType,
+  ensureMilestonesSchema,
+} from "./_lib/db";
+
+const createMilestoneSchema = z.object({
+  type: z.enum(MILESTONE_TYPES),
+  target: z.number().positive(),
+  title: z.string().trim().min(1).max(255),
+  reward_description: z.string().trim().max(500).optional(),
+});
+
+const listMilestonesQuerySchema = z.object({
+  creator: usernameSchema,
+});
+
+type CreatorMetrics = Record<MilestoneType, number>;
+
+type MilestoneRow = {
+  id: string;
+  creator_id: string;
+  type: MilestoneType;
+  target: string | number;
+  title: string;
+  reward_description: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function mapTarget(value: string | number) {
+  return typeof value === "number" ? value : Number(value);
+}
+
+async function getCreatorMetrics(username: string): Promise<{
+  creatorId: string;
+  creatorUsername: string;
+  metrics: CreatorMetrics;
+} | null> {
+  const { rows } = await sql`
+    SELECT
+      u.id,
+      u.username,
+      COALESCE(u.total_tips_received, 0) AS total_tips_received,
+      COALESCE(u.current_viewers, 0) AS current_viewers,
+      (
+        SELECT COUNT(*)::int
+        FROM user_follows uf
+        WHERE uf.followee_id = u.id
+      ) AS follower_count
+    FROM users u
+    WHERE LOWER(u.username) = LOWER(${username})
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const row = rows[0];
+
+  return {
+    creatorId: row.id,
+    creatorUsername: row.username,
+    metrics: {
+      sub_count: Number(row.follower_count ?? 0),
+      tip_amount: Number(row.total_tips_received ?? 0),
+      viewer_count: Number(row.current_viewers ?? 0),
+    },
+  };
+}
+
+function withProgress(row: MilestoneRow, metrics: CreatorMetrics) {
+  const progress = metrics[row.type] ?? 0;
+  const target = mapTarget(row.target);
+
+  return {
+    ...row,
+    target,
+    progress,
+    is_completed: Boolean(row.completed_at) || progress >= target,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, listMilestonesQuerySchema);
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    await ensureMilestonesSchema();
+
+    const creator = await getCreatorMetrics(queryResult.data.creator);
+    if (!creator) {
+      return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+    }
+
+    const { rows } = await sql`
+      SELECT id, creator_id, type, target, title, reward_description, completed_at, created_at, updated_at
+      FROM route_f_milestones
+      WHERE creator_id = ${creator.creatorId}
+      ORDER BY created_at DESC
+    `;
+
+    const milestones = rows.map(row =>
+      withProgress(row as MilestoneRow, creator.metrics)
+    );
+
+    await Promise.all(
+      milestones
+        .filter(
+          milestone =>
+            !milestone.completed_at && milestone.progress >= milestone.target
+        )
+        .map(
+          milestone =>
+            sql`
+            UPDATE route_f_milestones
+            SET completed_at = now(), updated_at = now()
+            WHERE id = ${milestone.id} AND completed_at IS NULL
+          `
+        )
+    );
+
+    const normalized = milestones.map(milestone => ({
+      ...milestone,
+      completed_at:
+        milestone.completed_at ??
+        (milestone.progress >= milestone.target
+          ? new Date().toISOString()
+          : null),
+    }));
+
+    return NextResponse.json({
+      creator: creator.creatorUsername,
+      metrics: creator.metrics,
+      active: normalized.filter(milestone => !milestone.completed_at),
+      completed: normalized.filter(milestone =>
+        Boolean(milestone.completed_at)
+      ),
+    });
+  } catch (error) {
+    console.error("[milestones] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createMilestoneSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { type, target, title, reward_description } = bodyResult.data;
+
+  try {
+    await ensureMilestonesSchema();
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS active_count
+      FROM route_f_milestones
+      WHERE creator_id = ${session.userId}
+        AND completed_at IS NULL
+    `;
+
+    if (Number(countRows[0]?.active_count ?? 0) >= 5) {
+      return NextResponse.json(
+        { error: "Creators may only have 5 active milestones" },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_milestones (creator_id, type, target, title, reward_description)
+      VALUES (${session.userId}, ${type}, ${target}, ${title}, ${reward_description ?? null})
+      RETURNING id, creator_id, type, target, title, reward_description, completed_at, created_at, updated_at
+    `;
+
+    return NextResponse.json(
+      {
+        ...rows[0],
+        target: Number(rows[0].target),
+        progress: 0,
+        is_completed: false,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[milestones] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Closes #456
Closes #457
Closes #462
Closes #464

## Summary
- add creator alert configuration and test alert delivery endpoints
- add creator milestone CRUD plus live progress tracking from current platform metrics
- add clip emoji reaction endpoints with per-user uniqueness and aggregated counts
- add curated collection CRUD plus collection item management for recordings/clips
- update the existing jobs dynamic route to the Next 16 promise-based params signature so production build passes

## Testing
- npm test -- app/api/routes-f/alerts/__tests__/route.test.ts app/api/routes-f/milestones/__tests__/route.test.ts app/api/routes-f/clips/reactions/__tests__/route.test.ts app/api/routes-f/collections/__tests__/route.test.ts
- npm run type-check
- npm run lint
- npm run format:check
- npm run build