### PR TITLE
feat(routes-f): add engagement and recommendation apis

### DIFF
--- a/app/api/routes-f/_lib/session.ts
+++ b/app/api/routes-f/_lib/session.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+import { verifySession, type VerifiedSession } from "@/lib/auth/verify-session";
+
+export async function getOptionalSession(
+  req: NextRequest
+): Promise<Extract<VerifiedSession, { ok: true }> | null> {
+  const hasSessionCookie =
+    req.cookies.has("privy_session") ||
+    req.cookies.has("wallet_session") ||
+    req.cookies.has("wallet");
+
+  if (!hasSessionCookie) {
+    return null;
+  }
+
+  const session = await verifySession(req);
+  return session.ok ? session : null;
+}

--- a/app/api/routes-f/audit/route.ts
+++ b/app/api/routes-f/audit/route.ts
@@ -66,12 +66,13 @@ export async function GET(req: NextRequest): Promise<Response> {
   const result = validateQuery(new URL(req.url).searchParams, querySchema);
   if (result instanceof NextResponse) return result;
   const { user, type, from, to, limit, cursor } = result.data;
+  const pageLimit = limit ?? 50;
 
   await ensureAuditTable();
 
-  const fromDate = from ? new Date(from) : null;
-  const toDate = to ? new Date(to) : null;
-  const cursorDate = cursor ? new Date(cursor) : null;
+  const fromDate = from ? new Date(from).toISOString() : null;
+  const toDate = to ? new Date(to).toISOString() : null;
+  const cursorDate = cursor ? new Date(cursor).toISOString() : null;
 
   const { rows: events } = await sql`
     SELECT
@@ -92,11 +93,11 @@ export async function GET(req: NextRequest): Promise<Response> {
       AND (${toDate ?? null}::timestamptz IS NULL OR al.created_at <= ${toDate ?? null})
       AND (${cursorDate ?? null}::timestamptz IS NULL OR al.created_at < ${cursorDate ?? null})
     ORDER BY al.created_at DESC
-    LIMIT ${limit + 1}
+    LIMIT ${pageLimit + 1}
   `;
 
-  const hasMore = events.length > limit;
-  const page = hasMore ? events.slice(0, limit) : events;
+  const hasMore = events.length > pageLimit;
+  const page = hasMore ? events.slice(0, pageLimit) : events;
   const nextCursor = hasMore ? page[page.length - 1].created_at : null;
 
   const { rows: countRows } = await sql`
@@ -110,7 +111,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   `;
 
   return NextResponse.json({
-    events: page.map((e) => ({
+    events: page.map(e => ({
       id: e.id,
       event_type: e.event_type,
       user: e.subject_username ? { username: e.subject_username } : null,

--- a/app/api/routes-f/collab/[id]/route.ts
+++ b/app/api/routes-f/collab/[id]/route.ts
@@ -6,67 +6,70 @@ import { validateBody } from "@/app/api/routes-f/_lib/validate";
 import { ensureCollabSchema } from "../_lib/db";
 
 const collabPatchSchema = z.object({
-    status: z.enum(["accepted", "declined"]),
+  status: z.enum(["accepted", "declined"]),
 });
 
-type RouteContext = { params: { id: string } };
+type RouteContext = { params: Promise<{ id: string }> };
 
 /**
  * PATCH /api/routes-f/collab/[id]
  * Accept or decline a collab request.
  */
 export async function PATCH(
-    req: NextRequest,
-    { params }: RouteContext
+  req: NextRequest,
+  { params }: RouteContext
 ): Promise<NextResponse> {
-    const session = await verifySession(req);
-    if (!session.ok) return session.response;
+  const session = await verifySession(req);
+  if (!session.ok) return session.response;
 
-    const { id } = params;
-    const parsed = await validateBody(req, collabPatchSchema);
-    if (parsed instanceof Response) return parsed;
-    const { status } = parsed.data;
+  const { id } = await params;
+  const parsed = await validateBody(req, collabPatchSchema);
+  if (parsed instanceof Response) return parsed;
+  const { status } = parsed.data;
 
-    try {
-        await ensureCollabSchema();
+  try {
+    await ensureCollabSchema();
 
-        // 1. Fetch request and check authorization
-        const { rows } = await sql`
+    // 1. Fetch request and check authorization
+    const { rows } = await sql`
       SELECT sender_id, receiver_id, status FROM collab_requests WHERE id = ${id}
     `;
 
-        if (rows.length === 0) {
-            return NextResponse.json({ error: "Request not found" }, { status: 404 });
-        }
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Request not found" }, { status: 404 });
+    }
 
-        const request = rows[0];
+    const request = rows[0];
 
-        // Only the receiver can accept or decline
-        if (request.receiver_id !== session.userId) {
-            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-        }
+    // Only the receiver can accept or decline
+    if (request.receiver_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
 
-        // Can only update if currently pending
-        if (request.status !== "pending") {
-            return NextResponse.json(
-                { error: `Cannot update request with status: ${request.status}` },
-                { status: 400 }
-            );
-        }
+    // Can only update if currently pending
+    if (request.status !== "pending") {
+      return NextResponse.json(
+        { error: `Cannot update request with status: ${request.status}` },
+        { status: 400 }
+      );
+    }
 
-        // 2. Update status
-        const { rows: updatedRows } = await sql`
+    // 2. Update status
+    const { rows: updatedRows } = await sql`
       UPDATE collab_requests
       SET status = ${status}, updated_at = NOW()
       WHERE id = ${id}
       RETURNING *
     `;
 
-        return NextResponse.json(updatedRows[0]);
-    } catch (error) {
-        console.error("[collab:PATCH] Error:", error);
-        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-    }
+    return NextResponse.json(updatedRows[0]);
+  } catch (error) {
+    console.error("[collab:PATCH] Error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 /**
@@ -74,47 +77,52 @@ export async function PATCH(
  * Cancel a pending collab request.
  */
 export async function DELETE(
-    req: NextRequest,
-    { params }: RouteContext
+  req: NextRequest,
+  { params }: RouteContext
 ): Promise<NextResponse> {
-    const session = await verifySession(req);
-    if (!session.ok) return session.response;
+  const session = await verifySession(req);
+  if (!session.ok) return session.response;
 
-    const { id } = params;
+  const { id } = await params;
 
-    try {
-        await ensureCollabSchema();
+  try {
+    await ensureCollabSchema();
 
-        // 1. Fetch request and check authorization
-        const { rows } = await sql`
+    // 1. Fetch request and check authorization
+    const { rows } = await sql`
       SELECT sender_id, status FROM collab_requests WHERE id = ${id}
     `;
 
-        if (rows.length === 0) {
-            return NextResponse.json({ error: "Request not found" }, { status: 404 });
-        }
-
-        const request = rows[0];
-
-        // Only the sender can cancel
-        if (request.sender_id !== session.userId) {
-            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-        }
-
-        // Can only cancel if currently pending
-        if (request.status !== "pending") {
-            return NextResponse.json(
-                { error: `Cannot cancel request with status: ${request.status}` },
-                { status: 400 }
-            );
-        }
-
-        // 2. Delete request
-        await sql`DELETE FROM collab_requests WHERE id = ${id}`;
-
-        return NextResponse.json({ message: "Collaboration request cancelled successfully" });
-    } catch (error) {
-        console.error("[collab:DELETE] Error:", error);
-        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Request not found" }, { status: 404 });
     }
+
+    const request = rows[0];
+
+    // Only the sender can cancel
+    if (request.sender_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Can only cancel if currently pending
+    if (request.status !== "pending") {
+      return NextResponse.json(
+        { error: `Cannot cancel request with status: ${request.status}` },
+        { status: 400 }
+      );
+    }
+
+    // 2. Delete request
+    await sql`DELETE FROM collab_requests WHERE id = ${id}`;
+
+    return NextResponse.json({
+      message: "Collaboration request cancelled successfully",
+    });
+  } catch (error) {
+    console.error("[collab:DELETE] Error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/app/api/routes-f/feedback/route.ts
+++ b/app/api/routes-f/feedback/route.ts
@@ -35,15 +35,13 @@ const submitFeedbackSchema = z
     metadata: z.record(z.unknown()).optional(),
   })
   .refine(
-    (d) => d.type !== "nps" || (d.rating !== null && d.rating !== undefined),
+    d => d.type !== "nps" || (d.rating !== null && d.rating !== undefined),
     { message: "rating is required for nps type", path: ["rating"] }
   );
 
 const listFeedbackSchema = z.object({
   type: z.enum(FEEDBACK_TYPES).optional(),
-  status: z
-    .enum(["new", "read", "actioned", "dismissed"])
-    .optional(),
+  status: z.enum(["new", "read", "actioned", "dismissed"]).optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
@@ -118,13 +116,18 @@ export async function GET(req: NextRequest): Promise<Response> {
   const auth = await requireAdmin(req);
   if (!auth.ok) return auth.response;
 
-  const result = validateQuery(new URL(req.url).searchParams, listFeedbackSchema);
+  const result = validateQuery(
+    new URL(req.url).searchParams,
+    listFeedbackSchema
+  );
   if (result instanceof NextResponse) return result;
   const { type, status, page, limit } = result.data;
+  const pageNumber = page ?? 1;
+  const pageLimit = limit ?? 20;
 
   await ensureFeedbackTable();
 
-  const offset = (page - 1) * limit;
+  const offset = (pageNumber - 1) * pageLimit;
 
   const { rows } = await sql`
     SELECT
@@ -135,7 +138,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     WHERE (${type ?? null}::text IS NULL OR f.type = ${type ?? null})
       AND (${status ?? null}::text IS NULL OR f.status = ${status ?? null})
     ORDER BY f.created_at DESC
-    LIMIT ${limit} OFFSET ${offset}
+    LIMIT ${pageLimit} OFFSET ${offset}
   `;
 
   const { rows: countRows } = await sql`
@@ -148,7 +151,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   return NextResponse.json({
     items: rows,
     total: Number(countRows[0]?.total ?? 0),
-    page,
-    limit,
+    page: pageNumber,
+    limit: pageLimit,
   });
 }

--- a/app/api/routes-f/gifts/__tests__/route.test.ts
+++ b/app/api/routes-f/gifts/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+jest.mock("../_lib/db", () => ({
+  ensureGiftSchema: jest.fn().mockResolvedValue(undefined),
+  getGiftCatalogItem: jest.fn((id: string) =>
+    id === "crown"
+      ? {
+          id: "crown",
+          name: "Crown",
+          price_usd: 25,
+          icon_url: "/images/gifts/crown.png",
+          animation_url: "/animations/gifts/crown.json",
+        }
+      : undefined
+  ),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+function makeRequest(body: object) {
+  return new Request("http://localhost/api/routes-f/gifts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f gifts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "sender-1",
+      wallet: null,
+      privyId: "did:privy:1",
+      username: "alice",
+      email: "alice@example.com",
+    });
+  });
+
+  it("creates a gift transaction", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: "recipient-1", username: "bob" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "gift-tx-1",
+            gift_id: "crown",
+            gift_name: "Crown",
+            quantity: 2,
+            amount_usdc: "50",
+            tx_hash: "0xtx",
+          },
+        ],
+      });
+
+    const res = await POST(
+      makeRequest({
+        recipient_id: "550e8400-e29b-41d4-a716-446655440000",
+        gift_id: "crown",
+        quantity: 2,
+        tx_hash: "0xtx",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.gift_id).toBe("crown");
+    expect(json.amount_usdc).toBe("50");
+  });
+
+  it("enforces quantity max 100", async () => {
+    const res = await POST(
+      makeRequest({
+        recipient_id: "550e8400-e29b-41d4-a716-446655440000",
+        gift_id: "crown",
+        quantity: 101,
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/gifts/_lib/db.ts
+++ b/app/api/routes-f/gifts/_lib/db.ts
@@ -1,0 +1,98 @@
+import { sql } from "@vercel/postgres";
+
+export const GIFT_CATALOG = [
+  {
+    id: "flower",
+    name: "Flower",
+    price_usd: 1,
+    icon_url: "/images/gifts/flower.png",
+    animation_url: "/animations/gifts/flower.json",
+  },
+  {
+    id: "candy",
+    name: "Candy",
+    price_usd: 5,
+    icon_url: "/images/gifts/candy.png",
+    animation_url: "/animations/gifts/candy.json",
+  },
+  {
+    id: "crown",
+    name: "Crown",
+    price_usd: 25,
+    icon_url: "/images/gifts/crown.png",
+    animation_url: "/animations/gifts/crown.json",
+  },
+  {
+    id: "lion",
+    name: "Lion",
+    price_usd: 100,
+    icon_url: "/images/gifts/lion.png",
+    animation_url: "/animations/gifts/lion.json",
+  },
+  {
+    id: "dragon",
+    name: "Dragon",
+    price_usd: 500,
+    icon_url: "/images/gifts/dragon.png",
+    animation_url: "/animations/gifts/dragon.json",
+  },
+] as const;
+
+export type GiftCatalogItem = (typeof GIFT_CATALOG)[number];
+
+export async function ensureGiftSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS gift_transactions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      supporter_id UUID REFERENCES users(id) ON DELETE SET NULL,
+      creator_id UUID REFERENCES users(id) ON DELETE CASCADE,
+      recipient_id UUID REFERENCES users(id) ON DELETE CASCADE,
+      stream_session_id UUID REFERENCES stream_sessions(id) ON DELETE SET NULL,
+      gift_id TEXT NOT NULL,
+      gift_name TEXT NOT NULL,
+      quantity INTEGER NOT NULL DEFAULT 1,
+      amount_usdc NUMERIC(20,2) NOT NULL DEFAULT 0,
+      tx_hash TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    ALTER TABLE gift_transactions
+    ADD COLUMN IF NOT EXISTS recipient_id UUID REFERENCES users(id) ON DELETE CASCADE
+  `;
+
+  await sql`
+    ALTER TABLE gift_transactions
+    ADD COLUMN IF NOT EXISTS gift_id TEXT
+  `;
+
+  await sql`
+    ALTER TABLE gift_transactions
+    ADD COLUMN IF NOT EXISTS gift_name TEXT
+  `;
+
+  await sql`
+    ALTER TABLE gift_transactions
+    ADD COLUMN IF NOT EXISTS quantity INTEGER NOT NULL DEFAULT 1
+  `;
+
+  await sql`
+    ALTER TABLE gift_transactions
+    ADD COLUMN IF NOT EXISTS tx_hash TEXT
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_gift_transactions_supporter_created
+    ON gift_transactions (supporter_id, created_at DESC)
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_gift_transactions_creator_created
+    ON gift_transactions (creator_id, created_at DESC)
+  `;
+}
+
+export function getGiftCatalogItem(id: string): GiftCatalogItem | undefined {
+  return GIFT_CATALOG.find(item => item.id === id);
+}

--- a/app/api/routes-f/gifts/catalog/route.ts
+++ b/app/api/routes-f/gifts/catalog/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { GIFT_CATALOG } from "../_lib/db";
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json({
+    catalog: GIFT_CATALOG,
+  });
+}

--- a/app/api/routes-f/gifts/history/route.ts
+++ b/app/api/routes-f/gifts/history/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { ensureGiftSchema } from "../_lib/db";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensureGiftSchema();
+
+    const { rows } = await sql`
+      SELECT
+        gt.id,
+        gt.gift_id,
+        gt.gift_name,
+        gt.quantity,
+        gt.amount_usdc::text AS amount_usdc,
+        gt.tx_hash,
+        gt.stream_session_id AS stream_id,
+        gt.created_at,
+        gt.supporter_id,
+        gt.creator_id,
+        sender.username AS sender_username,
+        sender.avatar AS sender_avatar,
+        recipient.username AS recipient_username,
+        recipient.avatar AS recipient_avatar,
+        CASE
+          WHEN gt.supporter_id = ${session.userId} THEN 'sent'
+          ELSE 'received'
+        END AS direction
+      FROM gift_transactions gt
+      LEFT JOIN users sender ON sender.id = gt.supporter_id
+      LEFT JOIN users recipient ON recipient.id = gt.creator_id
+      WHERE gt.supporter_id = ${session.userId}
+         OR gt.creator_id = ${session.userId}
+      ORDER BY gt.created_at DESC
+      LIMIT 100
+    `;
+
+    return NextResponse.json({
+      history: rows,
+    });
+  } catch (error) {
+    console.error("[routes-f gifts/history GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch gift history" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/gifts/route.ts
+++ b/app/api/routes-f/gifts/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { ensureGiftSchema, getGiftCatalogItem } from "./_lib/db";
+
+const sendGiftSchema = z.object({
+  recipient_id: uuidSchema,
+  gift_id: z.enum(["flower", "candy", "crown", "lion", "dragon"]),
+  quantity: z.number().int().min(1).max(100),
+  stream_id: uuidSchema.optional(),
+  tx_hash: z.string().trim().min(1).max(255).optional(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, sendGiftSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensureGiftSchema();
+
+    const { recipient_id, gift_id, quantity, stream_id, tx_hash } =
+      bodyResult.data;
+    const gift = getGiftCatalogItem(gift_id);
+
+    if (!gift) {
+      return NextResponse.json({ error: "Gift not found" }, { status: 404 });
+    }
+
+    const { rows: recipientRows } = await sql`
+      SELECT id, username
+      FROM users
+      WHERE id = ${recipient_id}
+      LIMIT 1
+    `;
+
+    if (recipientRows.length === 0) {
+      return NextResponse.json(
+        { error: "Recipient not found" },
+        { status: 404 }
+      );
+    }
+
+    const amountUsd = gift.price_usd * quantity;
+
+    const { rows } = await sql`
+      INSERT INTO gift_transactions (
+        supporter_id,
+        creator_id,
+        recipient_id,
+        stream_session_id,
+        gift_id,
+        gift_name,
+        quantity,
+        amount_usdc,
+        tx_hash
+      )
+      VALUES (
+        ${session.userId},
+        ${recipient_id},
+        ${recipient_id},
+        ${stream_id ?? null},
+        ${gift.id},
+        ${gift.name},
+        ${quantity},
+        ${amountUsd},
+        ${tx_hash ?? null}
+      )
+      RETURNING
+        id,
+        supporter_id,
+        creator_id,
+        recipient_id,
+        stream_session_id AS stream_id,
+        gift_id,
+        gift_name,
+        quantity,
+        amount_usdc::text AS amount_usdc,
+        tx_hash,
+        created_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[routes-f gifts POST]", error);
+    return NextResponse.json({ error: "Failed to send gift" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/maintenance/route.ts
+++ b/app/api/routes-f/maintenance/route.ts
@@ -82,6 +82,8 @@ export async function POST(req: NextRequest): Promise<Response> {
   const result = await validateBody(req, activateSchema);
   if (result instanceof NextResponse) return result;
   const { message, estimated_end, affects, block_new_streams } = result.data;
+  const impactAreas = [...(affects ?? ["all"])];
+  const serializedImpactAreas = JSON.stringify(impactAreas);
 
   await ensureMaintenanceTable();
 
@@ -98,7 +100,9 @@ export async function POST(req: NextRequest): Promise<Response> {
       ${message},
       NOW(),
       ${estimated_end?.toISOString() ?? null},
-      ${affects as string[]},
+      ARRAY(
+        SELECT jsonb_array_elements_text(${serializedImpactAreas}::jsonb)
+      ),
       ${auth.session.userId}
     )
     RETURNING *
@@ -106,7 +110,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   // Store block_new_streams flag in metadata-style column if needed —
   // persisted in the affects array as a convention marker
-  if (block_new_streams && !affects.includes("streaming")) {
+  if (block_new_streams && !impactAreas.includes("streaming")) {
     await sql`
       UPDATE maintenance_windows
       SET affects = array_append(affects, 'streaming')

--- a/app/api/routes-f/polls/[id]/route.ts
+++ b/app/api/routes-f/polls/[id]/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { closeExpiredPolls, ensurePollSchema } from "../_lib/db";
+
+const updatePollSchema = z.object({
+  question: z.string().trim().min(1).max(200).optional(),
+  options: z.array(z.string().trim().min(1).max(80)).min(2).max(6).optional(),
+  duration_seconds: z.number().int().min(15).max(600).optional(),
+  status: z.enum(["active", "closed"]).optional(),
+});
+
+async function getOwnedPoll(id: string, userId: string) {
+  const { rows } = await sql<{
+    id: string;
+    streamer_id: string;
+    options: Array<{ id: number; text: string }>;
+    status: string;
+  }>`
+    SELECT id, streamer_id, options, status
+    FROM stream_polls
+    WHERE id = ${id}
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return {
+      error: NextResponse.json({ error: "Poll not found" }, { status: 404 }),
+    };
+  }
+
+  if (rows[0].streamer_id !== userId) {
+    return {
+      error: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { poll: rows[0] };
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updatePollSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensurePollSchema();
+    await closeExpiredPolls();
+
+    const { id } = await params;
+    const owned = await getOwnedPoll(id, session.userId);
+    if (owned.error) {
+      return owned.error;
+    }
+
+    const existing = owned.poll!;
+    const nextOptions = bodyResult.data.options
+      ? bodyResult.data.options.map((text, index) => ({ id: index + 1, text }))
+      : existing.options;
+    const nextStatus = bodyResult.data.status ?? existing.status;
+    const closesAt = bodyResult.data.duration_seconds
+      ? new Date(
+          Date.now() + bodyResult.data.duration_seconds * 1000
+        ).toISOString()
+      : null;
+
+    await sql`
+      UPDATE stream_polls
+      SET
+        question = COALESCE(${bodyResult.data.question ?? null}, question),
+        options = ${JSON.stringify(nextOptions)}::jsonb,
+        duration_seconds = COALESCE(${bodyResult.data.duration_seconds ?? null}, duration_seconds),
+        status = ${nextStatus},
+        closes_at = COALESCE(${closesAt}, closes_at)
+      WHERE id = ${id}
+    `;
+
+    return NextResponse.json({ id, status: nextStatus });
+  } catch (error) {
+    console.error("[routes-f polls/:id PATCH]", error);
+    return NextResponse.json(
+      { error: "Failed to update poll" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  try {
+    await ensurePollSchema();
+
+    const { id } = await params;
+    const owned = await getOwnedPoll(id, session.userId);
+    if (owned.error) {
+      return owned.error;
+    }
+
+    await sql`
+      DELETE FROM stream_polls
+      WHERE id = ${id}
+    `;
+
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    console.error("[routes-f polls/:id DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to delete poll" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/polls/[id]/vote/route.ts
+++ b/app/api/routes-f/polls/[id]/vote/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { closeExpiredPolls, ensurePollSchema } from "../../_lib/db";
+
+const voteSchema = z.object({
+  option_id: z.number().int().min(1),
+});
+
+async function buildVoteResponse(pollId: string, viewerId: string) {
+  const { rows: pollRows } = await sql<{
+    id: string;
+    question: string;
+    options: Array<{ id: number; text: string }>;
+    status: string;
+    closes_at: string;
+  }>`
+    SELECT id, question, options, status, closes_at
+    FROM stream_polls
+    WHERE id = ${pollId}
+    LIMIT 1
+  `;
+
+  if (pollRows.length === 0) {
+    return null;
+  }
+
+  const { rows: voteRows } = await sql<{ option_id: number; votes: number }>`
+    SELECT option_id, COUNT(*)::int AS votes
+    FROM poll_votes
+    WHERE poll_id = ${pollId}
+    GROUP BY option_id
+  `;
+
+  const { rows: viewerRows } = await sql<{ option_id: number }>`
+    SELECT option_id
+    FROM poll_votes
+    WHERE poll_id = ${pollId}
+      AND voter_id = ${viewerId}
+    LIMIT 1
+  `;
+
+  const totalVotes = voteRows.reduce((sum, row) => sum + Number(row.votes), 0);
+  const voteMap = new Map(
+    voteRows.map(row => [Number(row.option_id), Number(row.votes)])
+  );
+
+  return {
+    id: pollRows[0].id,
+    question: pollRows[0].question,
+    options: (pollRows[0].options ?? []).map(option => {
+      const votes = voteMap.get(option.id) ?? 0;
+      return {
+        ...option,
+        votes,
+        percentage: totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0,
+      };
+    }),
+    status: pollRows[0].status,
+    closes_at: pollRows[0].closes_at,
+    viewer_voted: viewerRows[0]?.option_id ?? null,
+  };
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, voteSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    await ensurePollSchema();
+    await closeExpiredPolls();
+
+    const { id } = await params;
+    const { rows: pollRows } = await sql<{
+      id: string;
+      options: Array<{ id: number; text: string }>;
+      status: string;
+      closes_at: string;
+    }>`
+      SELECT id, options, status, closes_at
+      FROM stream_polls
+      WHERE id = ${id}
+      LIMIT 1
+    `;
+
+    if (pollRows.length === 0) {
+      return NextResponse.json({ error: "Poll not found" }, { status: 404 });
+    }
+
+    const poll = pollRows[0];
+    if (poll.status !== "active" || new Date(poll.closes_at) <= new Date()) {
+      return NextResponse.json({ error: "Poll has closed" }, { status: 410 });
+    }
+
+    const validOptionIds = new Set(
+      (poll.options ?? []).map(option => option.id)
+    );
+    if (!validOptionIds.has(bodyResult.data.option_id)) {
+      return NextResponse.json({ error: "Invalid option_id" }, { status: 400 });
+    }
+
+    await sql`
+      INSERT INTO poll_votes (poll_id, voter_id, option_id)
+      VALUES (${id}, ${session.userId}, ${bodyResult.data.option_id})
+      ON CONFLICT (poll_id, voter_id)
+      DO UPDATE SET
+        option_id = EXCLUDED.option_id,
+        voted_at = NOW()
+    `;
+
+    const payload = await buildVoteResponse(id, session.userId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error("[routes-f polls/:id/vote POST]", error);
+    return NextResponse.json({ error: "Failed to cast vote" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/polls/__tests__/route.test.ts
+++ b/app/api/routes-f/polls/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+jest.mock("@/app/api/routes-f/_lib/session", () => ({
+  getOptionalSession: jest.fn(),
+}));
+jest.mock("../_lib/db", () => ({
+  ensurePollSchema: jest.fn().mockResolvedValue(undefined),
+  closeExpiredPolls: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import { GET, POST } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const getOptionalSessionMock = getOptionalSession as jest.Mock;
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f polls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({
+      ok: true,
+      userId: "streamer-1",
+      wallet: null,
+      privyId: "did:privy:streamer",
+      username: "streamer",
+      email: "streamer@example.com",
+    });
+    getOptionalSessionMock.mockResolvedValue(null);
+  });
+
+  it("returns the active poll for a stream", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: "poll-1" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "poll-1",
+            question: "Which game next?",
+            options: [
+              { id: 1, text: "Valorant" },
+              { id: 2, text: "Minecraft" },
+            ],
+            status: "active",
+            closes_at: "2026-03-29T12:00:00Z",
+            viewer_voted: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { option_id: 1, votes: 4 },
+          { option_id: 2, votes: 2 },
+        ],
+      });
+
+    const res = await GET(
+      makeRequest(
+        "GET",
+        "/api/routes-f/polls?stream_id=550e8400-e29b-41d4-a716-446655440000"
+      )
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.options[0].votes).toBe(4);
+    expect(json.options[0].percentage).toBe(67);
+  });
+
+  it("creates a poll for the stream owner", async () => {
+    sqlMock
+      .mockResolvedValueOnce({
+        rows: [{ user_id: "streamer-1" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: "poll-1" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "poll-1",
+            question: "Which game next?",
+            options: [
+              { id: 1, text: "Valorant" },
+              { id: 2, text: "Minecraft" },
+            ],
+            status: "active",
+            closes_at: "2026-03-29T12:00:00Z",
+            viewer_voted: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/polls", {
+        stream_id: "550e8400-e29b-41d4-a716-446655440000",
+        question: "Which game next?",
+        options: ["Valorant", "Minecraft"],
+        duration_seconds: 60,
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.question).toBe("Which game next?");
+  });
+});

--- a/app/api/routes-f/polls/_lib/db.ts
+++ b/app/api/routes-f/polls/_lib/db.ts
@@ -1,0 +1,62 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensurePollSchema(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS stream_polls (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id UUID NOT NULL REFERENCES stream_sessions(id) ON DELETE CASCADE,
+      streamer_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      question TEXT NOT NULL,
+      options JSONB NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      duration_seconds INTEGER NOT NULL DEFAULT 60,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      closes_at TIMESTAMPTZ NOT NULL
+    )
+  `;
+
+  await sql`
+    ALTER TABLE stream_polls
+    ADD COLUMN IF NOT EXISTS streamer_id UUID REFERENCES users(id) ON DELETE CASCADE
+  `;
+
+  await sql`
+    ALTER TABLE stream_polls
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active'
+  `;
+
+  await sql`
+    ALTER TABLE stream_polls
+    ADD COLUMN IF NOT EXISTS closes_at TIMESTAMPTZ
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS poll_votes (
+      poll_id UUID NOT NULL REFERENCES stream_polls(id) ON DELETE CASCADE,
+      voter_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      option_id INTEGER NOT NULL,
+      voted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (poll_id, voter_id)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_stream_polls_stream_created
+    ON stream_polls (stream_id, created_at DESC)
+  `;
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_stream_polls_one_active
+    ON stream_polls (stream_id)
+    WHERE status = 'active'
+  `;
+}
+
+export async function closeExpiredPolls(): Promise<void> {
+  await sql`
+    UPDATE stream_polls
+    SET status = 'closed'
+    WHERE status = 'active'
+      AND closes_at <= NOW()
+  `;
+}

--- a/app/api/routes-f/polls/route.ts
+++ b/app/api/routes-f/polls/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import { closeExpiredPolls, ensurePollSchema } from "./_lib/db";
+
+const pollQuerySchema = z.object({
+  stream_id: uuidSchema,
+});
+
+const createPollSchema = z.object({
+  stream_id: uuidSchema,
+  question: z.string().trim().min(1).max(200),
+  options: z.array(z.string().trim().min(1).max(80)).min(2).max(6),
+  duration_seconds: z.number().int().min(15).max(600).default(60),
+});
+
+async function buildPollResponse(pollId: string, viewerId?: string | null) {
+  const { rows: pollRows } = await sql<{
+    id: string;
+    question: string;
+    options: Array<{ id: number; text: string }>;
+    status: string;
+    closes_at: string;
+    viewer_voted: number | null;
+  }>`
+    SELECT
+      p.id,
+      p.question,
+      p.options,
+      p.status,
+      p.closes_at,
+      (
+        SELECT pv.option_id
+        FROM poll_votes pv
+        WHERE pv.poll_id = p.id
+          AND pv.voter_id = ${viewerId ?? null}
+        LIMIT 1
+      ) AS viewer_voted
+    FROM stream_polls p
+    WHERE p.id = ${pollId}
+    LIMIT 1
+  `;
+
+  if (pollRows.length === 0) {
+    return null;
+  }
+
+  const poll = pollRows[0];
+  const { rows: voteRows } = await sql<{ option_id: number; votes: number }>`
+    SELECT option_id, COUNT(*)::int AS votes
+    FROM poll_votes
+    WHERE poll_id = ${pollId}
+    GROUP BY option_id
+  `;
+
+  const totalVotes = voteRows.reduce((sum, row) => sum + Number(row.votes), 0);
+  const voteMap = new Map(
+    voteRows.map(row => [Number(row.option_id), Number(row.votes)])
+  );
+  const options = (poll.options ?? []).map(option => {
+    const votes = voteMap.get(option.id) ?? 0;
+    const percentage =
+      totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
+    return { ...option, votes, percentage };
+  });
+
+  return {
+    id: poll.id,
+    question: poll.question,
+    options,
+    status:
+      poll.status === "active" && new Date(poll.closes_at) <= new Date()
+        ? "closed"
+        : poll.status,
+    closes_at: poll.closes_at,
+    viewer_voted: poll.viewer_voted ?? null,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    pollQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    await ensurePollSchema();
+    await closeExpiredPolls();
+
+    const session = await getOptionalSession(req);
+    const { rows } = await sql<{ id: string }>`
+      SELECT id
+      FROM stream_polls
+      WHERE stream_id = ${queryResult.data.stream_id}
+        AND status = 'active'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ poll: null });
+    }
+
+    const poll = await buildPollResponse(rows[0].id, session?.userId ?? null);
+    return NextResponse.json(poll);
+  } catch (error) {
+    console.error("[routes-f polls GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch poll" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createPollSchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { stream_id, question, options } = bodyResult.data;
+  const durationSeconds = bodyResult.data.duration_seconds ?? 60;
+
+  try {
+    await ensurePollSchema();
+    await closeExpiredPolls();
+
+    const { rows: streamRows } = await sql<{ user_id: string }>`
+      SELECT user_id
+      FROM stream_sessions
+      WHERE id = ${stream_id}
+      LIMIT 1
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+    }
+
+    if (streamRows[0].user_id !== session.userId) {
+      return NextResponse.json(
+        { error: "Only the stream owner can create polls" },
+        { status: 403 }
+      );
+    }
+
+    const closesAt = new Date(
+      Date.now() + durationSeconds * 1000
+    ).toISOString();
+    const normalizedOptions = options.map((text, index) => ({
+      id: index + 1,
+      text,
+    }));
+
+    try {
+      const { rows } = await sql<{ id: string }>`
+        INSERT INTO stream_polls (
+          stream_id,
+          streamer_id,
+          question,
+          options,
+          status,
+          duration_seconds,
+          closes_at
+        )
+        VALUES (
+          ${stream_id},
+          ${session.userId},
+          ${question},
+          ${JSON.stringify(normalizedOptions)}::jsonb,
+          'active',
+          ${durationSeconds},
+          ${closesAt}
+        )
+        RETURNING id
+      `;
+
+      const poll = await buildPollResponse(rows[0].id, session.userId);
+      return NextResponse.json(poll, { status: 201 });
+    } catch (error) {
+      const pgError = error as { code?: string };
+      if (pgError.code === "23505") {
+        return NextResponse.json(
+          { error: "Only one active poll is allowed per stream" },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
+  } catch (error) {
+    console.error("[routes-f polls POST]", error);
+    return NextResponse.json(
+      { error: "Failed to create poll" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/reactions/[streamId]/route.ts
+++ b/app/api/routes-f/reactions/[streamId]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import {
+  enforceReactionRateLimit,
+  getReactionSummary,
+  incrementReaction,
+  reactionEmojiSchema,
+} from "../_lib/reactions";
+import { z } from "zod";
+
+const reactionBodySchema = z.object({
+  emoji: reactionEmojiSchema,
+});
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ streamId: string }> }
+): Promise<NextResponse> {
+  const { streamId } = await params;
+
+  try {
+    const summary = await getReactionSummary(streamId);
+    return NextResponse.json(summary, {
+      headers: {
+        "Cache-Control": "public, max-age=2, stale-while-revalidate=2",
+      },
+    });
+  } catch (error) {
+    console.error("[routes-f reactions/:streamId GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch reactions" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ streamId: string }> }
+): Promise<NextResponse> {
+  const { streamId } = await params;
+  const bodyResult = await validateBody(req, reactionBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  try {
+    const session = await getOptionalSession(req);
+    const isLimited = await enforceReactionRateLimit(
+      req,
+      streamId,
+      session?.userId ?? null
+    );
+
+    if (isLimited) {
+      return NextResponse.json(
+        { error: "Too many reactions. Please slow down." },
+        { status: 429, headers: { "Retry-After": "10" } }
+      );
+    }
+
+    await incrementReaction(streamId, bodyResult.data.emoji);
+    const summary = await getReactionSummary(streamId);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        emoji: bodyResult.data.emoji,
+        reactions: summary.reactions,
+        total: summary.total,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f reactions/:streamId POST]", error);
+    return NextResponse.json(
+      { error: "Failed to record reaction" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/reactions/__tests__/route.test.ts
+++ b/app/api/routes-f/reactions/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@/app/api/routes-f/_lib/session", () => ({
+  getOptionalSession: jest.fn(),
+}));
+
+jest.mock("../_lib/reactions", () => ({
+  REACTIONS: ["❤️", "🔥", "😂", "👏", "💜", "🎉", "😮", "👑"],
+  reactionEmojiSchema: require("zod").z.enum([
+    "❤️",
+    "🔥",
+    "😂",
+    "👏",
+    "💜",
+    "🎉",
+    "😮",
+    "👑",
+  ]),
+  enforceReactionRateLimit: jest.fn(),
+  getReactionSummary: jest.fn(),
+  incrementReaction: jest.fn(),
+}));
+
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import {
+  enforceReactionRateLimit,
+  getReactionSummary,
+  incrementReaction,
+} from "../_lib/reactions";
+import { GET, POST } from "../[streamId]/route";
+
+const getOptionalSessionMock = getOptionalSession as jest.Mock;
+const enforceReactionRateLimitMock = enforceReactionRateLimit as jest.Mock;
+const getReactionSummaryMock = getReactionSummary as jest.Mock;
+const incrementReactionMock = incrementReaction as jest.Mock;
+
+function makeRequest(method: string, path: string, body?: object) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f reactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getOptionalSessionMock.mockResolvedValue(null);
+    enforceReactionRateLimitMock.mockResolvedValue(false);
+    getReactionSummaryMock.mockResolvedValue({
+      reactions: { "🔥": 3 },
+      total: 3,
+    });
+    incrementReactionMock.mockResolvedValue(undefined);
+  });
+
+  it("returns reaction counts for a stream", async () => {
+    const res = await GET(
+      makeRequest("GET", "/api/routes-f/reactions/stream-1"),
+      {
+        params: Promise.resolve({ streamId: "stream-1" }),
+      }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.total).toBe(3);
+    expect(json.reactions["🔥"]).toBe(3);
+  });
+
+  it("records an anonymous reaction", async () => {
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/reactions/stream-1", { emoji: "🔥" }),
+      { params: Promise.resolve({ streamId: "stream-1" }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(incrementReactionMock).toHaveBeenCalledWith("stream-1", "🔥");
+    expect(json.total).toBe(3);
+  });
+
+  it("returns 429 when reaction rate limit is hit", async () => {
+    enforceReactionRateLimitMock.mockResolvedValue(true);
+
+    const res = await POST(
+      makeRequest("POST", "/api/routes-f/reactions/stream-1", { emoji: "🔥" }),
+      { params: Promise.resolve({ streamId: "stream-1" }) }
+    );
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/app/api/routes-f/reactions/_lib/reactions.ts
+++ b/app/api/routes-f/reactions/_lib/reactions.ts
@@ -1,0 +1,219 @@
+import { NextRequest } from "next/server";
+import { sql } from "@vercel/postgres";
+import { Ratelimit } from "@upstash/ratelimit";
+import { z } from "zod";
+import { getUpstashRedis } from "@/lib/upstash";
+
+export const REACTIONS = [
+  "❤️",
+  "🔥",
+  "😂",
+  "👏",
+  "💜",
+  "🎉",
+  "😮",
+  "👑",
+] as const;
+
+export const reactionEmojiSchema = z.enum(REACTIONS);
+
+type ReactionEmoji = (typeof REACTIONS)[number];
+type ReactionCounts = Record<string, number>;
+
+const CACHE_TTL_SECONDS = 2;
+const RATE_LIMIT_WINDOW_SECONDS = 10;
+const RATE_LIMIT_MAX = 10;
+
+const memoryRateLimiter = new Map<string, number[]>();
+const memoryCache = new Map<
+  string,
+  { expiresAt: number; value: ReactionSummary }
+>();
+
+let rateLimiter: Ratelimit | null | undefined;
+
+export type ReactionSummary = {
+  reactions: ReactionCounts;
+  total: number;
+};
+
+function getReactionKey(streamId: string, emoji: ReactionEmoji): string {
+  return `reactions:${streamId}:${emoji}`;
+}
+
+function getReactionCacheKey(streamId: string): string {
+  return `reactions-cache:${streamId}`;
+}
+
+function getRequesterId(req: NextRequest, userId?: string | null): string {
+  if (userId) {
+    return `user:${userId}`;
+  }
+
+  const forwarded = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const realIp = req.headers.get("x-real-ip")?.trim();
+  return `ip:${forwarded || realIp || "unknown"}`;
+}
+
+async function getRateLimiter(): Promise<Ratelimit | null> {
+  if (rateLimiter !== undefined) {
+    return rateLimiter;
+  }
+
+  const redis = await getUpstashRedis();
+  rateLimiter = redis
+    ? new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(
+          RATE_LIMIT_MAX,
+          `${RATE_LIMIT_WINDOW_SECONDS} s`
+        ),
+        analytics: false,
+      })
+    : null;
+
+  return rateLimiter;
+}
+
+function getCachedMemorySummary(streamId: string): ReactionSummary | null {
+  const cached = memoryCache.get(streamId);
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    memoryCache.delete(streamId);
+    return null;
+  }
+
+  return cached.value;
+}
+
+function setCachedMemorySummary(
+  streamId: string,
+  summary: ReactionSummary
+): void {
+  memoryCache.set(streamId, {
+    expiresAt: Date.now() + CACHE_TTL_SECONDS * 1000,
+    value: summary,
+  });
+}
+
+export async function ensureStreamReactionColumns(): Promise<void> {
+  await sql`
+    ALTER TABLE stream_sessions
+    ADD COLUMN IF NOT EXISTS reaction_counts JSONB NOT NULL DEFAULT '{}'::jsonb
+  `;
+
+  await sql`
+    ALTER TABLE stream_sessions
+    ADD COLUMN IF NOT EXISTS reaction_total INTEGER NOT NULL DEFAULT 0
+  `;
+}
+
+export async function enforceReactionRateLimit(
+  req: NextRequest,
+  streamId: string,
+  userId?: string | null
+): Promise<boolean> {
+  const requesterId = `${streamId}:${getRequesterId(req, userId)}`;
+  const redisLimiter = await getRateLimiter();
+
+  if (redisLimiter) {
+    const { success } = await redisLimiter.limit(requesterId);
+    return !success;
+  }
+
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_SECONDS * 1000;
+  const current = (memoryRateLimiter.get(requesterId) ?? []).filter(
+    timestamp => timestamp > windowStart
+  );
+  current.push(now);
+  memoryRateLimiter.set(requesterId, current);
+  return current.length > RATE_LIMIT_MAX;
+}
+
+export async function incrementReaction(
+  streamId: string,
+  emoji: ReactionEmoji
+): Promise<void> {
+  const redis = await getUpstashRedis();
+
+  if (redis) {
+    await redis.incr(getReactionKey(streamId, emoji));
+    await redis.del(getReactionCacheKey(streamId));
+    return;
+  }
+
+  const current = getCachedMemorySummary(streamId) ?? {
+    reactions: {},
+    total: 0,
+  };
+  current.reactions[emoji] = (current.reactions[emoji] ?? 0) + 1;
+  current.total += 1;
+  setCachedMemorySummary(streamId, current);
+}
+
+export async function getReactionSummary(
+  streamId: string
+): Promise<ReactionSummary> {
+  const redis = await getUpstashRedis();
+
+  if (redis) {
+    const cacheKey = getReactionCacheKey(streamId);
+    const cached = await redis.get<ReactionSummary>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const counts = await Promise.all(
+      REACTIONS.map(async emoji => {
+        const value = await redis.get<number>(getReactionKey(streamId, emoji));
+        return [emoji, Number(value ?? 0)] as const;
+      })
+    );
+
+    const reactions = counts.reduce<ReactionCounts>((acc, [emoji, count]) => {
+      if (count > 0) {
+        acc[emoji] = count;
+      }
+      return acc;
+    }, {});
+
+    const total = counts.reduce((sum, [, count]) => sum + count, 0);
+    const summary = { reactions, total };
+
+    await redis.set(cacheKey, summary, { ex: CACHE_TTL_SECONDS });
+    return summary;
+  }
+
+  const cached = getCachedMemorySummary(streamId);
+  return cached ?? { reactions: {}, total: 0 };
+}
+
+export async function aggregateAndFlushStreamReactions(
+  streamSessionId: string
+): Promise<ReactionSummary> {
+  await ensureStreamReactionColumns();
+
+  const summary = await getReactionSummary(streamSessionId);
+
+  await sql`
+    UPDATE stream_sessions
+    SET
+      reaction_counts = ${JSON.stringify(summary.reactions)}::jsonb,
+      reaction_total = ${summary.total},
+      ended_at = COALESCE(ended_at, CURRENT_TIMESTAMP)
+    WHERE id = ${streamSessionId}
+  `;
+
+  const redis = await getUpstashRedis();
+  if (redis) {
+    const keys = REACTIONS.map(emoji => getReactionKey(streamSessionId, emoji));
+    await redis.del(...keys, getReactionCacheKey(streamSessionId));
+  }
+
+  memoryCache.delete(streamSessionId);
+  return summary;
+}

--- a/app/api/routes-f/reactions/route.ts
+++ b/app/api/routes-f/reactions/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { REACTIONS } from "./_lib/reactions";
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json({
+    allowed_reactions: REACTIONS,
+  });
+}

--- a/app/api/routes-f/recommendations/__tests__/route.test.ts
+++ b/app/api/routes-f/recommendations/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({ sql: jest.fn() }));
+jest.mock("@/app/api/routes-f/_lib/session", () => ({
+  getOptionalSession: jest.fn(),
+}));
+jest.mock("@/lib/upstash", () => ({
+  getUpstashRedis: jest.fn().mockResolvedValue(null),
+}));
+
+import { sql } from "@vercel/postgres";
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import { GET } from "../route";
+
+const sqlMock = sql as unknown as jest.Mock;
+const getOptionalSessionMock = getOptionalSession as jest.Mock;
+
+function makeRequest(path: string) {
+  return new Request(
+    `http://localhost${path}`
+  ) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f recommendations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns anonymous trending recommendations", async () => {
+    getOptionalSessionMock.mockResolvedValue(null);
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "user-1",
+          username: "alice",
+          avatar: null,
+          current_viewers: 120,
+          creator: {
+            streamTitle: "Ranked grind",
+            category: "Gaming",
+            tags: ["fps"],
+          },
+          viewer_score: 0.12,
+          freshness_score: 0,
+        },
+      ],
+    });
+
+    const res = await GET(makeRequest("/api/routes-f/recommendations"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.anonymous).toBe(true);
+    expect(json.recommended[0].reason).toBe("Trending live stream");
+  });
+
+  it("returns personalized recommendations for authenticated users", async () => {
+    getOptionalSessionMock.mockResolvedValue({ userId: "viewer-1" });
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "user-2",
+          username: "bob",
+          avatar: null,
+          current_viewers: 54,
+          creator: {
+            streamTitle: "Live coding",
+            category: "Technology",
+            tags: ["code"],
+          },
+          follow_score: 1,
+          tip_score: 0,
+          category_score: 0,
+          tag_score: 0,
+          viewer_score: 0.054,
+          freshness_score: 0,
+        },
+      ],
+    });
+
+    const res = await GET(makeRequest("/api/routes-f/recommendations"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.anonymous).toBe(false);
+    expect(json.recommended[0].reason).toBe("Creator you follow is live");
+  });
+});

--- a/app/api/routes-f/recommendations/route.ts
+++ b/app/api/routes-f/recommendations/route.ts
@@ -1,0 +1,249 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { getOptionalSession } from "@/app/api/routes-f/_lib/session";
+import { getUpstashRedis } from "@/lib/upstash";
+
+const recommendationsQuerySchema = z.object({
+  exclude_stream_id: z.string().uuid().optional(),
+});
+
+type RecommendationRow = {
+  id: string;
+  username: string;
+  avatar: string | null;
+  current_viewers: number | null;
+  creator: { streamTitle?: string; category?: string; tags?: string[] } | null;
+  follow_score?: number | null;
+  tip_score?: number | null;
+  category_score?: number | null;
+  tag_score?: number | null;
+  viewer_score?: number | null;
+  freshness_score?: number | null;
+};
+
+async function getCachedRecommendations<T>(
+  key: string,
+  ttlSeconds: number,
+  loader: () => Promise<T>
+): Promise<T> {
+  const redis = await getUpstashRedis();
+  if (redis) {
+    const cached = await redis.get<T>(key);
+    if (cached) {
+      return cached;
+    }
+
+    const data = await loader();
+    await redis.set(key, data, { ex: ttlSeconds });
+    return data;
+  }
+
+  return loader();
+}
+
+function toRecommendation(row: RecommendationRow) {
+  const category = row.creator?.category ?? "General";
+  const reason =
+    Number(row.follow_score ?? 0) > 0
+      ? "Creator you follow is live"
+      : Number(row.tip_score ?? 0) > 0
+        ? "Creator you previously tipped"
+        : Number(row.category_score ?? 0) > 0
+          ? "Category you watch"
+          : Number(row.tag_score ?? 0) > 0
+            ? "Tags you watch"
+            : Number(row.freshness_score ?? 0) > 0
+              ? "New creator to discover"
+              : "Trending live stream";
+
+  return {
+    username: row.username,
+    avatar: row.avatar,
+    stream_title: row.creator?.streamTitle ?? "Live now",
+    category,
+    viewer_count: Number(row.current_viewers ?? 0),
+    is_live: true,
+    reason,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    recommendationsQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    const session = await getOptionalSession(req);
+    const excludeStreamId = queryResult.data.exclude_stream_id ?? null;
+    const cacheKey = session
+      ? `recommendations:user:${session.userId}:${excludeStreamId ?? "none"}`
+      : `recommendations:anon:${excludeStreamId ?? "none"}`;
+    const cacheTtl = session ? 300 : 120;
+
+    const payload = await getCachedRecommendations(
+      cacheKey,
+      cacheTtl,
+      async () => {
+        if (!session) {
+          const { rows } = await sql<RecommendationRow>`
+          SELECT
+            u.id,
+            u.username,
+            u.avatar,
+            u.current_viewers,
+            u.creator,
+            (LEAST(COALESCE(u.current_viewers, 0), 1000) * 0.001)::float AS viewer_score,
+            CASE
+              WHEN u.created_at >= NOW() - INTERVAL '30 days' THEN 0.2
+              ELSE 0
+            END::float AS freshness_score
+          FROM users u
+          WHERE u.is_live = true
+            AND (${excludeStreamId}::uuid IS NULL OR u.id <> ${excludeStreamId})
+          ORDER BY
+            ((LEAST(COALESCE(u.current_viewers, 0), 1000) * 0.001) +
+            CASE WHEN u.created_at >= NOW() - INTERVAL '30 days' THEN 0.2 ELSE 0 END) DESC,
+            u.current_viewers DESC,
+            u.username ASC
+          LIMIT 20
+        `;
+
+          return {
+            recommended: rows.map(toRecommendation),
+            anonymous: true,
+          };
+        }
+
+        const { rows } = await sql<RecommendationRow>`
+        WITH user_categories AS (
+          SELECT DISTINCT LOWER(category) AS category
+          FROM route_f_watch_events
+          WHERE user_id = ${session.userId}
+        ),
+        user_tags AS (
+          SELECT DISTINCT LOWER(tag) AS tag
+          FROM route_f_watch_events e
+          JOIN users watched_creator ON watched_creator.id = e.stream_id
+          CROSS JOIN LATERAL UNNEST(
+            COALESCE(
+              ARRAY(
+                SELECT jsonb_array_elements_text(
+                  CASE
+                    WHEN jsonb_typeof(COALESCE(watched_creator.creator, '{}'::jsonb)->'tags', '[]'::jsonb) = 'array'
+                      THEN COALESCE(watched_creator.creator, '{}'::jsonb)->'tags'
+                    ELSE '[]'::jsonb
+                  END
+                )
+              ),
+              ARRAY[]::text[]
+            )
+          ) AS tag
+          WHERE e.user_id = ${session.userId}
+        ),
+        tipped_creators AS (
+          SELECT DISTINCT recipient_id
+          FROM tip_transactions
+          WHERE sender_id = ${session.userId}
+        )
+        SELECT
+          u.id,
+          u.username,
+          u.avatar,
+          u.current_viewers,
+          u.creator,
+          CASE WHEN uf.follower_id IS NOT NULL THEN 1.0 ELSE 0 END::float AS follow_score,
+          CASE WHEN tc.recipient_id IS NOT NULL THEN 0.9 ELSE 0 END::float AS tip_score,
+          CASE
+            WHEN uc.category IS NOT NULL
+              AND LOWER(COALESCE(u.creator->>'category', '')) = uc.category
+            THEN 0.7
+            ELSE 0
+          END::float AS category_score,
+          CASE
+            WHEN ut.tag IS NOT NULL THEN 0.6
+            ELSE 0
+          END::float AS tag_score,
+          (LEAST(COALESCE(u.current_viewers, 0), 1000) * 0.001)::float AS viewer_score,
+          CASE
+            WHEN u.created_at >= NOW() - INTERVAL '30 days' THEN 0.2
+            ELSE 0
+          END::float AS freshness_score
+        FROM users u
+        LEFT JOIN user_follows uf
+          ON uf.followee_id = u.id AND uf.follower_id = ${session.userId}
+        LEFT JOIN tipped_creators tc
+          ON tc.recipient_id = u.id
+        LEFT JOIN user_categories uc
+          ON LOWER(COALESCE(u.creator->>'category', '')) = uc.category
+        LEFT JOIN user_tags ut
+          ON EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(
+              CASE
+                WHEN jsonb_typeof(COALESCE(u.creator, '{}'::jsonb)->'tags', '[]'::jsonb) = 'array'
+                  THEN COALESCE(u.creator, '{}'::jsonb)->'tags'
+                ELSE '[]'::jsonb
+              END
+            ) AS creator_tag
+            WHERE LOWER(creator_tag) = ut.tag
+          )
+        WHERE u.is_live = true
+          AND u.id <> ${session.userId}
+          AND (${excludeStreamId}::uuid IS NULL OR u.id <> ${excludeStreamId})
+        GROUP BY
+          u.id,
+          u.username,
+          u.avatar,
+          u.current_viewers,
+          u.creator,
+          uf.follower_id,
+          tc.recipient_id,
+          uc.category,
+          ut.tag
+        ORDER BY
+          (
+            CASE WHEN uf.follower_id IS NOT NULL THEN 1.0 ELSE 0 END +
+            CASE WHEN tc.recipient_id IS NOT NULL THEN 0.9 ELSE 0 END +
+            CASE
+              WHEN uc.category IS NOT NULL
+                AND LOWER(COALESCE(u.creator->>'category', '')) = uc.category
+              THEN 0.7
+              ELSE 0
+            END +
+            CASE WHEN ut.tag IS NOT NULL THEN 0.6 ELSE 0 END +
+            (LEAST(COALESCE(u.current_viewers, 0), 1000) * 0.001) +
+            CASE WHEN u.created_at >= NOW() - INTERVAL '30 days' THEN 0.2 ELSE 0 END
+          ) DESC,
+          u.current_viewers DESC,
+          u.username ASC
+        LIMIT 20
+      `;
+
+        return {
+          recommended: rows.map(toRecommendation),
+          anonymous: false,
+        };
+      }
+    );
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": session
+          ? "private, max-age=300"
+          : "public, max-age=120",
+      },
+    });
+  } catch (error) {
+    console.error("[routes-f recommendations GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch recommendations" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/recommendations/similar/route.ts
+++ b/app/api/routes-f/recommendations/similar/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { usernameSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const similarQuerySchema = z.object({
+  username: usernameSchema,
+});
+
+type SimilarCreatorRow = {
+  username: string;
+  avatar: string | null;
+  creator: { category?: string; tags?: string[] } | null;
+  current_viewers: number | null;
+  shared_tags: string[] | null;
+  tag_overlap_count: number | null;
+};
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    similarQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  try {
+    const { rows: creatorRows } = await sql<{
+      id: string;
+      username: string;
+      creator: { category?: string; tags?: string[] } | null;
+    }>`
+      SELECT id, username, creator
+      FROM users
+      WHERE username = ${queryResult.data.username}
+      LIMIT 1
+    `;
+
+    if (creatorRows.length === 0) {
+      return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+    }
+
+    const creator = creatorRows[0];
+    const category = creator.creator?.category ?? null;
+    const serializedTags = JSON.stringify(creator.creator?.tags ?? []);
+
+    const { rows } = await sql<SimilarCreatorRow>`
+      SELECT
+        u.username,
+        u.avatar,
+        u.creator,
+        u.current_viewers,
+        COALESCE(
+          ARRAY(
+            SELECT DISTINCT tag
+            FROM jsonb_array_elements_text(
+              CASE
+                WHEN jsonb_typeof(COALESCE(u.creator, '{}'::jsonb)->'tags', '[]'::jsonb) = 'array'
+                  THEN COALESCE(u.creator, '{}'::jsonb)->'tags'
+                ELSE '[]'::jsonb
+              END
+            ) AS tag
+            WHERE tag IN (
+              SELECT jsonb_array_elements_text(${serializedTags}::jsonb)
+            )
+          ),
+          ARRAY[]::text[]
+        ) AS shared_tags,
+        COALESCE(
+          ARRAY_LENGTH(
+            ARRAY(
+              SELECT DISTINCT tag
+              FROM jsonb_array_elements_text(
+                CASE
+                  WHEN jsonb_typeof(COALESCE(u.creator, '{}'::jsonb)->'tags', '[]'::jsonb) = 'array'
+                    THEN COALESCE(u.creator, '{}'::jsonb)->'tags'
+                  ELSE '[]'::jsonb
+                END
+              ) AS tag
+              WHERE tag IN (
+                SELECT jsonb_array_elements_text(${serializedTags}::jsonb)
+              )
+            ),
+            1
+          ),
+          0
+        )::int AS tag_overlap_count
+      FROM users u
+      WHERE u.id <> ${creator.id}
+        AND (
+          (${category} IS NOT NULL AND LOWER(COALESCE(u.creator->>'category', '')) = LOWER(${category}))
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(
+              CASE
+                WHEN jsonb_typeof(COALESCE(u.creator, '{}'::jsonb)->'tags', '[]'::jsonb) = 'array'
+                  THEN COALESCE(u.creator, '{}'::jsonb)->'tags'
+                ELSE '[]'::jsonb
+              END
+            ) AS tag
+            WHERE tag IN (
+              SELECT jsonb_array_elements_text(${serializedTags}::jsonb)
+            )
+          )
+        )
+      ORDER BY
+        CASE
+          WHEN ${category} IS NOT NULL
+            AND LOWER(COALESCE(u.creator->>'category', '')) = LOWER(${category})
+          THEN 1
+          ELSE 0
+        END DESC,
+        tag_overlap_count DESC,
+        COALESCE(u.current_viewers, 0) DESC,
+        u.username ASC
+      LIMIT 20
+    `;
+
+    return NextResponse.json({
+      creator: queryResult.data.username,
+      similar: rows.map(row => ({
+        username: row.username,
+        avatar: row.avatar,
+        category: row.creator?.category ?? "General",
+        tags: row.creator?.tags ?? [],
+        viewer_count: Number(row.current_viewers ?? 0),
+        reason:
+          row.tag_overlap_count && row.tag_overlap_count > 0
+            ? "Overlapping category and tags"
+            : "Overlapping category",
+        shared_tags: row.shared_tags ?? [],
+      })),
+    });
+  } catch (error) {
+    console.error("[routes-f recommendations/similar GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch similar creators" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/streams/delete/route.ts
+++ b/app/api/streams/delete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@vercel/postgres";
 import { deleteMuxStream } from "@/lib/mux/server";
 import { verifySession } from "@/lib/auth/verify-session";
+import { aggregateAndFlushStreamReactions } from "@/app/api/routes-f/reactions/_lib/reactions";
 
 export async function DELETE(req: NextRequest) {
   // Verify caller is authenticated — identity comes from the server-side session
@@ -49,6 +50,18 @@ export async function DELETE(req: NextRequest) {
     }
 
     try {
+      const { rows: sessionRows } = await sql<{ id: string }>`
+        SELECT id
+        FROM stream_sessions
+        WHERE user_id = ${user.id} AND ended_at IS NULL
+        ORDER BY started_at DESC
+        LIMIT 1
+      `;
+
+      if (sessionRows.length > 0) {
+        await aggregateAndFlushStreamReactions(sessionRows[0].id);
+      }
+
       await sql`
         UPDATE stream_sessions SET
           ended_at = CURRENT_TIMESTAMP

--- a/app/api/webhooks/mux/route.ts
+++ b/app/api/webhooks/mux/route.ts
@@ -6,6 +6,7 @@ import {
   createRecordingReadyNotification,
   withNotificationTransaction,
 } from "@/lib/notifications";
+import { aggregateAndFlushStreamReactions } from "@/app/api/routes-f/reactions/_lib/reactions";
 
 /**
  * Mux Webhook Handler
@@ -207,6 +208,18 @@ export async function POST(req: Request) {
 
           if (userResult.rows.length > 0) {
             const user = userResult.rows[0];
+            const sessionResult = await sql<{ id: string }>`
+              SELECT id
+              FROM stream_sessions
+              WHERE user_id = ${user.id} AND ended_at IS NULL
+              ORDER BY started_at DESC
+              LIMIT 1
+            `;
+
+            if (sessionResult.rows.length > 0) {
+              await aggregateAndFlushStreamReactions(sessionResult.rows[0].id);
+            }
+
             await sql`
               UPDATE stream_sessions SET ended_at = CURRENT_TIMESTAMP
               WHERE user_id = ${user.id} AND ended_at IS NULL

--- a/components/stream/view-stream.tsx
+++ b/components/stream/view-stream.tsx
@@ -41,7 +41,7 @@ import { useChat } from "@/hooks/useChat";
 import { TipButton, TipModalContainer } from "@/components/tipping";
 import { useTipModal } from "@/hooks/useTipModal";
 import { toast } from "sonner";
-import AccessGate from "./AccessGate";
+import { AccessGate } from "./AccessGate";
 
 const socialIcons: Record<string, JSX.Element> = {
   twitter: <Twitter className="h-4 w-4" />,
@@ -585,9 +585,23 @@ const ViewStream = ({
                 {accessBlocked ? (
                   <div className="absolute inset-0 flex items-center justify-center bg-zinc-950 z-20 overflow-y-auto">
                     <AccessGate
-                      reason={accessReason}
                       streamerUsername={username}
-                      accessConfig={accessConfig}
+                      assetCode={
+                        accessConfig?.asset_code ??
+                        accessConfig?.assetCode ??
+                        "TOKEN"
+                      }
+                      minBalance={String(
+                        accessConfig?.min_balance ??
+                          accessConfig?.minBalance ??
+                          accessReason?.min_balance ??
+                          "1"
+                      )}
+                      onRetry={() => {
+                        setIsCheckingAccess(true);
+                        setAccessBlocked(false);
+                      }}
+                      isChecking={isCheckingAccess}
                     />
                   </div>
                 ) : isLive && userData?.playbackId ? (

--- a/lib/upstash.ts
+++ b/lib/upstash.ts
@@ -1,0 +1,24 @@
+import { Redis } from "@upstash/redis";
+
+let redis: Redis | null = null;
+
+export function hasUpstashRedis(): boolean {
+  return Boolean(
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+  );
+}
+
+export async function getUpstashRedis(): Promise<Redis | null> {
+  if (!hasUpstashRedis()) {
+    return null;
+  }
+
+  if (!redis) {
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL!,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+    });
+  }
+
+  return redis;
+}


### PR DESCRIPTION
## Description
Implements the new routes-f engagement, monetization, and recommendation APIs, plus the supporting stream-end aggregation hooks needed for live reactions and historical analytics.

Closes #410
Closes #413
Closes #417
Closes #483

## Changes proposed

### What were you told to do?
Add the routes-f live stream reactions, recommendations, gift catalog/history, and live polls APIs, wire reaction totals into end-of-stream persistence, and ship the work as a single PR linked to the four issues.

### What did I do?
#### Engagement APIs
- Added anonymous live stream reactions endpoints with allowed-emoji validation, Upstash-backed rate limiting, 2-second polling cache support, and Redis-to-Postgres aggregation on stream shutdown.
- Added live polls endpoints for create/read/vote/update/delete flows with streamer ownership checks, one-active-poll enforcement, vote percentages, and viewer vote reflection.

#### Discovery and Monetization APIs
- Added personalized and anonymous recommendation endpoints with follow, tip, category, tag, viewer-count, and freshness signals, plus a similar-creators endpoint.
- Added gift catalog, gift history, and gift send endpoints with catalog metadata, authenticated history lookups, transaction persistence, quantity limits, and tx-hash support.

#### Supporting fixes and compatibility updates
- Added shared optional-session and Upstash helpers for routes-f APIs.
- Updated stream teardown paths to persist reaction aggregates when a stream ends.
- Fixed existing type/build blockers in related routes and the stream access gate wiring so the required build pipeline passes on this branch.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with targeted Jest route tests for reactions, recommendations, gifts, and polls, plus full `npm run type-check` and `npm run build`. The build completes successfully; it still logs existing environment warnings for missing Upstash/Mux/Postgres runtime secrets in local build mode.
