### PR TITLE
feat(routes-f): add VOD chapter timestamps endpoints

### DIFF
--- a/app/api/routes-f/vod/chapters/[id]/__tests__/route.test.ts
+++ b/app/api/routes-f/vod/chapters/[id]/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for DELETE /api/routes-f/vod/chapters/[id]
+ *
+ * Mocks:
+ *   - @vercel/postgres  — no real DB
+ *   - next/server       — minimal polyfill
+ *   - @/lib/rate-limit  — always allows
+ *   - @/lib/auth/verify-session — controllable session
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => async () => false,
+}));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { DELETE } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_CHAPTER_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const authedSession = {
+  ok: true as const,
+  userId: "user-123",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "testuser",
+  email: "test@example.com",
+};
+
+const unauthSession = {
+  ok: false as const,
+  response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+  }),
+};
+
+function makeDeleteRequest(id: string): import("next/server").NextRequest {
+  return new Request(`http://localhost/api/routes-f/vod/chapters/${id}`, {
+    method: "DELETE",
+  }) as unknown as import("next/server").NextRequest;
+}
+
+function makeParams(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+let consoleErrorSpy: jest.SpyInstance;
+
+// ── DELETE tests ───────────────────────────────────────────────────────────────
+
+describe("DELETE /api/routes-f/vod/chapters/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(authedSession);
+  });
+  afterEach(() => consoleErrorSpy?.mockRestore());
+
+  it("returns 401 when not authenticated", async () => {
+    verifySessionMock.mockResolvedValue(unauthSession);
+    const res = await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for a non-UUID chapter id", async () => {
+    const res = await DELETE(makeDeleteRequest("bad-id"), makeParams("bad-id"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid/i);
+  });
+
+  it("returns 404 when chapter does not exist", async () => {
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns 403 when caller does not own the recording", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_CHAPTER_ID, user_id: "other-user" }],
+    });
+
+    const res = await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/forbidden/i);
+  });
+
+  it("returns 204 on successful deletion", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_CHAPTER_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // DELETE
+
+    const res = await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+    expect(res.status).toBe(204);
+    // 204 No Content — body is null or undefined depending on runtime
+    expect(res.body ?? null).toBeNull();
+  });
+
+  it("performs the DELETE query with the correct chapter id", async () => {
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_CHAPTER_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+
+    // SQL calls: 0=SELECT (JOIN), 1=DELETE
+    // The DELETE call should include the chapter id as an interpolated value
+    const deleteCall = sqlMock.mock.calls[1];
+    expect(deleteCall.slice(1)).toContain(VALID_CHAPTER_ID);
+  });
+
+  it("returns 500 on unexpected DB error", async () => {
+    sqlMock.mockRejectedValueOnce(new Error("DB crash"));
+
+    const res = await DELETE(
+      makeDeleteRequest(VALID_CHAPTER_ID),
+      makeParams(VALID_CHAPTER_ID)
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/routes-f/vod/chapters/[id]/route.ts
+++ b/app/api/routes-f/vod/chapters/[id]/route.ts
@@ -1,0 +1,75 @@
+/**
+ * DELETE /api/routes-f/vod/chapters/[id] — remove a chapter marker
+ *
+ * Auth required. Caller must own the recording the chapter belongs to.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createRateLimiter } from "@/lib/rate-limit";
+import { verifySession } from "@/lib/auth/verify-session";
+
+const isIpRateLimited = createRateLimiter(60_000, 5);
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (await isIpRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid chapter id format" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Join to stream_recordings to verify the caller owns the recording
+    const { rows } = await sql`
+      SELECT c.id, r.user_id
+      FROM vod_chapters c
+      JOIN stream_recordings r ON r.id = c.recording_id
+      WHERE c.id = ${id}
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Chapter not found" }, { status: 404 });
+    }
+
+    if (rows[0].user_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`DELETE FROM vod_chapters WHERE id = ${id}`;
+
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    console.error("[vod/chapters] DELETE error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/vod/chapters/__tests__/route.test.ts
+++ b/app/api/routes-f/vod/chapters/__tests__/route.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Tests for GET /api/routes-f/vod/chapters and POST /api/routes-f/vod/chapters
+ *
+ * Mocks:
+ *   - @vercel/postgres  — no real DB
+ *   - next/server       — minimal polyfill
+ *   - @/lib/rate-limit  — always allows
+ *   - @/lib/auth/verify-session — controllable session
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => async () => false,
+}));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET, POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_RECORDING_ID = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_CHAPTER_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const authedSession = {
+  ok: true as const,
+  userId: "user-123",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "testuser",
+  email: "test@example.com",
+};
+
+const unauthSession = {
+  ok: false as const,
+  response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+  }),
+};
+
+function makeGetRequest(search?: string): import("next/server").NextRequest {
+  return new Request(
+    `http://localhost/api/routes-f/vod/chapters${search ?? ""}`,
+    { method: "GET" }
+  ) as unknown as import("next/server").NextRequest;
+}
+
+function makePostRequest(body?: object): import("next/server").NextRequest {
+  return new Request("http://localhost/api/routes-f/vod/chapters", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+function mockEnsureTable() {
+  sqlMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+}
+
+let consoleErrorSpy: jest.SpyInstance;
+
+// ── GET tests ──────────────────────────────────────────────────────────────────
+
+describe("GET /api/routes-f/vod/chapters", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(authedSession);
+  });
+  afterEach(() => consoleErrorSpy?.mockRestore());
+
+  it("returns 400 when recording_id is missing", async () => {
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/recording_id/i);
+  });
+
+  it("returns 400 for a non-UUID recording_id", async () => {
+    const res = await GET(makeGetRequest("?recording_id=not-a-uuid"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid/i);
+  });
+
+  it("returns 404 when recording does not exist", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // stream_recordings lookup
+
+    const res = await GET(
+      makeGetRequest(`?recording_id=${VALID_RECORDING_ID}`)
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns 200 with chapters ordered by timestamp", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: VALID_RECORDING_ID }] }); // recording exists
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_CHAPTER_ID,
+          recording_id: VALID_RECORDING_ID,
+          title: "Intro",
+          timestamp_seconds: 0,
+          created_at: "2026-03-28T00:00:00Z",
+        },
+        {
+          id: "770e8400-e29b-41d4-a716-446655440002",
+          recording_id: VALID_RECORDING_ID,
+          title: "Part 2",
+          timestamp_seconds: 120,
+          created_at: "2026-03-28T00:00:01Z",
+        },
+      ],
+    });
+
+    const res = await GET(
+      makeGetRequest(`?recording_id=${VALID_RECORDING_ID}`)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.chapters).toHaveLength(2);
+    expect(body.chapters[0].title).toBe("Intro");
+    expect(body.chapters[1].title).toBe("Part 2");
+  });
+
+  it("returns 200 with empty chapters array when none exist", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: VALID_RECORDING_ID }] });
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(
+      makeGetRequest(`?recording_id=${VALID_RECORDING_ID}`)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.chapters).toEqual([]);
+  });
+
+  it("returns 500 on unexpected DB error", async () => {
+    mockEnsureTable();
+    sqlMock.mockRejectedValueOnce(new Error("DB crash"));
+
+    const res = await GET(
+      makeGetRequest(`?recording_id=${VALID_RECORDING_ID}`)
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/routes-f/vod/chapters", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(authedSession);
+  });
+  afterEach(() => consoleErrorSpy?.mockRestore());
+
+  it("returns 401 when not authenticated", async () => {
+    verifySessionMock.mockResolvedValue(unauthSession);
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 0,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/routes-f/vod/chapters", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{ not json }",
+    }) as unknown as import("next/server").NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when body is an array", async () => {
+    const res = await POST(makePostRequest([1, 2] as unknown as object));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when recording_id is missing", async () => {
+    const res = await POST(
+      makePostRequest({ title: "Intro", timestamp_seconds: 10 })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/recording_id/i);
+  });
+
+  it("returns 400 for invalid recording_id format", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: "bad-id",
+        title: "Intro",
+        timestamp_seconds: 10,
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid recording_id/i);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        timestamp_seconds: 10,
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/title/i);
+  });
+
+  it("returns 400 when title is an empty string", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "   ",
+        timestamp_seconds: 10,
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/title/i);
+  });
+
+  it("returns 400 when timestamp_seconds is negative", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: -1,
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/timestamp_seconds/i);
+  });
+
+  it("returns 400 when timestamp_seconds is a float", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 10.5,
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/timestamp_seconds/i);
+  });
+
+  it("returns 400 when timestamp_seconds is a string", async () => {
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: "10",
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/timestamp_seconds/i);
+  });
+
+  it("returns 404 when recording does not exist", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // stream_recordings lookup
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 0,
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller does not own the recording", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 600, user_id: "other-user" }],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 10,
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 422 when timestamp_seconds exceeds recording duration", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 300, user_id: "user-123" }],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "End",
+        timestamp_seconds: 400,
+      })
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/exceeds/i);
+  });
+
+  it("returns 422 when recording is already at the 100-chapter cap", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 3600, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "100" }] }); // chapter count
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Chapter 101",
+        timestamp_seconds: 60,
+      })
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum/i);
+  });
+
+  it("returns 201 with the created chapter on success", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 3600, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] }); // chapter count
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_CHAPTER_ID,
+          recording_id: VALID_RECORDING_ID,
+          title: "Intro",
+          timestamp_seconds: 0,
+          created_at: "2026-03-28T00:00:00Z",
+        },
+      ],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 0,
+      })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.chapter.id).toBe(VALID_CHAPTER_ID);
+    expect(body.chapter.title).toBe("Intro");
+    expect(body.chapter.timestamp_seconds).toBe(0);
+  });
+
+  it("trims whitespace from title before inserting", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 3600, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_CHAPTER_ID,
+          recording_id: VALID_RECORDING_ID,
+          title: "Trimmed Title",
+          timestamp_seconds: 5,
+          created_at: "2026-03-28T00:00:00Z",
+        },
+      ],
+    });
+
+    await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "  Trimmed Title  ",
+        timestamp_seconds: 5,
+      })
+    );
+
+    // The INSERT call receives the trimmed title as an interpolated value
+    // SQL calls: 0=ensureTable, 1=SELECT recording, 2=COUNT chapters, 3=INSERT
+    const insertCall = sqlMock.mock.calls[3];
+    expect(insertCall.slice(1)).toContain("Trimmed Title");
+    expect(insertCall.slice(1)).not.toContain("  Trimmed Title  ");
+  });
+
+  it("allows timestamp_seconds equal to recording duration", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: 300, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_CHAPTER_ID,
+          recording_id: VALID_RECORDING_ID,
+          title: "End",
+          timestamp_seconds: 300,
+          created_at: "2026-03-28T00:00:00Z",
+        },
+      ],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "End",
+        timestamp_seconds: 300,
+      })
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("skips duration check when recording has no duration", async () => {
+    mockEnsureTable();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, duration: null, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: VALID_CHAPTER_ID,
+          recording_id: VALID_RECORDING_ID,
+          title: "Chapter",
+          timestamp_seconds: 9999,
+          created_at: "2026-03-28T00:00:00Z",
+        },
+      ],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Chapter",
+        timestamp_seconds: 9999,
+      })
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 500 on unexpected DB error", async () => {
+    mockEnsureTable();
+    sqlMock.mockRejectedValueOnce(new Error("DB crash"));
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        title: "Intro",
+        timestamp_seconds: 10,
+      })
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/routes-f/vod/chapters/import/__tests__/route.test.ts
+++ b/app/api/routes-f/vod/chapters/import/__tests__/route.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Tests for POST /api/routes-f/vod/chapters/import
+ *
+ * Mocks:
+ *   - @vercel/postgres  — no real DB
+ *   - next/server       — minimal polyfill
+ *   - @/lib/rate-limit  — always allows
+ *   - @/lib/auth/verify-session — controllable session
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+
+jest.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => async () => false,
+}));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const VALID_RECORDING_ID = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_STREAM_ID = "660e8400-e29b-41d4-a716-446655440001";
+
+const authedSession = {
+  ok: true as const,
+  userId: "user-123",
+  wallet: null,
+  privyId: "did:privy:abc",
+  username: "testuser",
+  email: "test@example.com",
+};
+
+const unauthSession = {
+  ok: false as const,
+  response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+  }),
+};
+
+function makePostRequest(body?: object): import("next/server").NextRequest {
+  return new Request("http://localhost/api/routes-f/vod/chapters/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+function mockEnsureTables() {
+  sqlMock.mockResolvedValueOnce({ rows: [] }); // CREATE vod_chapters
+  sqlMock.mockResolvedValueOnce({ rows: [] }); // CREATE stream_chapters
+}
+
+let consoleErrorSpy: jest.SpyInstance;
+
+// ── POST tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/routes-f/vod/chapters/import", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    verifySessionMock.mockResolvedValue(authedSession);
+  });
+  afterEach(() => consoleErrorSpy?.mockRestore());
+
+  it("returns 401 when not authenticated", async () => {
+    verifySessionMock.mockResolvedValue(unauthSession);
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request(
+      "http://localhost/api/routes-f/vod/chapters/import",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{ invalid }",
+      }
+    ) as unknown as import("next/server").NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when body is an array", async () => {
+    const res = await POST(makePostRequest([1, 2] as unknown as object));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when recording_id is missing", async () => {
+    const res = await POST(makePostRequest({ stream_id: VALID_STREAM_ID }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/recording_id/i);
+  });
+
+  it("returns 400 for invalid recording_id format", async () => {
+    const res = await POST(
+      makePostRequest({ recording_id: "bad", stream_id: VALID_STREAM_ID })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid recording_id/i);
+  });
+
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await POST(
+      makePostRequest({ recording_id: VALID_RECORDING_ID })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/stream_id/i);
+  });
+
+  it("returns 400 for invalid stream_id format", async () => {
+    const res = await POST(
+      makePostRequest({ recording_id: VALID_RECORDING_ID, stream_id: "bad" })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid stream_id/i);
+  });
+
+  it("returns 404 when recording does not exist", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // stream_recordings lookup
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns 403 when caller does not own the recording", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "other-user" }],
+    });
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with imported=0 when stream has no chapters", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // stream_chapters — empty
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(0);
+    expect(body.truncated).toBe(false);
+  });
+
+  it("returns 422 when recording is already at the 100-chapter cap", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        { title: "Ch1", timestamp_seconds: 0 },
+        { title: "Ch2", timestamp_seconds: 60 },
+      ],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "100" }] }); // existing chapters count
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum/i);
+  });
+
+  it("imports all source chapters when under the cap", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        { title: "Intro", timestamp_seconds: 0 },
+        { title: "Part 2", timestamp_seconds: 300 },
+      ],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] }); // existing count
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // INSERT ch 1
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // INSERT ch 2
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(2);
+    expect(body.truncated).toBe(false);
+    expect(body.message).toMatch(/2 chapters/i);
+  });
+
+  it("truncates to available slots and sets truncated=true", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "user-123" }],
+    });
+    // 3 source chapters
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        { title: "A", timestamp_seconds: 0 },
+        { title: "B", timestamp_seconds: 60 },
+        { title: "C", timestamp_seconds: 120 },
+      ],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "99" }] }); // only 1 slot left
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // INSERT ch A only
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.truncated).toBe(true);
+
+    // Only 1 INSERT should have been made
+    const insertCalls = sqlMock.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "object" &&
+        (call[0] as TemplateStringsArray)[0]?.includes(
+          "INSERT INTO vod_chapters"
+        )
+    );
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it("uses singular 'chapter' in message when importing exactly 1", async () => {
+    mockEnsureTables();
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ id: VALID_RECORDING_ID, user_id: "user-123" }],
+    });
+    sqlMock.mockResolvedValueOnce({
+      rows: [{ title: "Solo", timestamp_seconds: 0 }],
+    });
+    sqlMock.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+    sqlMock.mockResolvedValueOnce({ rows: [] }); // INSERT
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    const body = await res.json();
+    expect(body.message).toMatch(/1 chapter\b/);
+    expect(body.message).not.toMatch(/chapters/);
+  });
+
+  it("returns 500 on unexpected DB error", async () => {
+    mockEnsureTables();
+    sqlMock.mockRejectedValueOnce(new Error("DB crash"));
+
+    const res = await POST(
+      makePostRequest({
+        recording_id: VALID_RECORDING_ID,
+        stream_id: VALID_STREAM_ID,
+      })
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/routes-f/vod/chapters/import/route.ts
+++ b/app/api/routes-f/vod/chapters/import/route.ts
@@ -1,0 +1,177 @@
+/**
+ * POST /api/routes-f/vod/chapters/import
+ * Bulk-import chapter markers from a live stream into a VOD recording.
+ *
+ * Body: { recording_id: string, stream_id: string }
+ *
+ * Copies all chapters from stream_chapters where stream_id matches,
+ * up to the per-recording cap of 100. Auth required; caller must own
+ * the recording.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createRateLimiter } from "@/lib/rate-limit";
+import { verifySession } from "@/lib/auth/verify-session";
+
+const isIpRateLimited = createRateLimiter(60_000, 5);
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_CHAPTERS_PER_RECORDING = 100;
+
+async function ensureTables(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS vod_chapters (
+      id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+      recording_id      VARCHAR      NOT NULL,
+      title             VARCHAR(255) NOT NULL,
+      timestamp_seconds INTEGER      NOT NULL,
+      created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    )
+  `;
+  await sql`
+    CREATE TABLE IF NOT EXISTS stream_chapters (
+      id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id         VARCHAR      NOT NULL,
+      title             VARCHAR(255) NOT NULL,
+      timestamp_seconds INTEGER      NOT NULL,
+      created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (await isIpRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 }
+    );
+  }
+
+  const { recording_id, stream_id } = body as Record<string, unknown>;
+
+  if (typeof recording_id !== "string" || !recording_id) {
+    return NextResponse.json(
+      { error: "recording_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!UUID_RE.test(recording_id)) {
+    return NextResponse.json(
+      { error: "Invalid recording_id format" },
+      { status: 400 }
+    );
+  }
+  if (typeof stream_id !== "string" || !stream_id) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!UUID_RE.test(stream_id)) {
+    return NextResponse.json(
+      { error: "Invalid stream_id format" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureTables();
+
+    // Verify recording exists and caller owns it
+    const { rows: recordings } = await sql`
+      SELECT id, user_id FROM stream_recordings WHERE id = ${recording_id} LIMIT 1
+    `;
+
+    if (recordings.length === 0) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    if (recordings[0].user_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Fetch source chapters ordered by timestamp
+    const { rows: sourceChapters } = await sql`
+      SELECT title, timestamp_seconds
+      FROM stream_chapters
+      WHERE stream_id = ${stream_id}
+      ORDER BY timestamp_seconds ASC
+    `;
+
+    if (sourceChapters.length === 0) {
+      return NextResponse.json({
+        imported: 0,
+        truncated: false,
+        message: "No chapters found for the specified stream",
+      });
+    }
+
+    // Determine how many slots remain under the cap
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*) AS count FROM vod_chapters WHERE recording_id = ${recording_id}
+    `;
+    const existingCount = parseInt(countRows[0].count, 10);
+    const available = MAX_CHAPTERS_PER_RECORDING - existingCount;
+
+    if (available <= 0) {
+      return NextResponse.json(
+        {
+          error: `Maximum of ${MAX_CHAPTERS_PER_RECORDING} chapters per recording already reached`,
+        },
+        { status: 422 }
+      );
+    }
+
+    const chaptersToImport = sourceChapters.slice(0, available);
+    const truncated = sourceChapters.length > available;
+
+    for (const ch of chaptersToImport) {
+      await sql`
+        INSERT INTO vod_chapters (recording_id, title, timestamp_seconds)
+        VALUES (${recording_id}, ${ch.title}, ${ch.timestamp_seconds})
+      `;
+    }
+
+    return NextResponse.json({
+      imported: chaptersToImport.length,
+      truncated,
+      message: `Successfully imported ${chaptersToImport.length} chapter${chaptersToImport.length !== 1 ? "s" : ""}`,
+    });
+  } catch (err) {
+    console.error("[vod/chapters/import] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/vod/chapters/route.ts
+++ b/app/api/routes-f/vod/chapters/route.ts
@@ -1,0 +1,231 @@
+/**
+ * GET  /api/routes-f/vod/chapters?recording_id= — list chapters for a VOD
+ * POST /api/routes-f/vod/chapters               — add a chapter marker
+ *
+ * Constraints:
+ *   - POST requires session auth; caller must own the recording
+ *   - timestamp_seconds must be >= 0 and within the recording's duration
+ *   - Max 100 chapters per recording
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { createRateLimiter } from "@/lib/rate-limit";
+import { verifySession } from "@/lib/auth/verify-session";
+
+const isIpRateLimited = createRateLimiter(60_000, 5);
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_CHAPTERS_PER_RECORDING = 100;
+
+function getIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+async function ensureChaptersTable(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS vod_chapters (
+      id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+      recording_id      VARCHAR      NOT NULL,
+      title             VARCHAR(255) NOT NULL,
+      timestamp_seconds INTEGER      NOT NULL,
+      created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+    )
+  `;
+}
+
+// ── GET /api/routes-f/vod/chapters?recording_id= ────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const ip = getIp(req);
+  if (await isIpRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const recordingId = searchParams.get("recording_id");
+
+  if (!recordingId) {
+    return NextResponse.json(
+      { error: "recording_id is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!UUID_RE.test(recordingId)) {
+    return NextResponse.json(
+      { error: "Invalid recording_id format" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureChaptersTable();
+
+    const { rows: recordings } = await sql`
+      SELECT id FROM stream_recordings WHERE id = ${recordingId} LIMIT 1
+    `;
+
+    if (recordings.length === 0) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    const { rows } = await sql`
+      SELECT id, recording_id, title, timestamp_seconds, created_at
+      FROM vod_chapters
+      WHERE recording_id = ${recordingId}
+      ORDER BY timestamp_seconds ASC
+    `;
+
+    return NextResponse.json({ chapters: rows });
+  } catch (err) {
+    console.error("[vod/chapters] GET error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+// ── POST /api/routes-f/vod/chapters ─────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const ip = getIp(req);
+  if (await isIpRateLimited(ip)) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 }
+    );
+  }
+
+  const { recording_id, title, timestamp_seconds } = body as Record<
+    string,
+    unknown
+  >;
+
+  if (typeof recording_id !== "string" || !recording_id) {
+    return NextResponse.json(
+      { error: "recording_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!UUID_RE.test(recording_id)) {
+    return NextResponse.json(
+      { error: "Invalid recording_id format" },
+      { status: 400 }
+    );
+  }
+  if (typeof title !== "string" || !title.trim()) {
+    return NextResponse.json(
+      { error: "title is required and must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+  if (
+    typeof timestamp_seconds !== "number" ||
+    !Number.isInteger(timestamp_seconds) ||
+    timestamp_seconds < 0
+  ) {
+    return NextResponse.json(
+      { error: "timestamp_seconds must be a non-negative integer" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ensureChaptersTable();
+
+    // Verify recording exists and caller owns it; fetch duration for validation
+    const { rows: recordings } = await sql`
+      SELECT id, duration, user_id FROM stream_recordings
+      WHERE id = ${recording_id}
+      LIMIT 1
+    `;
+
+    if (recordings.length === 0) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    const recording = recordings[0];
+
+    if (recording.user_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Validate timestamp is within recording duration
+    const duration =
+      typeof recording.duration === "number"
+        ? recording.duration
+        : parseFloat(recording.duration);
+    if (!isNaN(duration) && timestamp_seconds > Math.floor(duration)) {
+      return NextResponse.json(
+        {
+          error: `timestamp_seconds (${timestamp_seconds}) exceeds recording duration (${Math.floor(duration)}s)`,
+        },
+        { status: 422 }
+      );
+    }
+
+    // Enforce chapter cap
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*) AS count FROM vod_chapters WHERE recording_id = ${recording_id}
+    `;
+    const currentCount = parseInt(countRows[0].count, 10);
+    if (currentCount >= MAX_CHAPTERS_PER_RECORDING) {
+      return NextResponse.json(
+        {
+          error: `Maximum of ${MAX_CHAPTERS_PER_RECORDING} chapters per recording reached`,
+        },
+        { status: 422 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO vod_chapters (recording_id, title, timestamp_seconds)
+      VALUES (${recording_id}, ${title.trim()}, ${timestamp_seconds})
+      RETURNING id, recording_id, title, timestamp_seconds, created_at
+    `;
+
+    return NextResponse.json({ chapter: rows[0] }, { status: 201 });
+  } catch (err) {
+    console.error("[vod/chapters] POST error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Closes #491

## Summary

- **GET** `/api/routes-f/vod/chapters?recording_id=` — lists all chapters for a VOD recording, ordered by `timestamp_seconds`
- **POST** `/api/routes-f/vod/chapters` — adds a chapter marker; validates ownership, duration bounds, and the 100-chapter cap
- **DELETE** `/api/routes-f/vod/chapters/[id]` — removes a chapter; ownership verified by joining `vod_chapters` → `stream_recordings.user_id`; returns 204 No Content
- **POST** `/api/routes-f/vod/chapters/import` — bulk-imports chapters from `stream_chapters` (by `stream_id`) into a VOD recording; respects the cap and returns `truncated: true` when the source exceeds available slots

## Acceptance criteria

| Requirement | How it's met |
|---|---|
| `timestamp_seconds` within recording duration | Fetches `duration` from `stream_recordings`; returns 422 if exceeded |
| Import copies all chapters from source stream | Reads from `stream_chapters` ordered by `timestamp_seconds` |
| Max 100 chapters per recording | Enforced on both single-add (422) and import (truncation) |
| Route lives in `app/api/routes-f/vod/chapters/` | ✓ |

## Implementation notes

- Follows the same patterns as `app/api/routes-f/import/route.ts`: `@vercel/postgres` tagged SQL, `createRateLimiter` (5 req/min per IP), `verifySession` for auth
- `vod_chapters` and `stream_chapters` tables are created with `CREATE TABLE IF NOT EXISTS` on first request
- `DELETE` returns a plain `Response(null, { status: 204 })` (not `NextResponse`) to avoid the `NextResponse` constructor requirement in the test environment

## Test plan

- [x] 47 unit tests, 3 suites — all passing (`npm test`)
- [x] TypeScript: `npm run type-check` — clean
- [x] Lint: `npm run lint` — no errors
- [x] Format: `npm run format:check` — all files pass Prettier