### PR TITLE
Feat/routes f multi endpoints

### DIFF
--- a/app/api/routes-f/clips/captions/_lib/db.ts
+++ b/app/api/routes-f/clips/captions/_lib/db.ts
@@ -1,0 +1,53 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureCaptionsSchema(): Promise<void> {
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_clip_captions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      clip_id UUID NOT NULL REFERENCES stream_recordings(id) ON DELETE CASCADE,
+      language VARCHAR(10) NOT NULL,
+      label VARCHAR(255) NOT NULL,
+      vtt_content TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE(clip_id, language)
+    )
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_clip_captions_clip
+      ON route_f_clip_captions (clip_id)
+  `;
+}
+
+/**
+ * Validates WebVTT content format
+ */
+export function validateWebVTT(content: string): boolean {
+    const lines = content.trim().split("\n");
+    if (lines.length < 2) return false;
+
+    // Must start with WEBVTT
+    if (!lines[0].startsWith("WEBVTT")) return false;
+
+    // Check for at least one cue
+    let hasCue = false;
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        // Cue timestamp format: HH:MM:SS.mmm --> HH:MM:SS.mmm
+        if (line.includes("-->")) {
+            hasCue = true;
+            break;
+        }
+    }
+
+    return hasCue;
+}
+
+/**
+ * Validates BCP-47 language tag
+ */
+export function validateLanguageTag(tag: string): boolean {
+    // Simple BCP-47 validation: language-region format
+    // Examples: en, en-US, es, fr-CA
+    return /^[a-z]{2}(-[A-Z]{2})?$/.test(tag);
+}

--- a/app/api/routes-f/clips/captions/route.ts
+++ b/app/api/routes-f/clips/captions/route.ts
@@ -1,0 +1,217 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import {
+    ensureCaptionsSchema,
+    validateWebVTT,
+    validateLanguageTag,
+} from "./_lib/db";
+
+const listCaptionsQuerySchema = z.object({
+    clip_id: uuidSchema,
+});
+
+const uploadCaptionSchema = z.object({
+    clip_id: uuidSchema,
+    language: z.string().trim().min(2).max(10),
+    label: z.string().trim().min(1).max(255),
+    vtt_content: z.string().trim().min(1),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+    const { searchParams } = new URL(req.url);
+    const queryResult = validateQuery(searchParams, listCaptionsQuerySchema);
+    if (queryResult instanceof Response) {
+        return queryResult;
+    }
+
+    try {
+        await ensureCaptionsSchema();
+
+        const { clip_id } = queryResult.data;
+
+        const { rows } = await sql`
+      SELECT id, language, label, created_at
+      FROM route_f_clip_captions
+      WHERE clip_id = ${clip_id}
+      ORDER BY created_at ASC
+    `;
+
+        return NextResponse.json({
+            captions: rows.map(row => ({
+                id: row.id,
+                language: row.language,
+                label: row.label,
+                created_at: row.created_at,
+            })),
+        });
+    } catch (error) {
+        console.error("[clips/captions] GET error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const bodyResult = await validateBody(req, uploadCaptionSchema);
+    if (bodyResult instanceof Response) {
+        return bodyResult;
+    }
+
+    try {
+        await ensureCaptionsSchema();
+
+        const { clip_id, language, label, vtt_content } = bodyResult.data;
+
+        // Validate language tag
+        if (!validateLanguageTag(language)) {
+            return NextResponse.json(
+                {
+                    error: "Validation failed",
+                    issues: [
+                        {
+                            field: "language",
+                            message: "Language must be a valid BCP-47 tag (e.g., en, es, fr, en-US)",
+                        },
+                    ],
+                },
+                { status: 400 }
+            );
+        }
+
+        // Validate WebVTT content
+        if (!validateWebVTT(vtt_content)) {
+            return NextResponse.json(
+                {
+                    error: "Validation failed",
+                    issues: [
+                        {
+                            field: "vtt_content",
+                            message: "Content must be valid WebVTT format (must start with WEBVTT and contain at least one cue)",
+                        },
+                    ],
+                },
+                { status: 400 }
+            );
+        }
+
+        // Check clip exists and user owns it
+        const { rows: clipRows } = await sql`
+      SELECT id FROM stream_recordings
+      WHERE id = ${clip_id} AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+        if (clipRows.length === 0) {
+            return NextResponse.json(
+                { error: "Clip not found or unauthorized" },
+                { status: 404 }
+            );
+        }
+
+        // Check caption count for this clip
+        const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int as count FROM route_f_clip_captions
+      WHERE clip_id = ${clip_id}
+    `;
+
+        if (countRows[0].count >= 5) {
+            return NextResponse.json(
+                {
+                    error: "Validation failed",
+                    issues: [
+                        {
+                            field: "clip_id",
+                            message: "Maximum 5 caption tracks per clip",
+                        },
+                    ],
+                },
+                { status: 400 }
+            );
+        }
+
+        // Upsert caption
+        const { rows } = await sql`
+      INSERT INTO route_f_clip_captions (clip_id, language, label, vtt_content, created_at)
+      VALUES (${clip_id}, ${language}, ${label}, ${vtt_content}, now())
+      ON CONFLICT (clip_id, language) DO UPDATE SET
+        label = EXCLUDED.label,
+        vtt_content = EXCLUDED.vtt_content
+      RETURNING id, language, label, created_at
+    `;
+
+        return NextResponse.json(
+            {
+                id: rows[0].id,
+                language: rows[0].language,
+                label: rows[0].label,
+                created_at: rows[0].created_at,
+            },
+            { status: 201 }
+        );
+    } catch (error) {
+        console.error("[clips/captions] POST error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { pathname } = new URL(req.url);
+    const captionId = pathname.split("/").pop();
+
+    if (!captionId || !uuidSchema.safeParse(captionId).success) {
+        return NextResponse.json(
+            { error: "Invalid caption ID" },
+            { status: 400 }
+        );
+    }
+
+    try {
+        await ensureCaptionsSchema();
+
+        // Verify ownership
+        const { rows: captionRows } = await sql`
+      SELECT cc.id FROM route_f_clip_captions cc
+      JOIN stream_recordings sr ON cc.clip_id = sr.id
+      WHERE cc.id = ${captionId} AND sr.user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+        if (captionRows.length === 0) {
+            return NextResponse.json(
+                { error: "Caption not found or unauthorized" },
+                { status: 404 }
+            );
+        }
+
+        await sql`
+      DELETE FROM route_f_clip_captions WHERE id = ${captionId}
+    `;
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("[clips/captions] DELETE error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/routes-f/creator/bio/_lib/db.ts
+++ b/app/api/routes-f/creator/bio/_lib/db.ts
@@ -1,0 +1,20 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureCreatorBioSchema(): Promise<void> {
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_creator_bios (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+      bio_text TEXT,
+      social_links JSONB DEFAULT '[]'::jsonb,
+      schedule_text TEXT,
+      banner_url TEXT,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_creator_bios_user
+      ON route_f_creator_bios (user_id)
+  `;
+}

--- a/app/api/routes-f/creator/bio/route.ts
+++ b/app/api/routes-f/creator/bio/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { usernameSchema, urlSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { ensureCreatorBioSchema } from "./_lib/db";
+
+const socialLinkSchema = z.object({
+    label: z.string().trim().min(1).max(50),
+    url: urlSchema,
+});
+
+const updateBioSchema = z.object({
+    bio_text: z.string().trim().max(500).optional(),
+    social_links: z.array(socialLinkSchema).max(5).optional(),
+    schedule_text: z.string().trim().max(200).optional(),
+    banner_url: urlSchema.optional(),
+});
+
+const getBioQuerySchema = z.object({
+    username: usernameSchema,
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+    const { searchParams } = new URL(req.url);
+    const queryResult = validateQuery(searchParams, getBioQuerySchema);
+    if (queryResult instanceof Response) {
+        return queryResult;
+    }
+
+    try {
+        await ensureCreatorBioSchema();
+
+        const { rows: userRows } = await sql`
+      SELECT id FROM users WHERE username = ${queryResult.data.username} LIMIT 1
+    `;
+
+        if (userRows.length === 0) {
+            return NextResponse.json(
+                { error: "Creator not found" },
+                { status: 404 }
+            );
+        }
+
+        const userId = userRows[0].id;
+
+        const { rows } = await sql`
+      SELECT bio_text, social_links, schedule_text, banner_url, updated_at
+      FROM route_f_creator_bios
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `;
+
+        if (rows.length === 0) {
+            return NextResponse.json({
+                bio_text: null,
+                social_links: [],
+                schedule_text: null,
+                banner_url: null,
+                updated_at: null,
+            });
+        }
+
+        const bio = rows[0];
+        return NextResponse.json({
+            bio_text: bio.bio_text ?? null,
+            social_links: bio.social_links ?? [],
+            schedule_text: bio.schedule_text ?? null,
+            banner_url: bio.banner_url ?? null,
+            updated_at: bio.updated_at,
+        });
+    } catch (error) {
+        console.error("[creator/bio] GET error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const bodyResult = await validateBody(req, updateBioSchema);
+    if (bodyResult instanceof Response) {
+        return bodyResult;
+    }
+
+    try {
+        await ensureCreatorBioSchema();
+
+        const { bio_text, social_links, schedule_text, banner_url } =
+            bodyResult.data;
+
+        // Upsert bio record
+        const { rows } = await sql`
+      INSERT INTO route_f_creator_bios (user_id, bio_text, social_links, schedule_text, banner_url, updated_at)
+      VALUES (${session.userId}, ${bio_text ?? null}, ${JSON.stringify(social_links ?? [])}, ${schedule_text ?? null}, ${banner_url ?? null}, now())
+      ON CONFLICT (user_id) DO UPDATE SET
+        bio_text = COALESCE(EXCLUDED.bio_text, route_f_creator_bios.bio_text),
+        social_links = COALESCE(EXCLUDED.social_links, route_f_creator_bios.social_links),
+        schedule_text = COALESCE(EXCLUDED.schedule_text, route_f_creator_bios.schedule_text),
+        banner_url = COALESCE(EXCLUDED.banner_url, route_f_creator_bios.banner_url),
+        updated_at = now()
+      RETURNING bio_text, social_links, schedule_text, banner_url, updated_at
+    `;
+
+        const updated = rows[0];
+        return NextResponse.json({
+            bio_text: updated.bio_text ?? null,
+            social_links: updated.social_links ?? [],
+            schedule_text: updated.schedule_text ?? null,
+            banner_url: updated.banner_url ?? null,
+            updated_at: updated.updated_at,
+        });
+    } catch (error) {
+        console.error("[creator/bio] PATCH error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/routes-f/stream/recording/_lib/db.ts
+++ b/app/api/routes-f/stream/recording/_lib/db.ts
@@ -1,0 +1,30 @@
+import { sql } from "@vercel/postgres";
+
+export type RecordingVisibility = "public" | "unlisted" | "private";
+
+export async function ensureRecordingSchema(): Promise<void> {
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_recordings (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      mux_playback_id VARCHAR(255) NOT NULL,
+      mux_asset_id VARCHAR(255),
+      title VARCHAR(255) NOT NULL,
+      visibility VARCHAR(20) NOT NULL DEFAULT 'private',
+      thumbnail_url TEXT,
+      duration_seconds INT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_recordings_user
+      ON route_f_stream_recordings (user_id, created_at DESC)
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_recordings_visibility
+      ON route_f_stream_recordings (visibility, created_at DESC)
+  `;
+}

--- a/app/api/routes-f/stream/recording/route.ts
+++ b/app/api/routes-f/stream/recording/route.ts
@@ -1,0 +1,213 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema, paginationSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { ensureRecordingSchema } from "./_lib/db";
+
+const visibilitySchema = z.enum(["public", "unlisted", "private"]);
+
+const updateRecordingSchema = z.object({
+    title: z.string().trim().min(1).max(255).optional(),
+    visibility: visibilitySchema.optional(),
+    thumbnail_url: z.string().url().optional(),
+});
+
+const deleteRecordingSchema = z.object({
+    confirm: z.boolean().refine(v => v === true, {
+        message: "Must confirm deletion with confirm: true",
+    }),
+});
+
+const listRecordingsQuerySchema = paginationSchema;
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryResult = validateQuery(searchParams, listRecordingsQuerySchema);
+    if (queryResult instanceof Response) {
+        return queryResult;
+    }
+
+    try {
+        await ensureRecordingSchema();
+
+        const limit = queryResult.data.limit ?? 20;
+        const cursor = queryResult.data.cursor;
+
+        let queryResult2;
+
+        if (cursor) {
+            queryResult2 = await sql`
+        SELECT id, mux_playback_id, title, visibility, thumbnail_url, duration_seconds, created_at
+        FROM route_f_stream_recordings
+        WHERE user_id = ${session.userId} AND created_at < (
+          SELECT created_at FROM route_f_stream_recordings WHERE id = ${cursor}
+        )
+        ORDER BY created_at DESC
+        LIMIT ${limit + 1}
+      `;
+        } else {
+            queryResult2 = await sql`
+        SELECT id, mux_playback_id, title, visibility, thumbnail_url, duration_seconds, created_at
+        FROM route_f_stream_recordings
+        WHERE user_id = ${session.userId}
+        ORDER BY created_at DESC
+        LIMIT ${limit + 1}
+      `;
+        }
+
+        const rows = queryResult2.rows;
+        const hasMore = rows.length > limit;
+        const recordings = rows.slice(0, limit);
+        const nextCursor = hasMore ? recordings[recordings.length - 1]?.id : null;
+
+        return NextResponse.json({
+            recordings: recordings.map((r: any) => ({
+                id: r.id,
+                mux_playback_id: r.mux_playback_id,
+                title: r.title,
+                visibility: r.visibility,
+                thumbnail_url: r.thumbnail_url ?? null,
+                duration_seconds: r.duration_seconds ?? null,
+                created_at: r.created_at,
+            })),
+            next_cursor: nextCursor,
+            has_more: hasMore,
+        });
+    } catch (error) {
+        console.error("[stream/recording] GET error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PATCH(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { pathname } = new URL(req.url);
+    const recordingId = pathname.split("/").pop();
+
+    if (!recordingId || !uuidSchema.safeParse(recordingId).success) {
+        return NextResponse.json(
+            { error: "Invalid recording ID" },
+            { status: 400 }
+        );
+    }
+
+    const bodyResult = await validateBody(req, updateRecordingSchema);
+    if (bodyResult instanceof Response) {
+        return bodyResult;
+    }
+
+    try {
+        await ensureRecordingSchema();
+
+        // Verify ownership
+        const { rows: ownerRows } = await sql`
+      SELECT id FROM route_f_stream_recordings
+      WHERE id = ${recordingId} AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+        if (ownerRows.length === 0) {
+            return NextResponse.json(
+                { error: "Recording not found or unauthorized" },
+                { status: 404 }
+            );
+        }
+
+        const { title, visibility, thumbnail_url } = bodyResult.data;
+
+        const { rows } = await sql`
+      UPDATE route_f_stream_recordings
+      SET
+        title = COALESCE(${title ?? null}, title),
+        visibility = COALESCE(${visibility ?? null}, visibility),
+        thumbnail_url = COALESCE(${thumbnail_url ?? null}, thumbnail_url),
+        updated_at = now()
+      WHERE id = ${recordingId}
+      RETURNING id, mux_playback_id, title, visibility, thumbnail_url, duration_seconds, created_at
+    `;
+
+        const updated = rows[0];
+        return NextResponse.json({
+            id: updated.id,
+            mux_playback_id: updated.mux_playback_id,
+            title: updated.title,
+            visibility: updated.visibility,
+            thumbnail_url: updated.thumbnail_url ?? null,
+            duration_seconds: updated.duration_seconds ?? null,
+            created_at: updated.created_at,
+        });
+    } catch (error) {
+        console.error("[stream/recording] PATCH error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { pathname } = new URL(req.url);
+    const recordingId = pathname.split("/").pop();
+
+    if (!recordingId || !uuidSchema.safeParse(recordingId).success) {
+        return NextResponse.json(
+            { error: "Invalid recording ID" },
+            { status: 400 }
+        );
+    }
+
+    const bodyResult = await validateBody(req, deleteRecordingSchema);
+    if (bodyResult instanceof Response) {
+        return bodyResult;
+    }
+
+    try {
+        await ensureRecordingSchema();
+
+        // Verify ownership
+        const { rows: ownerRows } = await sql`
+      SELECT id FROM route_f_stream_recordings
+      WHERE id = ${recordingId} AND user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+        if (ownerRows.length === 0) {
+            return NextResponse.json(
+                { error: "Recording not found or unauthorized" },
+                { status: 404 }
+            );
+        }
+
+        await sql`
+      DELETE FROM route_f_stream_recordings
+      WHERE id = ${recordingId}
+    `;
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("[stream/recording] DELETE error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/routes-f/stream/soundtrack/_lib/db.ts
+++ b/app/api/routes-f/stream/soundtrack/_lib/db.ts
@@ -1,0 +1,51 @@
+import { sql } from "@vercel/postgres";
+
+export async function ensureSoundtrackSchema(): Promise<void> {
+    // Soundtrack catalog table
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_soundtrack_catalog (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      title VARCHAR(255) NOT NULL,
+      artist VARCHAR(255) NOT NULL,
+      duration_seconds INT NOT NULL,
+      url TEXT NOT NULL,
+      royalty_free BOOLEAN NOT NULL DEFAULT true,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+    // Stream now playing table
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_now_playing (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id UUID NOT NULL UNIQUE,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      track_id UUID NOT NULL REFERENCES route_f_soundtrack_catalog(id) ON DELETE CASCADE,
+      started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `;
+
+    // Stream playlist table
+    await sql`
+    CREATE TABLE IF NOT EXISTS route_f_stream_playlists (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      stream_id UUID NOT NULL,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      track_id UUID NOT NULL REFERENCES route_f_soundtrack_catalog(id) ON DELETE CASCADE,
+      position INT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE(stream_id, position)
+    )
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_now_playing_stream
+      ON route_f_stream_now_playing (stream_id)
+  `;
+
+    await sql`
+    CREATE INDEX IF NOT EXISTS idx_route_f_stream_playlists_stream
+      ON route_f_stream_playlists (stream_id, position)
+  `;
+}

--- a/app/api/routes-f/stream/soundtrack/route.ts
+++ b/app/api/routes-f/stream/soundtrack/route.ts
@@ -1,0 +1,255 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { verifySession } from "@/lib/auth/verify-session";
+import { uuidSchema } from "@/app/api/routes-f/_lib/schemas";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { ensureSoundtrackSchema } from "./_lib/db";
+
+const streamIdSchema = z.object({
+    stream_id: uuidSchema,
+});
+
+const playTrackSchema = z.object({
+    track_id: uuidSchema,
+    stream_id: uuidSchema,
+});
+
+const skipTrackSchema = z.object({
+    stream_id: uuidSchema,
+});
+
+const stopPlaybackSchema = z.object({
+    stream_id: uuidSchema,
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { searchParams } = new URL(req.url);
+    const queryResult = validateQuery(searchParams, streamIdSchema);
+    if (queryResult instanceof Response) {
+        return queryResult;
+    }
+
+    try {
+        await ensureSoundtrackSchema();
+
+        const { stream_id } = queryResult.data;
+
+        // Get now playing track
+        const { rows: nowPlayingRows } = await sql`
+      SELECT
+        np.id,
+        np.track_id,
+        sc.title,
+        sc.artist,
+        sc.duration_seconds,
+        np.started_at
+      FROM route_f_stream_now_playing np
+      JOIN route_f_soundtrack_catalog sc ON np.track_id = sc.id
+      WHERE np.stream_id = ${stream_id} AND np.user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+        // Get playlist
+        const { rows: playlistRows } = await sql`
+      SELECT
+        sp.id,
+        sp.track_id,
+        sp.position,
+        sc.title,
+        sc.artist,
+        sc.duration_seconds
+      FROM route_f_stream_playlists sp
+      JOIN route_f_soundtrack_catalog sc ON sp.track_id = sc.id
+      WHERE sp.stream_id = ${stream_id} AND sp.user_id = ${session.userId}
+      ORDER BY sp.position ASC
+    `;
+
+        return NextResponse.json({
+            now_playing: nowPlayingRows.length > 0 ? {
+                track_id: nowPlayingRows[0].track_id,
+                title: nowPlayingRows[0].title,
+                artist: nowPlayingRows[0].artist,
+                duration_seconds: nowPlayingRows[0].duration_seconds,
+                started_at: nowPlayingRows[0].started_at,
+            } : null,
+            playlist: playlistRows.map(row => ({
+                id: row.id,
+                track_id: row.track_id,
+                position: row.position,
+                title: row.title,
+                artist: row.artist,
+                duration_seconds: row.duration_seconds,
+            })),
+        });
+    } catch (error) {
+        console.error("[stream/soundtrack] GET error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const bodyResult = await validateBody(req, playTrackSchema);
+    if (bodyResult instanceof Response) {
+        return bodyResult;
+    }
+
+    try {
+        await ensureSoundtrackSchema();
+
+        const { track_id, stream_id } = bodyResult.data;
+
+        // Verify track exists
+        const { rows: trackRows } = await sql`
+      SELECT id FROM route_f_soundtrack_catalog WHERE id = ${track_id} LIMIT 1
+    `;
+
+        if (trackRows.length === 0) {
+            return NextResponse.json(
+                { error: "Track not found" },
+                { status: 404 }
+            );
+        }
+
+        // Upsert now playing
+        const { rows } = await sql`
+      INSERT INTO route_f_stream_now_playing (stream_id, user_id, track_id, started_at, updated_at)
+      VALUES (${stream_id}, ${session.userId}, ${track_id}, now(), now())
+      ON CONFLICT (stream_id) DO UPDATE SET
+        track_id = EXCLUDED.track_id,
+        started_at = now(),
+        updated_at = now()
+      RETURNING track_id, started_at
+    `;
+
+        return NextResponse.json({
+            track_id: rows[0].track_id,
+            started_at: rows[0].started_at,
+        });
+    } catch (error) {
+        console.error("[stream/soundtrack] POST play error:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+    const session = await verifySession(req);
+    if (!session.ok) {
+        return session.response;
+    }
+
+    const { pathname } = new URL(req.url);
+    const action = pathname.split("/").pop();
+
+    if (action === "skip") {
+        const bodyResult = await validateBody(req, skipTrackSchema);
+        if (bodyResult instanceof Response) {
+            return bodyResult;
+        }
+
+        try {
+            await ensureSoundtrackSchema();
+
+            const { stream_id } = bodyResult.data;
+
+            // Get current position in playlist
+            const { rows: currentRows } = await sql`
+        SELECT np.track_id, sp.position
+        FROM route_f_stream_now_playing np
+        LEFT JOIN route_f_stream_playlists sp ON sp.track_id = np.track_id AND sp.stream_id = np.stream_id
+        WHERE np.stream_id = ${stream_id} AND np.user_id = ${session.userId}
+        LIMIT 1
+      `;
+
+            if (currentRows.length === 0) {
+                return NextResponse.json(
+                    { error: "No track currently playing" },
+                    { status: 400 }
+                );
+            }
+
+            const currentPosition = currentRows[0].position ?? 0;
+
+            // Get next track
+            const { rows: nextRows } = await sql`
+        SELECT track_id FROM route_f_stream_playlists
+        WHERE stream_id = ${stream_id} AND user_id = ${session.userId} AND position > ${currentPosition}
+        ORDER BY position ASC
+        LIMIT 1
+      `;
+
+            if (nextRows.length === 0) {
+                return NextResponse.json(
+                    { error: "No next track in playlist" },
+                    { status: 400 }
+                );
+            }
+
+            // Update now playing
+            const { rows } = await sql`
+        UPDATE route_f_stream_now_playing
+        SET track_id = ${nextRows[0].track_id}, started_at = now(), updated_at = now()
+        WHERE stream_id = ${stream_id}
+        RETURNING track_id, started_at
+      `;
+
+            return NextResponse.json({
+                track_id: rows[0].track_id,
+                started_at: rows[0].started_at,
+            });
+        } catch (error) {
+            console.error("[stream/soundtrack] PUT skip error:", error);
+            return NextResponse.json(
+                { error: "Internal server error" },
+                { status: 500 }
+            );
+        }
+    }
+
+    if (action === "stop") {
+        const bodyResult = await validateBody(req, stopPlaybackSchema);
+        if (bodyResult instanceof Response) {
+            return bodyResult;
+        }
+
+        try {
+            await ensureSoundtrackSchema();
+
+            const { stream_id } = bodyResult.data;
+
+            await sql`
+        DELETE FROM route_f_stream_now_playing
+        WHERE stream_id = ${stream_id} AND user_id = ${session.userId}
+      `;
+
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            console.error("[stream/soundtrack] PUT stop error:", error);
+            return NextResponse.json(
+                { error: "Internal server error" },
+                { status: 500 }
+            );
+        }
+    }
+
+    return NextResponse.json(
+        { error: "Invalid action" },
+        { status: 400 }
+    );
+}


### PR DESCRIPTION
# Multi-Feature Routes-F Implementation

Implements four new API endpoints for StreamFi's routes-f feature set:

closes #530
closes #531
closes #533
closes #532

## Features

### 1. Creator Bio Management (#530)
- `GET /api/routes-f/creator/bio?username=` - Public bio retrieval
- `PATCH /api/routes-f/creator/bio` - Authenticated bio updates
- Supports bio text (500 chars), social links (5 max), schedule text (200 chars), banner URL

### 2. VOD Recording Management (#531)
- `GET /api/routes-f/stream/recording` - List creator's recordings with pagination
- `PATCH /api/routes-f/stream/recording/[id]` - Update metadata (title, visibility, thumbnail)
- `DELETE /api/routes-f/stream/recording/[id]` - Permanent deletion with confirmation
- Visibility levels: public, unlisted, private

### 3. Background Music Integration (#533)
- `GET /api/routes-f/stream/soundtrack?stream_id=` - Get now playing and playlist
- `POST /api/routes-f/stream/soundtrack/play` - Start track playback
- `PUT /api/routes-f/stream/soundtrack/skip` - Skip to next track
- `PUT /api/routes-f/stream/soundtrack/stop` - Stop playback
- Royalty-free track catalog with streamer-only controls

### 4. Caption/Subtitle Management (#532)
- `GET /api/routes-f/clips/captions?clip_id=` - List captions for a clip
- `POST /api/routes-f/clips/captions` - Upload caption track (BCP-47 language, WebVTT format)
- `DELETE /api/routes-f/clips/captions/[id]` - Remove caption track
- Max 5 captions per clip with format validation

## Implementation Details
- All endpoints follow existing routes-f patterns
- Database schemas with proper indexes and constraints
- Input validation using Zod schemas
- Authentication via verifySession
- Cursor-based pagination for list endpoints
- Comprehensive error handling with per-field validation errors
