### PR TITLE
feat(routes-f): add creator team, loyalty tiers, and stream session goals endpoints

### DIFF
--- a/app/api/routes-f/creator/team/[id]/route.ts
+++ b/app/api/routes-f/creator/team/[id]/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+interface RouteParams {
+  params: Promise<{ id: string }> | { id: string };
+}
+
+const TEAM_ROLES = ["moderator", "editor"] as const;
+
+const updateTeamRoleSchema = z.object({
+  role: z.enum(TEAM_ROLES),
+});
+
+async function ensureCreatorTeamSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_creator_team_members (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      member_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      role TEXT NOT NULL CHECK (role IN ('moderator', 'editor')),
+      status TEXT NOT NULL DEFAULT 'invited' CHECK (status IN ('invited', 'active')),
+      invited_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (creator_id, member_id)
+    )
+  `;
+}
+
+function validateId(id: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json({ error: "Invalid team member id" }, { status: 400 });
+  }
+  return null;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  const bodyResult = await validateBody(req, updateTeamRoleSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensureCreatorTeamSchema();
+
+    const { rows } = await sql`
+      UPDATE route_f_creator_team_members
+      SET role = ${bodyResult.data.role}, updated_at = NOW()
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      RETURNING id, creator_id, member_id, role, status, invited_at, updated_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Team member not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(rows[0]);
+  } catch (error) {
+    console.error("[routes-f creator/team/[id] PATCH]", error);
+    return NextResponse.json(
+      { error: "Failed to update team member role" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  try {
+    await ensureCreatorTeamSchema();
+
+    const { rows } = await sql`
+      DELETE FROM route_f_creator_team_members
+      WHERE id = ${id}
+        AND creator_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Team member not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      id: rows[0].id,
+      deleted: true,
+    });
+  } catch (error) {
+    console.error("[routes-f creator/team/[id] DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to remove team member" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/creator/team/__tests__/route.test.ts
+++ b/app/api/routes-f/creator/team/__tests__/route.test.ts
@@ -1,0 +1,186 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { PATCH, DELETE } from "../[id]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const AUTHED_SESSION = {
+  ok: true as const,
+  userId: "creator-id",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "creator",
+  email: "creator@example.com",
+};
+
+const TEAM_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f creator/team", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue(AUTHED_SESSION);
+  });
+
+  it("lists creator team members", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: TEAM_ID,
+            member_id: "member-id",
+            username: "moduser",
+            avatar: null,
+            role: "moderator",
+            status: "invited",
+            invited_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await GET(makeRequest("GET", "/api/routes-f/creator/team"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.count).toBe(1);
+    expect(json.team[0].role).toBe("moderator");
+  });
+
+  it("enforces max 10 team members", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ team_size: 10 }] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/creator/team", {
+        username: "moduser",
+        role: "moderator",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("requires invited user to exist", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ team_size: 2 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/creator/team", {
+        username: "ghostuser",
+        role: "editor",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toMatch(/does not exist/i);
+  });
+
+  it("invites an existing user as a team member", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ team_size: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: "member-id", username: "moduser", avatar: null }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: TEAM_ID,
+            creator_id: "creator-id",
+            member_id: "member-id",
+            role: "moderator",
+            status: "invited",
+            invited_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/creator/team", {
+        username: "moduser",
+        role: "moderator",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.role).toBe("moderator");
+    expect(json.member.username).toBe("moduser");
+  });
+
+  it("updates a team member role", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: TEAM_ID,
+            creator_id: "creator-id",
+            member_id: "member-id",
+            role: "editor",
+            status: "invited",
+            invited_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await PATCH(
+      makeRequest("PATCH", `/api/routes-f/creator/team/${TEAM_ID}`, {
+        role: "editor",
+      }),
+      { params: { id: TEAM_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.role).toBe("editor");
+  });
+
+  it("deletes a team member", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: TEAM_ID }] });
+
+    const res = await DELETE(
+      makeRequest("DELETE", `/api/routes-f/creator/team/${TEAM_ID}`),
+      { params: { id: TEAM_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/routes-f/creator/team/route.ts
+++ b/app/api/routes-f/creator/team/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { usernameSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const TEAM_ROLES = ["moderator", "editor"] as const;
+
+const inviteTeamMemberSchema = z.object({
+  username: usernameSchema,
+  role: z.enum(TEAM_ROLES),
+});
+
+async function ensureCreatorTeamSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_creator_team_members (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      member_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      role TEXT NOT NULL CHECK (role IN ('moderator', 'editor')),
+      status TEXT NOT NULL DEFAULT 'invited' CHECK (status IN ('invited', 'active')),
+      invited_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (creator_id, member_id)
+    )
+  `;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureCreatorTeamSchema();
+
+    const { rows } = await sql`
+      SELECT
+        tm.id,
+        tm.member_id,
+        u.username,
+        u.avatar,
+        tm.role,
+        tm.status,
+        tm.invited_at,
+        tm.updated_at
+      FROM route_f_creator_team_members tm
+      JOIN users u ON u.id = tm.member_id
+      WHERE tm.creator_id = ${session.userId}
+      ORDER BY tm.invited_at DESC
+    `;
+
+    return NextResponse.json({
+      team: rows,
+      count: rows.length,
+    });
+  } catch (error) {
+    console.error("[routes-f creator/team GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch creator team" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, inviteTeamMemberSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { username, role } = bodyResult.data;
+
+  try {
+    await ensureCreatorTeamSchema();
+
+    const { rows: sizeRows } = await sql`
+      SELECT COUNT(*)::int AS team_size
+      FROM route_f_creator_team_members
+      WHERE creator_id = ${session.userId}
+    `;
+
+    if (Number(sizeRows[0]?.team_size ?? 0) >= 10) {
+      return NextResponse.json(
+        { error: "A creator can have at most 10 team members" },
+        { status: 409 }
+      );
+    }
+
+    const { rows: userRows } = await sql`
+      SELECT id, username, avatar
+      FROM users
+      WHERE LOWER(username) = LOWER(${username})
+      LIMIT 1
+    `;
+
+    if (userRows.length === 0) {
+      return NextResponse.json(
+        { error: "Invited user does not exist" },
+        { status: 404 }
+      );
+    }
+
+    const invitedUser = userRows[0];
+    if (String(invitedUser.id) === session.userId) {
+      return NextResponse.json(
+        { error: "You cannot invite yourself" },
+        { status: 400 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_creator_team_members (
+        creator_id,
+        member_id,
+        role,
+        status
+      )
+      VALUES (
+        ${session.userId},
+        ${invitedUser.id},
+        ${role},
+        'invited'
+      )
+      ON CONFLICT (creator_id, member_id) DO NOTHING
+      RETURNING id, creator_id, member_id, role, status, invited_at, updated_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "User is already in the creator team" },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ...rows[0],
+        member: {
+          username: invitedUser.username,
+          avatar: invitedUser.avatar,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f creator/team POST]", error);
+    return NextResponse.json(
+      { error: "Failed to invite team member" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/loyalty/tiers/__tests__/route.test.ts
+++ b/app/api/routes-f/loyalty/tiers/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, PATCH } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const AUTHED_SESSION = {
+  ok: true as const,
+  userId: "creator-id",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "creator",
+  email: "creator@example.com",
+};
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f loyalty/tiers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue(AUTHED_SESSION);
+  });
+
+  it("returns default tiers when creator has no saved config", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: "creator-id", username: "creator", tiers: null }],
+      });
+
+    const res = await GET(
+      makeRequest("GET", "/api/routes-f/loyalty/tiers?creator=creator")
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.tiers).toHaveLength(4);
+    expect(json.tiers[0].name).toBe("Viewer");
+  });
+
+  it("enforces strictly ascending min_points on PATCH", async () => {
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/routes-f/loyalty/tiers", {
+        tiers: [
+          { name: "Viewer", min_points: 0, perks: [] },
+          { name: "Regular", min_points: 500, perks: ["custom_badge"] },
+          { name: "VIP", min_points: 400, perks: ["priority_chat"] },
+        ],
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("updates tiers for authenticated creator", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            creator_id: "creator-id",
+            tiers: [
+              { name: "Viewer", min_points: 0, perks: [] },
+              {
+                name: "VIP",
+                min_points: 1000,
+                perks: ["custom_badge", "priority_chat"],
+              },
+            ],
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      });
+
+    const res = await PATCH(
+      makeRequest("PATCH", "/api/routes-f/loyalty/tiers", {
+        tiers: [
+          { name: "Viewer", min_points: 0, perks: [] },
+          {
+            name: "VIP",
+            min_points: 1000,
+            perks: ["custom_badge", "priority_chat"],
+          },
+        ],
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.creator_id).toBe("creator-id");
+    expect(json.tiers).toHaveLength(2);
+  });
+});

--- a/app/api/routes-f/loyalty/tiers/route.ts
+++ b/app/api/routes-f/loyalty/tiers/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { usernameSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const LOYALTY_PERKS = [
+  "custom_badge",
+  "priority_chat",
+  "emote_slots",
+  "ad_free",
+] as const;
+
+type LoyaltyPerk = (typeof LOYALTY_PERKS)[number];
+
+type LoyaltyTier = {
+  name: string;
+  min_points: number;
+  perks: LoyaltyPerk[];
+};
+
+const DEFAULT_TIERS: LoyaltyTier[] = [
+  { name: "Viewer", min_points: 0, perks: [] },
+  { name: "Regular", min_points: 500, perks: ["custom_badge"] },
+  {
+    name: "VIP",
+    min_points: 2000,
+    perks: ["custom_badge", "priority_chat"],
+  },
+  {
+    name: "Legend",
+    min_points: 10000,
+    perks: ["custom_badge", "priority_chat", "emote_slots"],
+  },
+];
+
+const tierSchema = z.object({
+  name: z.string().trim().min(1).max(60),
+  min_points: z.number().int().min(0),
+  perks: z.array(z.enum(LOYALTY_PERKS)).max(4),
+});
+
+const getTierQuerySchema = z.object({
+  creator: usernameSchema,
+});
+
+const updateTierSchema = z
+  .object({
+    tiers: z.array(tierSchema).min(1).max(4),
+  })
+  .superRefine(({ tiers }, ctx) => {
+    for (let index = 1; index < tiers.length; index += 1) {
+      if (tiers[index].min_points <= tiers[index - 1].min_points) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["tiers", index, "min_points"],
+          message: "min_points must be strictly ascending",
+        });
+      }
+    }
+  });
+
+async function ensureLoyaltyTierSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_loyalty_tiers (
+      creator_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      tiers JSONB NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+function normalizeTiers(tiers: LoyaltyTier[]): LoyaltyTier[] {
+  return tiers.map(tier => ({
+    name: tier.name.trim(),
+    min_points: tier.min_points,
+    perks: [...new Set(tier.perks)],
+  }));
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    getTierQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    await ensureLoyaltyTierSchema();
+
+    const { creator } = queryResult.data;
+    const { rows } = await sql`
+      SELECT
+        u.id,
+        u.username,
+        t.tiers
+      FROM users u
+      LEFT JOIN route_f_loyalty_tiers t
+        ON t.creator_id = u.id
+      WHERE LOWER(u.username) = LOWER(${creator})
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+    }
+
+    const row = rows[0];
+    const tiers = Array.isArray(row.tiers) ? row.tiers : DEFAULT_TIERS;
+
+    return NextResponse.json({
+      creator: row.username,
+      tiers,
+    });
+  } catch (error) {
+    console.error("[routes-f loyalty/tiers GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch loyalty tiers" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updateTierSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const tiers = normalizeTiers(bodyResult.data.tiers);
+
+  try {
+    await ensureLoyaltyTierSchema();
+
+    const { rows } = await sql`
+      INSERT INTO route_f_loyalty_tiers (creator_id, tiers, updated_at)
+      VALUES (${session.userId}, ${JSON.stringify(tiers)}::jsonb, NOW())
+      ON CONFLICT (creator_id)
+      DO UPDATE SET
+        tiers = EXCLUDED.tiers,
+        updated_at = NOW()
+      RETURNING creator_id, tiers, updated_at
+    `;
+
+    return NextResponse.json(rows[0]);
+  } catch (error) {
+    console.error("[routes-f loyalty/tiers PATCH]", error);
+    return NextResponse.json(
+      { error: "Failed to update loyalty tiers" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/stream/goals/[id]/route.ts
+++ b/app/api/routes-f/stream/goals/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+
+interface RouteParams {
+  params: Promise<{ id: string }> | { id: string };
+}
+
+async function ensureStreamGoalsSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_goals (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id UUID NOT NULL,
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      type TEXT NOT NULL CHECK (type IN ('tip_amount', 'new_subs', 'viewer_count')),
+      target NUMERIC(20, 7) NOT NULL CHECK (target > 0),
+      title VARCHAR(160) NOT NULL,
+      completed_at TIMESTAMPTZ,
+      stream_started_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+function validateId(id: string): NextResponse | null {
+  const result = uuidSchema.safeParse(id);
+  if (!result.success) {
+    return NextResponse.json({ error: "Invalid goal id" }, { status: 400 });
+  }
+  return null;
+}
+
+export async function DELETE(
+  req: NextRequest,
+  context: RouteParams
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await context.params;
+  const idError = validateId(id);
+  if (idError) {
+    return idError;
+  }
+
+  try {
+    await ensureStreamGoalsSchema();
+
+    const { rows: goalRows } = await sql`
+      SELECT id, creator_id
+      FROM route_f_stream_goals
+      WHERE id = ${id}
+      LIMIT 1
+    `;
+
+    if (goalRows.length === 0) {
+      return NextResponse.json({ error: "Goal not found" }, { status: 404 });
+    }
+
+    if (String(goalRows[0].creator_id) !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`
+      DELETE FROM route_f_stream_goals
+      WHERE id = ${id}
+    `;
+
+    return NextResponse.json({
+      id,
+      deleted: true,
+    });
+  } catch (error) {
+    console.error("[routes-f stream/goals/[id] DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to delete stream goal" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/stream/goals/__tests__/route.test.ts
+++ b/app/api/routes-f/stream/goals/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+import { DELETE } from "../[id]/route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const AUTHED_SESSION = {
+  ok: true as const,
+  userId: "creator-id",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "creator",
+  email: "creator@example.com",
+};
+
+const STREAM_ID = "550e8400-e29b-41d4-a716-446655440000";
+const GOAL_ID = "660e8400-e29b-41d4-a716-446655440000";
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f stream/goals", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue(AUTHED_SESSION);
+  });
+
+  it("returns goals with computed progress and marks completed_at", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: GOAL_ID,
+            stream_id: STREAM_ID,
+            creator_id: "creator-id",
+            type: "tip_amount",
+            target: "100",
+            title: "100 tip goal",
+            completed_at: null,
+            stream_started_at: "2026-03-28T00:00:00Z",
+            created_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ progress: "120" }] })
+      .mockResolvedValueOnce({ rows: [{ progress: 3 }] })
+      .mockResolvedValueOnce({ rows: [{ progress: 40 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(
+      makeRequest("GET", `/api/routes-f/stream/goals?stream_id=${STREAM_ID}`)
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.goals).toHaveLength(1);
+    expect(json.goals[0].progress).toBe(120);
+    expect(json.goals[0].is_completed).toBe(true);
+  });
+
+  it("enforces max 2 active goals per stream", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ active_count: 2 }] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/stream/goals", {
+        stream_id: STREAM_ID,
+        type: "new_subs",
+        target: 10,
+        title: "10 new subs",
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("creates a stream goal and returns computed progress", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ active_count: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [{ started_at: "2026-03-28T00:00:00Z", user_id: "creator-id" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: GOAL_ID,
+            stream_id: STREAM_ID,
+            creator_id: "creator-id",
+            type: "new_subs",
+            target: "10",
+            title: "10 new subs",
+            completed_at: null,
+            stream_started_at: "2026-03-28T00:00:00Z",
+            created_at: "2026-03-28T00:00:00Z",
+            updated_at: "2026-03-28T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ progress: "40" }] })
+      .mockResolvedValueOnce({ rows: [{ progress: 6 }] })
+      .mockResolvedValueOnce({ rows: [{ progress: 100 }] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/stream/goals", {
+        stream_id: STREAM_ID,
+        type: "new_subs",
+        target: 10,
+        title: "10 new subs",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.target).toBe(10);
+    expect(json.progress).toBe(6);
+    expect(json.is_completed).toBe(false);
+  });
+
+  it("forbids deleting someone else's goal", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: GOAL_ID, creator_id: "another-creator-id" }],
+      });
+
+    const res = await DELETE(
+      makeRequest("DELETE", `/api/routes-f/stream/goals/${GOAL_ID}`),
+      { params: { id: GOAL_ID } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toBe("Forbidden");
+  });
+});

--- a/app/api/routes-f/stream/goals/route.ts
+++ b/app/api/routes-f/stream/goals/route.ts
@@ -1,0 +1,325 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const GOAL_TYPES = ["tip_amount", "new_subs", "viewer_count"] as const;
+
+type GoalType = (typeof GOAL_TYPES)[number];
+
+type GoalMetrics = Record<GoalType, number>;
+
+type GoalRow = {
+  id: string;
+  stream_id: string;
+  creator_id: string;
+  type: GoalType;
+  target: string | number;
+  title: string;
+  completed_at: string | null;
+  stream_started_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+const listGoalQuerySchema = z.object({
+  stream_id: z.string().uuid(),
+});
+
+const createGoalSchema = z.object({
+  stream_id: z.string().uuid(),
+  type: z.enum(GOAL_TYPES),
+  target: z.number().positive(),
+  title: z.string().trim().min(1).max(160),
+});
+
+async function ensureStreamGoalsSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_goals (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id UUID NOT NULL,
+      creator_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      type TEXT NOT NULL CHECK (type IN ('tip_amount', 'new_subs', 'viewer_count')),
+      target NUMERIC(20, 7) NOT NULL CHECK (target > 0),
+      title VARCHAR(160) NOT NULL,
+      completed_at TIMESTAMPTZ,
+      stream_started_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+function toNumber(value: string | number): number {
+  return typeof value === "number" ? value : Number(value);
+}
+
+async function getLiveGoalMetrics(
+  creatorId: string,
+  streamStartedAt: string
+): Promise<GoalMetrics> {
+  const [tipsResult, subsResult, viewersResult] = await Promise.all([
+    sql<{ progress: string | null }>`
+      SELECT COALESCE(SUM(amount_xlm), 0)::text AS progress
+      FROM tip_transactions
+      WHERE creator_id = ${creatorId}
+        AND created_at >= ${streamStartedAt}
+    `,
+    sql<{ progress: number | null }>`
+      SELECT COALESCE(COUNT(*)::int, 0) AS progress
+      FROM subscriptions
+      WHERE creator_id = ${creatorId}
+        AND created_at >= ${streamStartedAt}
+    `,
+    sql<{ progress: number | null }>`
+      SELECT COALESCE(current_viewers, 0)::int AS progress
+      FROM users
+      WHERE id = ${creatorId}
+      LIMIT 1
+    `,
+  ]);
+
+  return {
+    tip_amount: Number(tipsResult.rows[0]?.progress ?? 0),
+    new_subs: Number(subsResult.rows[0]?.progress ?? 0),
+    viewer_count: Number(viewersResult.rows[0]?.progress ?? 0),
+  };
+}
+
+async function markCompletedGoals(
+  goals: GoalRow[],
+  metrics: GoalMetrics
+): Promise<void> {
+  const completedGoalIds = goals
+    .filter(goal => !goal.completed_at && metrics[goal.type] >= toNumber(goal.target))
+    .map(goal => goal.id);
+
+  if (completedGoalIds.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    completedGoalIds.map(goalId => sql`
+      UPDATE route_f_stream_goals
+      SET completed_at = NOW(), updated_at = NOW()
+      WHERE id = ${goalId}
+        AND completed_at IS NULL
+    `)
+  );
+}
+
+function toGoalPayload(goal: GoalRow, metrics: GoalMetrics) {
+  const target = toNumber(goal.target);
+  const progress = metrics[goal.type] ?? 0;
+  const completedAt =
+    goal.completed_at ?? (progress >= target ? new Date().toISOString() : null);
+
+  return {
+    ...goal,
+    target,
+    progress,
+    completed_at: completedAt,
+    is_completed: Boolean(completedAt),
+  };
+}
+
+async function resolveStreamStartForCreator(
+  streamId: string,
+  creatorId: string
+): Promise<string> {
+  try {
+    const { rows } = await sql`
+      SELECT started_at, user_id
+      FROM stream_sessions
+      WHERE id = ${streamId}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return new Date().toISOString();
+    }
+
+    const stream = rows[0];
+    if (String(stream.user_id) !== creatorId) {
+      return "";
+    }
+
+    return stream.started_at
+      ? new Date(stream.started_at).toISOString()
+      : new Date().toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    listGoalQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { stream_id } = queryResult.data;
+
+  try {
+    await ensureStreamGoalsSchema();
+
+    const { rows } = await sql`
+      SELECT
+        id,
+        stream_id,
+        creator_id,
+        type,
+        target,
+        title,
+        completed_at,
+        stream_started_at,
+        created_at,
+        updated_at
+      FROM route_f_stream_goals
+      WHERE stream_id = ${stream_id}
+      ORDER BY created_at ASC
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ stream_id, goals: [] });
+    }
+
+    const goals = rows as GoalRow[];
+    const metrics = await getLiveGoalMetrics(
+      goals[0].creator_id,
+      goals[0].stream_started_at
+    );
+
+    await markCompletedGoals(goals, metrics);
+    const goalPayload = goals.map(goal => toGoalPayload(goal, metrics));
+
+    return NextResponse.json({
+      stream_id,
+      goals: goalPayload,
+      active_count: goalPayload.filter(goal => !goal.is_completed).length,
+    });
+  } catch (error) {
+    console.error("[routes-f stream/goals GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch stream goals" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createGoalSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { stream_id, type, target, title } = bodyResult.data;
+
+  try {
+    await ensureStreamGoalsSchema();
+
+    const { rows: ownerRows } = await sql`
+      SELECT creator_id
+      FROM route_f_stream_goals
+      WHERE stream_id = ${stream_id}
+      LIMIT 1
+    `;
+
+    if (
+      ownerRows.length > 0 &&
+      String(ownerRows[0].creator_id) !== session.userId
+    ) {
+      return NextResponse.json(
+        { error: "Only the stream owner can manage goals" },
+        { status: 403 }
+      );
+    }
+
+    const { rows: activeRows } = await sql`
+      SELECT COUNT(*)::int AS active_count
+      FROM route_f_stream_goals
+      WHERE stream_id = ${stream_id}
+        AND creator_id = ${session.userId}
+        AND completed_at IS NULL
+    `;
+
+    if (Number(activeRows[0]?.active_count ?? 0) >= 2) {
+      return NextResponse.json(
+        { error: "A stream can have at most 2 active goals" },
+        { status: 409 }
+      );
+    }
+
+    const streamStartedAt = await resolveStreamStartForCreator(
+      stream_id,
+      session.userId
+    );
+
+    if (!streamStartedAt) {
+      return NextResponse.json(
+        { error: "Only the stream owner can create goals for this stream" },
+        { status: 403 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO route_f_stream_goals (
+        stream_id,
+        creator_id,
+        type,
+        target,
+        title,
+        stream_started_at
+      )
+      VALUES (
+        ${stream_id},
+        ${session.userId},
+        ${type},
+        ${target},
+        ${title},
+        ${streamStartedAt}
+      )
+      RETURNING
+        id,
+        stream_id,
+        creator_id,
+        type,
+        target,
+        title,
+        completed_at,
+        stream_started_at,
+        created_at,
+        updated_at
+    `;
+
+    const goal = rows[0] as GoalRow;
+    const metrics = await getLiveGoalMetrics(goal.creator_id, goal.stream_started_at);
+
+    if (!goal.completed_at && metrics[goal.type] >= toNumber(goal.target)) {
+      await sql`
+        UPDATE route_f_stream_goals
+        SET completed_at = NOW(), updated_at = NOW()
+        WHERE id = ${goal.id}
+          AND completed_at IS NULL
+      `;
+      goal.completed_at = new Date().toISOString();
+    }
+
+    return NextResponse.json(toGoalPayload(goal, metrics), { status: 201 });
+  } catch (error) {
+    console.error("[routes-f stream/goals POST]", error);
+    return NextResponse.json(
+      { error: "Failed to create stream goal" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
This PR delivers three standalone routes-f features for creator controls and live engagement:
- #490 creator team management
- #496 creator loyalty tier configuration
- #499 session-scoped stream goals

## Implemented Endpoints
### #490 Creator Team
Path: app/api/routes-f/creator/team/
- GET /api/routes-f/creator/team
  - Lists creator team members and their roles.
- POST /api/routes-f/creator/team
  - Invites a member by username with role moderator or editor.
- PATCH /api/routes-f/creator/team/[id]
  - Changes a member role.
- DELETE /api/routes-f/creator/team/[id]
  - Removes a member.

Validation and constraints:
- Roles limited to moderator and editor.
- Maximum 10 members per creator.
- Invited user must exist in users table.
- Mutations are creator-scoped to the authenticated session.

### #496 Loyalty Tiers
Path: app/api/routes-f/loyalty/tiers/
- GET /api/routes-f/loyalty/tiers?creator=
  - Publicly returns a creator's tier config.
  - Falls back to default four-tier schema when no custom config exists.
- PATCH /api/routes-f/loyalty/tiers
  - Authenticated creator updates names, min_points, and perks.

Validation and constraints:
- Maximum 4 tiers.
- min_points strictly ascending.
- Perks enum restricted to: custom_badge, priority_chat, emote_slots, ad_free.

### #499 Stream Goals
Path: app/api/routes-f/stream/goals/
- GET /api/routes-f/stream/goals?stream_id=
  - Publicly returns goals for a stream session.
  - Includes completed goals.
- POST /api/routes-f/stream/goals
  - Creator creates goal with stream_id, type, target, and title.
- DELETE /api/routes-f/stream/goals/[id]
  - Creator removes a goal mid-stream.

Behavior and constraints:
- Goal type enum: tip_amount, new_subs, viewer_count.
- Max 2 active goals per stream.
- Progress auto-computed from live data (tips, subscriptions, current viewers).
- completed_at is auto-stamped when progress reaches target and completed goals remain visible.

## Persistence
Each feature is self-contained and ensures its own table at runtime:
- route_f_creator_team_members
- route_f_loyalty_tiers
- route_f_stream_goals

## Tests Added
- app/api/routes-f/creator/team/__tests__/route.test.ts
- app/api/routes-f/loyalty/tiers/__tests__/route.test.ts
- app/api/routes-f/stream/goals/__tests__/route.test.ts

## Verification
- npm test -- app/api/routes-f/loyalty/tiers/__tests__/route.test.ts app/api/routes-f/creator/team/__tests__/route.test.ts app/api/routes-f/stream/goals/__tests__/route.test.ts
- npm run type-check

Fixes #490
Fixes #496
Fixes #499