### PR TITLE
feat: add routes-f highlights, invites, templates, and analytics endpoints

### DIFF
--- a/app/api/routes-f/analytics/__tests__/route.test.ts
+++ b/app/api/routes-f/analytics/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureAnalyticsSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const STREAM_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    verifySessionMock.mockResolvedValue({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/analytics"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns aggregated watch analytics", async () => {
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "viewer-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "viewer",
+      email: "viewer@example.com",
+    });
+
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [{ total_watch_time: 3600, sessions_count: 4 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ category: "Tech", watch_time: 1800, sessions: 2 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            stream_id: STREAM_ID,
+            username: "alice",
+            avatar: null,
+            watch_time: 1800,
+            sessions: 2,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ bucket: "2026-03-28", watch_time: 1200, sessions: 1 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ bucket: "2026-03-24", watch_time: 2400, sessions: 3 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ bucket: "2026-03", watch_time: 3600, sessions: 4 }],
+      });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/analytics"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.total_watch_time).toBe(3600);
+    expect(json.top_streams).toHaveLength(1);
+  });
+
+  it("records a watch event", async () => {
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "viewer-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "viewer",
+      email: "viewer@example.com",
+    });
+
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: STREAM_ID }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "event-id",
+            user_id: "viewer-id",
+            stream_id: STREAM_ID,
+            duration_seconds: 120,
+            category: "Tech",
+            watched_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/analytics", {
+        stream_id: STREAM_ID,
+        duration_seconds: 120,
+        category: "Tech",
+      })
+    );
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/app/api/routes-f/analytics/_lib/db.ts
+++ b/app/api/routes-f/analytics/_lib/db.ts
@@ -1,0 +1,24 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureAnalyticsSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_watch_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      stream_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      duration_seconds INTEGER NOT NULL,
+      category VARCHAR(80) NOT NULL,
+      watched_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_watch_events_user_time
+      ON route_f_watch_events (user_id, watched_at DESC)
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_watch_events_stream_time
+      ON route_f_watch_events (stream_id, watched_at DESC)
+  `;
+}

--- a/app/api/routes-f/analytics/route.ts
+++ b/app/api/routes-f/analytics/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureAnalyticsSchema } from "./_lib/db";
+
+const createWatchEventSchema = z.object({
+  stream_id: uuidSchema,
+  duration_seconds: z.number().int().min(1).max(86400),
+  category: z.string().trim().min(1).max(80),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureAnalyticsSchema();
+
+    const [
+      summaryResult,
+      topCategoriesResult,
+      topStreamsResult,
+      dailyResult,
+      weeklyResult,
+      monthlyResult,
+    ] = await Promise.all([
+      sql`
+        SELECT
+          COALESCE(SUM(duration_seconds), 0)::int AS total_watch_time,
+          COUNT(*)::int AS sessions_count
+        FROM route_f_watch_events
+        WHERE user_id = ${session.userId}
+      `,
+      sql`
+        SELECT
+          category,
+          COALESCE(SUM(duration_seconds), 0)::int AS watch_time,
+          COUNT(*)::int AS sessions
+        FROM route_f_watch_events
+        WHERE user_id = ${session.userId}
+        GROUP BY category
+        ORDER BY watch_time DESC, sessions DESC, category ASC
+        LIMIT 5
+      `,
+      sql`
+        SELECT
+          e.stream_id,
+          u.username,
+          u.avatar,
+          COALESCE(SUM(e.duration_seconds), 0)::int AS watch_time,
+          COUNT(*)::int AS sessions
+        FROM route_f_watch_events e
+        JOIN users u ON u.id = e.stream_id
+        WHERE e.user_id = ${session.userId}
+        GROUP BY e.stream_id, u.username, u.avatar
+        ORDER BY watch_time DESC, sessions DESC, u.username ASC
+        LIMIT 5
+      `,
+      sql`
+        SELECT
+          TO_CHAR(date_trunc('day', watched_at), 'YYYY-MM-DD') AS bucket,
+          COALESCE(SUM(duration_seconds), 0)::int AS watch_time,
+          COUNT(*)::int AS sessions
+        FROM route_f_watch_events
+        WHERE user_id = ${session.userId}
+        GROUP BY date_trunc('day', watched_at)
+        ORDER BY date_trunc('day', watched_at) DESC
+        LIMIT 30
+      `,
+      sql`
+        SELECT
+          TO_CHAR(date_trunc('week', watched_at), 'YYYY-MM-DD') AS bucket,
+          COALESCE(SUM(duration_seconds), 0)::int AS watch_time,
+          COUNT(*)::int AS sessions
+        FROM route_f_watch_events
+        WHERE user_id = ${session.userId}
+        GROUP BY date_trunc('week', watched_at)
+        ORDER BY date_trunc('week', watched_at) DESC
+        LIMIT 12
+      `,
+      sql`
+        SELECT
+          TO_CHAR(date_trunc('month', watched_at), 'YYYY-MM') AS bucket,
+          COALESCE(SUM(duration_seconds), 0)::int AS watch_time,
+          COUNT(*)::int AS sessions
+        FROM route_f_watch_events
+        WHERE user_id = ${session.userId}
+        GROUP BY date_trunc('month', watched_at)
+        ORDER BY date_trunc('month', watched_at) DESC
+        LIMIT 12
+      `,
+    ]);
+
+    const summary = summaryResult.rows[0] ?? {
+      total_watch_time: 0,
+      sessions_count: 0,
+    };
+
+    return NextResponse.json({
+      total_watch_time: summary.total_watch_time,
+      sessions_count: summary.sessions_count,
+      top_categories: topCategoriesResult.rows,
+      top_streams: topStreamsResult.rows,
+      watch_time_by_period: {
+        day: dailyResult.rows,
+        week: weeklyResult.rows,
+        month: monthlyResult.rows,
+      },
+    });
+  } catch (error) {
+    console.error("[analytics] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createWatchEventSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { stream_id, duration_seconds, category } = bodyResult.data;
+
+  try {
+    await ensureAnalyticsSchema();
+
+    const { rows: streamRows } = await sql`
+      SELECT id FROM users WHERE id = ${stream_id} LIMIT 1
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_watch_events (
+        user_id,
+        stream_id,
+        duration_seconds,
+        category
+      )
+      VALUES (
+        ${session.userId},
+        ${stream_id},
+        ${duration_seconds},
+        ${category}
+      )
+      RETURNING id, user_id, stream_id, duration_seconds, category, watched_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[analytics] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/announcements/[id]/route.ts
+++ b/app/api/routes-f/announcements/[id]/route.ts
@@ -8,14 +8,14 @@ import { ensureRoutesFSchema } from "../../_lib/schema";
  */
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await ensureRoutesFSchema();
     const session = await verifySession(req);
     if (!session.ok) return session.response;
 
