### PR TITLE
feat: stream discovery and SEO improvements (#366)

### DIFF
--- a/app/[username]/watch/layout.tsx
+++ b/app/[username]/watch/layout.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+import { sql } from "@vercel/postgres";
+import React from "react";
+
+const BASE = process.env.NEXT_PUBLIC_APP_URL || "https://streamfi.com";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}): Promise<Metadata> {
+  const { username } = await params;
+
+  let streamTitle = `${username} is live`;
+  let playbackId: string | null = null;
+
+  try {
+    const { rows } = await sql`
+      SELECT mux_playback_id, stream_title
+      FROM users
+      WHERE username = ${username}
+      LIMIT 1
+    `;
+    if (rows[0]) {
+      streamTitle = rows[0].stream_title || streamTitle;
+      playbackId = rows[0].mux_playback_id;
+    }
+  } catch {
+    // fallback to defaults
+  }
+
+  const title = `${streamTitle} — ${username} is live on StreamFi`;
+  const canonical = `${BASE}/${username}/watch`;
+  const ogImage = playbackId
+    ? `https://image.mux.com/${playbackId}/thumbnail.jpg`
+    : `${BASE}/Images/streamFi.png`;
+
+  return {
+    title,
+    description: `Watch ${username} stream live on StreamFi`,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description: `Watch ${username} stream live on StreamFi`,
+      url: canonical,
+      images: [{ url: ogImage, width: 1280, height: 720, alt: title }],
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: `Watch ${username} stream live on StreamFi`,
+      images: [ogImage],
+    },
+  };
+}
+
+export default function WatchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/[username]/watch/opengraph-image.tsx
+++ b/app/[username]/watch/opengraph-image.tsx
@@ -1,0 +1,158 @@
+import { ImageResponse } from "next/og";
+import { sql } from "@vercel/postgres";
+
+export const runtime = "edge";
+export const alt = "Live stream on StreamFi";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+
+  let playbackId: string | null = null;
+  let avatar: string | null = null;
+  let streamTitle = `${username} is live`;
+
+  try {
+    const { rows } = await sql`
+      SELECT avatar, mux_playback_id, stream_title
+      FROM users
+      WHERE username = ${username}
+      LIMIT 1
+    `;
+    if (rows[0]) {
+      avatar = rows[0].avatar;
+      playbackId = rows[0].mux_playback_id;
+      streamTitle = rows[0].stream_title || streamTitle;
+    }
+  } catch {
+    // use defaults
+  }
+
+  const bgImage = playbackId
+    ? `https://image.mux.com/${playbackId}/thumbnail.jpg`
+    : null;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          backgroundColor: "#0f0f0f",
+        }}
+      >
+        {bgImage && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={bgImage}
+            alt=""
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              opacity: 0.6,
+            }}
+          />
+        )}
+
+        {/* LIVE badge — top-left */}
+        <div
+          style={{
+            position: "absolute",
+            top: 32,
+            left: 32,
+            backgroundColor: "#e53e3e",
+            color: "white",
+            fontSize: 28,
+            fontWeight: 700,
+            padding: "8px 20px",
+            borderRadius: 8,
+            display: "flex",
+          }}
+        >
+          LIVE
+        </div>
+
+        {/* StreamFi wordmark — top-right */}
+        <div
+          style={{
+            position: "absolute",
+            top: 32,
+            right: 32,
+            color: "white",
+            fontSize: 28,
+            fontWeight: 700,
+            display: "flex",
+          }}
+        >
+          StreamFi
+        </div>
+
+        {/* Bottom gradient overlay with streamer info */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            padding: "60px 32px 44px",
+            background:
+              "linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+          }}
+        >
+          {/* Avatar + username row */}
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            {avatar && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={avatar}
+                alt=""
+                style={{
+                  width: 56,
+                  height: 56,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                }}
+              />
+            )}
+            <span style={{ color: "white", fontSize: 32, fontWeight: 600 }}>
+              {username}
+            </span>
+          </div>
+
+          {/* Stream title */}
+          <span style={{ color: "#e2e8f0", fontSize: 24, fontWeight: 400 }}>
+            {streamTitle}
+          </span>
+        </div>
+
+        {/* Purple bottom accent line */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 6,
+            backgroundColor: "#7c3aed",
+            display: "flex",
+          }}
+        />
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/browse/category/[title]/layout.tsx
+++ b/app/browse/category/[title]/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import React from "react";
+
+const BASE = process.env.NEXT_PUBLIC_APP_URL || "https://streamfi.com";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ title: string }>;
+}): Promise<Metadata> {
+  const { title } = await params;
+  const decodedTitle = decodeURIComponent(title);
+  const canonical = `${BASE}/browse/category/${title}`;
+
+  return {
+    title: `${decodedTitle} streams`,
+    description: `Watch the best ${decodedTitle} streams live on StreamFi`,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title: `${decodedTitle} streams — StreamFi`,
+      description: `Watch the best ${decodedTitle} streams live on StreamFi`,
+      url: canonical,
+      type: "website",
+    },
+  };
+}
+
+export default function CategoryTitleLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,64 @@
+import { sql } from "@vercel/postgres";
+import type { MetadataRoute } from "next";
+
+const BASE = process.env.NEXT_PUBLIC_APP_URL || "https://streamfi.com";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const statics: MetadataRoute.Sitemap = [
+    {
+      url: BASE,
+      lastModified: new Date(),
+      priority: 1.0,
+      changeFrequency: "daily",
+    },
+    {
+      url: `${BASE}/browse`,
+      lastModified: new Date(),
+      priority: 0.8,
+      changeFrequency: "hourly",
+    },
+    {
+      url: `${BASE}/explore`,
+      lastModified: new Date(),
+      priority: 0.8,
+      changeFrequency: "hourly",
+    },
+  ];
+
+  let userRoutes: MetadataRoute.Sitemap = [];
+  let clipRoutes: MetadataRoute.Sitemap = [];
+
+  try {
+    const { rows: userRows } = await sql`
+      SELECT username, updated_at
+      FROM users
+      ORDER BY created_at DESC
+      LIMIT 500
+    `;
+    userRoutes = userRows.map(u => ({
+      url: `${BASE}/${u.username}`,
+      lastModified: u.updated_at ? new Date(u.updated_at) : new Date(),
+      priority: 0.7,
+      changeFrequency: "daily" as const,
+    }));
+
+    const { rows: clipRows } = await sql`
+      SELECT r.id, u.username, r.updated_at
+      FROM stream_recordings r
+      JOIN users u ON u.id = r.user_id
+      WHERE r.status = 'ready'
+      ORDER BY r.created_at DESC
+      LIMIT 1000
+    `;
+    clipRoutes = clipRows.map(r => ({
+      url: `${BASE}/${r.username}/clips/${r.id}`,
+      lastModified: r.updated_at ? new Date(r.updated_at) : new Date(),
+      priority: 0.5,
+      changeFrequency: "monthly" as const,
+    }));
+  } catch {
+    // Return statics on DB error to avoid breaking the sitemap
+  }
+
+  return [...statics, ...userRoutes, ...clipRoutes];
+}


