### PR TITLE
fix(routes-f): resolve category PATCH slug conflict handling

### DIFF
--- a/app/api/routes-f/categories/[slug]/route.ts
+++ b/app/api/routes-f/categories/[slug]/route.ts
@@ -64,6 +64,15 @@ async function requireAdmin(req: NextRequest) {
   return { ok: true as const, session };
 }
 
+function isUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+
+  const code = "code" in err ? (err as { code?: unknown }).code : undefined;
+  return code === "23505";
+}
+
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ slug: string }> }
@@ -187,6 +196,13 @@ export async function PATCH(
 
     return NextResponse.json(rows[0]);
   } catch (err) {
+    if (isUniqueViolation(err)) {
+      return NextResponse.json(
+        { error: "Category already exists" },
+        { status: 409 }
+      );
+    }
+
     console.error("[categories/:slug] PATCH error:", err);
     return NextResponse.json(
       { error: "Internal server error" },

--- a/app/api/routes-f/mock/route.ts
+++ b/app/api/routes-f/mock/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { sql } from "@vercel/postgres";
 
 const SCENARIOS = [
@@ -47,7 +47,7 @@ export async function GET(): Promise<Response> {
   return NextResponse.json({ scenarios: SCENARIOS });
 }
 
-export async function DELETE(_req: NextRequest): Promise<Response> {
+export async function DELETE(): Promise<Response> {
   if (isMainnet()) {
     return NextResponse.json(
       { error: "Not available in production" },


### PR DESCRIPTION
## Summary
- handle unique slug conflicts in `PATCH /api/routes-f/categories/[slug]` by returning `409` instead of a generic `500`
- align `app/api/routes-f/mock/route.ts` with eslint (`no-unused-vars`) so repository checks can pass
- branch is synced from latest `upstream/main` and built successfully before PR creation

Closes #433