-    const { id } = params;
+    const { id } = await params;
 
     const { rows } = await sql`
       SELECT creator_id FROM announcements WHERE id = ${id}
@@ -23,11 +23,18 @@ export async function DELETE(
     `;
 
     if (rows.length === 0) {
-      return NextResponse.json({ error: "Announcement not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Announcement not found" },
+        { status: 404 }
+      );
     }
 
     const announcement = rows[0];
-    const ownershipError = assertOwnership(session, null, announcement.creator_id);
+    const ownershipError = assertOwnership(
+      session,
+      null,
+      announcement.creator_id
+    );
     if (ownershipError) return ownershipError;
 
     await sql`DELETE FROM announcements WHERE id = ${id}`;
@@ -35,6 +42,9 @@ export async function DELETE(
     return NextResponse.json({ message: "Announcement deleted successfully" });
   } catch (error) {
     console.error("Announcement DELETE error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/routes-f/comments/[id]/route.ts
+++ b/app/api/routes-f/comments/[id]/route.ts
@@ -8,14 +8,14 @@ import { ensureRoutesFSchema } from "../../_lib/schema";
  */
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await ensureRoutesFSchema();
     const session = await verifySession(req);
     if (!session.ok) return session.response;
 
-    const { id } = params;
+    const { id } = await params;
 
     // Fetch comment and associated recording creator
     const { rows } = await sql`
@@ -45,6 +45,9 @@ export async function DELETE(
     return NextResponse.json({ message: "Comment deleted successfully" });
   } catch (error) {
     console.error("Comment DELETE error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/routes-f/highlights/[id]/route.ts
+++ b/app/api/routes-f/highlights/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { ensureHighlightsSchema } from "../_lib/db";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: RouteContext
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    await ensureHighlightsSchema();
+
+    const { rows } = await sql`
+      DELETE FROM route_f_highlights
+      WHERE id = ${id} AND user_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Highlight not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ deleted: true, id });
+  } catch (error) {
+    console.error("[highlights] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/highlights/__tests__/route.test.ts
+++ b/app/api/routes-f/highlights/__tests__/route.test.ts
@@ -1,0 +1,150 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureHighlightsSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../highlights/_lib/db", () => ({
+  ensureHighlightsSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { DELETE } from "../[id]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const RECORDING_ID = "550e8400-e29b-41d4-a716-446655440000";
+const HIGHLIGHT_ID = "550e8400-e29b-41d4-a716-446655440001";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f highlights", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "user-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "alice",
+      email: "alice@example.com",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lists the authenticated creator's highlights", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: HIGHLIGHT_ID,
+          recording_id: RECORDING_ID,
+          title: "Big moment",
+        },
+      ],
+    });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/highlights"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.highlights).toHaveLength(1);
+  });
+
+  it("rejects clips longer than 90 seconds", async () => {
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/highlights", {
+        recording_id: RECORDING_ID,
+        start_offset: 0,
+        end_offset: 91,
+        title: "Too long",
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a highlight with a playback URL", async () => {
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: RECORDING_ID,
+            user_id: "user-id",
+            playback_id: "mux-playback",
+            duration: 180,
+            title: "Recording",
+            status: "ready",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: HIGHLIGHT_ID,
+            recording_id: RECORDING_ID,
+            user_id: "user-id",
+            title: "Big moment",
+            start_offset: 5,
+            end_offset: 45,
+            playback_url:
+              "https://stream.mux.com/mux-playback.m3u8?asset_type=clip&start=5&end=45",
+            created_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/highlights", {
+        recording_id: RECORDING_ID,
+        start_offset: 5,
+        end_offset: 45,
+        title: "Big moment",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.playback_url).toContain("asset_type=clip");
+  });
+
+  it("deletes a highlight owned by the current creator", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: HIGHLIGHT_ID }],
+    });
+
+    const res = await DELETE(
+      makeRequest("DELETE", `/api/routes-f/highlights/${HIGHLIGHT_ID}`),
+      { params: Promise.resolve({ id: HIGHLIGHT_ID }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/routes-f/highlights/_lib/db.ts
+++ b/app/api/routes-f/highlights/_lib/db.ts
@@ -1,0 +1,26 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureHighlightsSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_highlights (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      recording_id UUID NOT NULL REFERENCES stream_recordings(id) ON DELETE CASCADE,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      title VARCHAR(120) NOT NULL,
+      start_offset INTEGER NOT NULL,
+      end_offset INTEGER NOT NULL,
+      playback_url TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_highlights_user_created
+      ON route_f_highlights (user_id, created_at DESC)
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_highlights_recording
+      ON route_f_highlights (recording_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/highlights/route.ts
+++ b/app/api/routes-f/highlights/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureHighlightsSchema } from "./_lib/db";
+
+const MAX_CLIP_LENGTH_SECONDS = 90;
+
+const createHighlightSchema = z.object({
+  recording_id: uuidSchema,
+  start_offset: z.number().int().min(0),
+  end_offset: z.number().int().min(1),
+  title: z.string().trim().min(1).max(120),
+});
+
+function buildPlaybackUrl(
+  playbackId: string,
+  startOffset: number,
+  endOffset: number
+): string {
+  const params = new URLSearchParams({
+    asset_type: "clip",
+    start: String(startOffset),
+    end: String(endOffset),
+  });
+
+  return `https://stream.mux.com/${playbackId}.m3u8?${params.toString()}`;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureHighlightsSchema();
+
+    const { rows } = await sql`
+      SELECT
+        h.id,
+        h.recording_id,
+        h.title,
+        h.start_offset,
+        h.end_offset,
+        h.playback_url,
+        h.created_at,
+        r.playback_id,
+        r.duration,
+        r.title AS recording_title
+      FROM route_f_highlights h
+      JOIN stream_recordings r ON r.id = h.recording_id
+      WHERE h.user_id = ${session.userId}
+      ORDER BY h.created_at DESC
+    `;
+
+    return NextResponse.json({ highlights: rows });
+  } catch (error) {
+    console.error("[highlights] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createHighlightSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { recording_id, start_offset, end_offset, title } = bodyResult.data;
+
+  if (start_offset >= end_offset) {
+    return NextResponse.json(
+      { error: "start_offset must be less than end_offset" },
+      { status: 400 }
+    );
+  }
+
+  if (end_offset - start_offset > MAX_CLIP_LENGTH_SECONDS) {
+    return NextResponse.json(
+      {
+        error: `Highlight clips may not exceed ${MAX_CLIP_LENGTH_SECONDS} seconds`,
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureHighlightsSchema();
+
+    const { rows: recordingRows } = await sql`
+      SELECT id, user_id, playback_id, duration, title, status
+      FROM stream_recordings
+      WHERE id = ${recording_id}
+      LIMIT 1
+    `;
+
+    if (recordingRows.length === 0) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    const recording = recordingRows[0];
+
+    if (recording.user_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (!recording.playback_id) {
+      return NextResponse.json(
+        { error: "Recording playback is not ready" },
+        { status: 409 }
+      );
+    }
+
+    if (
+      typeof recording.duration === "number" &&
+      end_offset > recording.duration
+    ) {
+      return NextResponse.json(
+        { error: "end_offset exceeds recording duration" },
+        { status: 400 }
+      );
+    }
+
+    const playbackUrl = buildPlaybackUrl(
+      recording.playback_id,
+      start_offset,
+      end_offset
+    );
+
+    const { rows } = await sql`
+      INSERT INTO route_f_highlights (
+        recording_id,
+        user_id,
+        title,
+        start_offset,
+        end_offset,
+        playback_url
+      )
+      VALUES (
+        ${recording_id},
+        ${session.userId},
+        ${title},
+        ${start_offset},
+        ${end_offset},
+        ${playbackUrl}
+      )
+      RETURNING id, recording_id, user_id, title, start_offset, end_offset, playback_url, created_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[highlights] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/invites/[code]/route.ts
+++ b/app/api/routes-f/invites/[code]/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { ensureInvitesSchema } from "../_lib/db";
+
+type RouteContext = {
+  params: Promise<{ code: string }>;
+};
+
+type InviteLookupRow = {
+  code: string;
+  stream_id: string;
+  creator_id: string;
+  max_uses: number;
+  use_count: number;
+  expires_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+  username: string;
+  avatar: string | null;
+  is_live: boolean | null;
+  creator: {
+    streamTitle?: string;
+    category?: string;
+    tags?: string[];
+    description?: string;
+  } | null;
+};
+
+function normalizeCode(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function isCodeUnavailable(invite: {
+  revoked_at: string | null;
+  expires_at: string | null;
+  use_count: number;
+  max_uses: number;
+}): boolean {
+  if (invite.revoked_at) {
+    return true;
+  }
+
+  if (
+    invite.expires_at &&
+    new Date(invite.expires_at).getTime() <= Date.now()
+  ) {
+    return true;
+  }
+
+  return invite.use_count >= invite.max_uses;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: RouteContext
+): Promise<NextResponse> {
+  const { code } = await params;
+  const normalizedCode = normalizeCode(code);
+
+  if (!/^[A-Z0-9]{8}$/.test(normalizedCode)) {
+    return NextResponse.json({ error: "Invalid invite code" }, { status: 400 });
+  }
+
+  try {
+    await ensureInvitesSchema();
+
+    const { rows } = await sql`
+      SELECT
+        i.code,
+        i.stream_id,
+        i.creator_id,
+        i.max_uses,
+        i.use_count,
+        i.expires_at,
+        i.revoked_at,
+        i.created_at,
+        u.username,
+        u.avatar,
+        u.is_live,
+        u.creator
+      FROM route_f_stream_invites i
+      JOIN users u ON u.id = i.stream_id
+      WHERE i.code = ${normalizedCode}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+    }
+
+    const invite = rows[0] as InviteLookupRow;
+
+    if (isCodeUnavailable(invite)) {
+      return NextResponse.json(
+        { error: "Invite code has expired or been exhausted" },
+        { status: 410 }
+      );
+    }
+
+    const creator = invite.creator ?? {};
+
+    return NextResponse.json({
+      code: invite.code,
+      remaining_uses: Math.max(invite.max_uses - invite.use_count, 0),
+      expires_at: invite.expires_at,
+      stream: {
+        id: invite.stream_id,
+        username: invite.username,
+        avatar: invite.avatar,
+        is_live: invite.is_live ?? false,
+        title: creator.streamTitle ?? "Untitled Stream",
+        category: creator.category ?? "",
+        tags: creator.tags ?? [],
+        description: creator.description ?? "",
+      },
+    });
+  } catch (error) {
+    console.error("[invites] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: RouteContext
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { code } = await params;
+  const normalizedCode = normalizeCode(code);
+
+  try {
+    await ensureInvitesSchema();
+
+    const { rows } = await sql`
+      UPDATE route_f_stream_invites
+      SET revoked_at = now(), updated_at = now()
+      WHERE code = ${normalizedCode} AND creator_id = ${session.userId}
+      RETURNING code
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ revoked: true, code: normalizedCode });
+  } catch (error) {
+    console.error("[invites] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/invites/__tests__/route.test.ts
+++ b/app/api/routes-f/invites/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureInvitesSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../invites/_lib/db", () => ({
+  ensureInvitesSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { POST } from "../route";
+import { GET, DELETE } from "../[code]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const STREAM_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f invites", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: STREAM_ID,
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "alice",
+      email: "alice@example.com",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("creates an invite code for the creator's stream", async () => {
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: STREAM_ID,
+            username: "alice",
+            avatar: null,
+            creator: { streamTitle: "Live coding" },
+            is_live: true,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            code: "ABCD1234",
+            stream_id: STREAM_ID,
+            creator_id: STREAM_ID,
+            max_uses: 5,
+            use_count: 0,
+            expires_at: null,
+            created_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/invites", {
+        stream_id: STREAM_ID,
+        max_uses: 5,
+      })
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 410 for an expired invite code", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          code: "ABCD1234",
+          stream_id: STREAM_ID,
+          creator_id: STREAM_ID,
+          max_uses: 5,
+          use_count: 0,
+          expires_at: "2020-01-01T00:00:00.000Z",
+          revoked_at: null,
+          created_at: "2026-03-28T00:00:00Z",
+          username: "alice",
+          avatar: null,
+          is_live: true,
+          creator: { streamTitle: "Live coding" },
+        },
+      ],
+    });
+
+    const res = await GET(
+      makeRequest("GET", "/api/routes-f/invites/ABCD1234"),
+      {
+        params: Promise.resolve({ code: "ABCD1234" }),
+      }
+    );
+
+    expect(res.status).toBe(410);
+  });
+
+  it("revokes an invite code for the creator", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ code: "ABCD1234" }],
+    });
+
+    const res = await DELETE(
+      makeRequest("DELETE", "/api/routes-f/invites/ABCD1234"),
+      { params: Promise.resolve({ code: "ABCD1234" }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.revoked).toBe(true);
+  });
+});

--- a/app/api/routes-f/invites/_lib/db.ts
+++ b/app/api/routes-f/invites/_lib/db.ts
@@ -1,0 +1,27 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureInvitesSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_invites (
+      code VARCHAR(8) PRIMARY KEY,
+      stream_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      max_uses INTEGER NOT NULL,
+      use_count INTEGER NOT NULL DEFAULT 0,
+      expires_at TIMESTAMPTZ,
+      revoked_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_invites_creator_created
+      ON route_f_stream_invites (creator_id, created_at DESC)
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_invites_stream
+      ON route_f_stream_invites (stream_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/invites/route.ts
+++ b/app/api/routes-f/invites/route.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureInvitesSchema } from "./_lib/db";
+
+const INVITE_CODE_LENGTH = 8;
+const INVITE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+const createInviteSchema = z.object({
+  stream_id: uuidSchema,
+  max_uses: z.number().int().min(1).max(10000),
+  expires_at: z.string().datetime({ offset: true }).optional(),
+});
+
+function generateInviteCode(): string {
+  const bytes = randomBytes(INVITE_CODE_LENGTH);
+  let code = "";
+
+  for (let index = 0; index < INVITE_CODE_LENGTH; index += 1) {
+    code += INVITE_ALPHABET[bytes[index] % INVITE_ALPHABET.length];
+  }
+
+  return code;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createInviteSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { stream_id, max_uses, expires_at } = bodyResult.data;
+
+  if (expires_at && new Date(expires_at).getTime() <= Date.now()) {
+    return NextResponse.json(
+      { error: "expires_at must be in the future" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureInvitesSchema();
+
+    const { rows: streamRows } = await sql`
+      SELECT id, username, avatar, creator, is_live
+      FROM users
+      WHERE id = ${stream_id}
+      LIMIT 1
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+    }
+
+    if (streamRows[0].id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const code = generateInviteCode();
+
+      try {
+        const { rows } = await sql`
+          INSERT INTO route_f_stream_invites (
+            code,
+            stream_id,
+            creator_id,
+            max_uses,
+            expires_at
+          )
+          VALUES (
+            ${code},
+            ${stream_id},
+            ${session.userId},
+            ${max_uses},
+            ${expires_at ?? null}
+          )
+          RETURNING code, stream_id, creator_id, max_uses, use_count, expires_at, created_at
+        `;
+
+        return NextResponse.json(rows[0], { status: 201 });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          String((error as { code?: string }).code) === "23505"
+        ) {
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    return NextResponse.json(
+      { error: "Failed to generate a unique invite code" },
+      { status: 500 }
+    );
+  } catch (error) {
+    console.error("[invites] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/live/chat/[messageId]/route.ts
+++ b/app/api/routes-f/live/chat/[messageId]/route.ts
@@ -7,12 +7,13 @@ import { verifySession } from "@/lib/auth/verify-session";
 // (currently: stream owner only — moderator table can extend this later).
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { messageId: string } }
+  { params }: { params: Promise<{ messageId: string }> }
 ) {
   const session = await verifySession(req);
   if (!session.ok) return session.response;
 
-  const messageId = parseInt(params.messageId, 10);
+  const { messageId: rawMessageId } = await params;
+  const messageId = parseInt(rawMessageId, 10);
   if (isNaN(messageId)) {
     return NextResponse.json({ error: "Invalid message ID" }, { status: 400 });
   }

--- a/app/api/routes-f/subscriptions/[id]/route.ts
+++ b/app/api/routes-f/subscriptions/[id]/route.ts
@@ -8,14 +8,14 @@ import { ensureRoutesFSchema } from "../../_lib/schema";
  */
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await ensureRoutesFSchema();
     const session = await verifySession(req);
     if (!session.ok) return session.response;
 
-    const { id } = params;
+    const { id } = await params;
 
     const { rows } = await sql`
       SELECT user_id, status FROM subscriptions WHERE id = ${id}
@@ -23,14 +23,17 @@ export async function DELETE(
     `;
 
     if (rows.length === 0) {
-      return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Subscription not found" },
+        { status: 404 }
+      );
     }
 
     const subscription = rows[0];
     const ownershipError = assertOwnership(session, null, subscription.user_id);
     if (ownershipError) return ownershipError;
 
-    if (subscription.status === 'cancelled') {
+    if (subscription.status === "cancelled") {
       return NextResponse.json({ message: "Subscription already cancelled" });
     }
 
@@ -38,9 +41,14 @@ export async function DELETE(
       UPDATE subscriptions SET status = 'cancelled' WHERE id = ${id}
     `;
 
-    return NextResponse.json({ message: "Subscription cancelled successfully" });
+    return NextResponse.json({
+      message: "Subscription cancelled successfully",
+    });
   } catch (error) {
     console.error("Subscription DELETE error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/routes-f/templates/[id]/route.ts
+++ b/app/api/routes-f/templates/[id]/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureTemplatesSchema } from "../_lib/db";
+
+const updateTemplateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(50).optional(),
+    title: z.string().trim().min(1).max(140).optional(),
+    category: z.string().trim().max(80).optional(),
+    tags: z.array(z.string().trim().min(1).max(25)).max(5).optional(),
+    description: z.string().trim().max(500).optional(),
+  })
+  .refine(value => Object.keys(value).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: RouteContext
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updateTemplateSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { id } = await params;
+  const { name, title, category, tags, description } = bodyResult.data;
+
+  try {
+    await ensureTemplatesSchema();
+
+    const { rows: existingRows } = await sql`
+      SELECT id, name, title, category, tags, description
+      FROM route_f_stream_templates
+      WHERE id = ${id} AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (existingRows.length === 0) {
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 }
+      );
+    }
+
+    if (name) {
+      const { rows: duplicateRows } = await sql`
+        SELECT id
+        FROM route_f_stream_templates
+        WHERE user_id = ${session.userId}
+          AND LOWER(name) = LOWER(${name})
+          AND id <> ${id}
+        LIMIT 1
+      `;
+
+      if (duplicateRows.length > 0) {
+        return NextResponse.json(
+          { error: "Template name must be unique per creator" },
+          { status: 409 }
+        );
+      }
+    }
+
+    const existing = existingRows[0];
+    const nextName = name ?? existing.name;
+    const nextTitle = title ?? existing.title;
+    const nextCategory = category ?? existing.category;
+    const nextTags = tags ?? existing.tags ?? [];
+    const nextDescription = description ?? existing.description;
+
+    const { rows } = await sql`
+      UPDATE route_f_stream_templates
+      SET
+        name = ${nextName},
+        title = ${nextTitle},
+        category = ${nextCategory || null},
+        tags = ${JSON.stringify(nextTags)},
+        description = ${nextDescription || null},
+        updated_at = now()
+      WHERE id = ${id} AND user_id = ${session.userId}
+      RETURNING id, user_id, name, title, category, tags, description, created_at, updated_at
+    `;
+
+    return NextResponse.json(rows[0]);
+  } catch (error) {
+    console.error("[templates] PATCH error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: RouteContext
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    await ensureTemplatesSchema();
+
+    const { rows } = await sql`
+      DELETE FROM route_f_stream_templates
+      WHERE id = ${id} AND user_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ deleted: true, id });
+  } catch (error) {
+    console.error("[templates] DELETE error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/templates/__tests__/route.test.ts
+++ b/app/api/routes-f/templates/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("../_lib/db", () => ({
+  ensureTemplatesSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../templates/_lib/db", () => ({
+  ensureTemplatesSchema: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { PATCH, DELETE } from "../[id]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const TEMPLATE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f templates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "user-id",
+      wallet: null,
+      privyId: "did:privy:abc",
+      username: "alice",
+      email: "alice@example.com",
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lists saved templates for the authenticated creator", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: TEMPLATE_ID, name: "Default setup" }],
+    });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/templates"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.templates).toHaveLength(1);
+  });
+
+  it("rejects creating more than 10 templates", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ template_count: 10 }],
+    });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/templates", {
+        name: "Default setup",
+        title: "My stream",
+        category: "Tech",
+        tags: ["nextjs"],
+        description: "Test",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("updates a template", async () => {
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: TEMPLATE_ID,
+            name: "Default setup",
+            title: "Old title",
+            category: "Tech",
+            tags: ["nextjs"],
+            description: "Old",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: TEMPLATE_ID,
+            user_id: "user-id",
+            name: "Default setup",
+            title: "New title",
+            category: "Tech",
+            tags: ["nextjs"],
+            description: "Old",
+            created_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T01:00:00Z",
+          },
+        ],
+      });
+
+    const res = await PATCH(
+      makeRequest("PATCH", `/api/routes-f/templates/${TEMPLATE_ID}`, {
+        title: "New title",
+      }),
+      { params: Promise.resolve({ id: TEMPLATE_ID }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.title).toBe("New title");
+  });
+
+  it("deletes a template", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: TEMPLATE_ID }] });
+
+    const res = await DELETE(
+      makeRequest("DELETE", `/api/routes-f/templates/${TEMPLATE_ID}`),
+      { params: Promise.resolve({ id: TEMPLATE_ID }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/routes-f/templates/_lib/db.ts
+++ b/app/api/routes-f/templates/_lib/db.ts
@@ -1,0 +1,27 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureTemplatesSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_templates (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name VARCHAR(50) NOT NULL,
+      title VARCHAR(140) NOT NULL,
+      category VARCHAR(80),
+      tags JSONB NOT NULL DEFAULT '[]'::jsonb,
+      description TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_route_f_stream_templates_user_name
+      ON route_f_stream_templates (user_id, LOWER(name))
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_templates_user_created
+      ON route_f_stream_templates (user_id, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/templates/route.ts
+++ b/app/api/routes-f/templates/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureTemplatesSchema } from "./_lib/db";
+
+const TAG_LIMIT = 5;
+const TAG_LENGTH_LIMIT = 25;
+const TEMPLATE_LIMIT = 10;
+
+const tagsSchema = z
+  .array(z.string().trim().min(1).max(TAG_LENGTH_LIMIT))
+  .max(TAG_LIMIT);
+
+const createTemplateSchema = z.object({
+  name: z.string().trim().min(1).max(50),
+  title: z.string().trim().min(1).max(140),
+  category: z.string().trim().max(80).optional().default(""),
+  tags: tagsSchema.optional().default([]),
+  description: z.string().trim().max(500).optional().default(""),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureTemplatesSchema();
+
+    const { rows } = await sql`
+      SELECT id, name, title, category, tags, description, created_at, updated_at
+      FROM route_f_stream_templates
+      WHERE user_id = ${session.userId}
+      ORDER BY created_at DESC
+    `;
+
+    return NextResponse.json({ templates: rows });
+  } catch (error) {
+    console.error("[templates] GET error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createTemplateSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { name, title, category, tags, description } = bodyResult.data;
+
+  try {
+    await ensureTemplatesSchema();
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS template_count
+      FROM route_f_stream_templates
+      WHERE user_id = ${session.userId}
+    `;
+
+    if (Number(countRows[0]?.template_count ?? 0) >= TEMPLATE_LIMIT) {
+      return NextResponse.json(
+        { error: `Creators may only have ${TEMPLATE_LIMIT} templates` },
+        { status: 409 }
+      );
+    }
+
+    const { rows: duplicateRows } = await sql`
+      SELECT id
+      FROM route_f_stream_templates
+      WHERE user_id = ${session.userId}
+        AND LOWER(name) = LOWER(${name})
+      LIMIT 1
+    `;
+
+    if (duplicateRows.length > 0) {
+      return NextResponse.json(
+        { error: "Template name must be unique per creator" },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_stream_templates (
+        user_id,
+        name,
+        title,
+        category,
+        tags,
+        description
+      )
+      VALUES (
+        ${session.userId},
+        ${name},
+        ${title},
+        ${category || null},
+        ${JSON.stringify(tags)},
+        ${description || null}
+      )
+      RETURNING id, user_id, name, title, category, tags, description, created_at, updated_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[templates] POST error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Description
Implemented the new `routes-f` creator utility endpoints for auto-generated highlights, invite codes, saved stream templates, and viewer watch analytics, including table bootstrap helpers and focused test coverage.

Closes #427
Closes #429
Closes #431
Closes #444

## Changes proposed

### What were you told to do?
Add the standalone `routes-f` endpoints for highlight generation, stream invite codes, stream title/tag templates, and per-viewer watch analytics, with the ownership, validation, response-shape, and storage rules described in the linked issues.

### What did I do?
#### Added the new routes-f endpoint groups
- Added `app/api/routes-f/highlights` with list, create, and delete handlers for creator-owned recording highlights.
- Added `app/api/routes-f/invites` with invite generation, validation, and revoke flows using 8-character URL-safe codes.
- Added `app/api/routes-f/templates` with list, create, update, and delete handlers for saved stream setup templates.
- Added `app/api/routes-f/analytics` with watch event ingestion plus aggregated day, week, and month analytics for the authenticated viewer.

#### Added persistence, validation, and guardrails
- Added feature-local schema bootstrap helpers under each route group using `@vercel/postgres`.
- Enforced creator ownership checks, offset and clip-length limits, template count and uniqueness limits, tag constraints, invite expiry and exhaustion checks, and analytics payload validation.
- Returned generated highlight playback URLs from Mux playback IDs and included top streams, top categories, and period buckets in analytics responses.

#### Added verification coverage and required compatibility fixes
- Added focused Jest coverage for the four new endpoint groups.
- Updated four existing dynamic `routes-f` handlers to Next 16's promised `params` signature so the repository build hook could pass without bypassing hooks.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [ ] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with `npx jest app/api/routes-f/highlights/__tests__/route.test.ts app/api/routes-f/invites/__tests__/route.test.ts app/api/routes-f/templates/__tests__/route.test.ts app/api/routes-f/analytics/__tests__/route.test.ts --runInBand`, `npm run type-check`, and `npm run build`. Build completed successfully after aligning four pre-existing dynamic route handlers with Next 16's required `params: Promise<...>` signature.