### PR DESCRIPTION
## Summary

- Add `app/[username]/watch/layout.tsx` with `generateMetadata` — title, OG image (Mux thumbnail), canonical URL in format `https://streamfi.com/{username}/watch`
- Add `app/[username]/watch/opengraph-image.tsx` — ImageResponse with red LIVE badge (top-left), StreamFi wordmark (top-right), Mux thumbnail background, streamer avatar + username row, stream title, purple bottom accent line
- Add `app/browse/category/[title]/layout.tsx` with `generateMetadata` including `alternates.canonical`
- Add `app/sitemap.ts` — dynamic sitemap including top 500 user profiles and up to 1000 public clip recordings from `stream_recordings`

## How to test

- Share a `/{username}/watch` link and verify the preview card shows a live badge, stream title, and Mux thumbnail
- Fetch `/sitemap.xml` and confirm user + clip routes appear
- Check category pages include a canonical link tag in the `<head>`

## Checklist

- [x] `app/[username]/watch/layout.tsx` with `generateMetadata`
- [x] `app/[username]/watch/opengraph-image.tsx` with LIVE badge + Mux thumbnail background
- [x] `app/browse/category/[title]/layout.tsx` has `alternates.canonical`
- [x] `app/sitemap.ts` includes public clip pages (up to 1000)

## Security Considerations

No user-controlled data is rendered unsanitised. SQL queries use parameterised `sql` template literals. OG image fallback is used if Mux playback ID is absent.

Fixes #366