### PR TITLE
feat(routes-f): GET /api/routes-f/validation-rules — shared schema registry

### DIFF
--- a/app/api/routes-f/validation-rules/_schemas/chat.ts
+++ b/app/api/routes-f/validation-rules/_schemas/chat.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+// banned_words is server-side only — never exported in the API response
+const BANNED_WORDS: string[] = [];
+
+export const chatSchema = z
+  .object({
+    message: z
+      .string()
+      .min(1, "Message cannot be empty")
+      .max(500, "Message must not exceed 500 characters"),
+    emote_only: z.boolean().default(false),
+  })
+  .superRefine((data, ctx) => {
+    const lower = data.message.toLowerCase();
+    for (const word of BANNED_WORDS) {
+      if (lower.includes(word)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["message"],
+          message: "Message contains prohibited content",
+        });
+        break;
+      }
+    }
+  });
+
+export type ChatInput = z.infer<typeof chatSchema>;
+
+export const chatRules = {
+  message: {
+    min: 1,
+    max: 500,
+    required: true,
+  },
+  emote_only: {
+    type: "boolean",
+    default: false,
+  },
+};

--- a/app/api/routes-f/validation-rules/_schemas/gift.ts
+++ b/app/api/routes-f/validation-rules/_schemas/gift.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const giftSchema = z.object({
+  amount: z
+    .number()
+    .positive("Amount must be greater than zero")
+    .max(10_000, "Maximum gift amount is 10,000"),
+  currency: z.enum(["STRFI", "USDC"], {
+    errorMap: () => ({ message: "Currency must be STRFI or USDC" }),
+  }),
+  message: z
+    .string()
+    .max(200, "Gift message must not exceed 200 characters")
+    .optional(),
+  recipient_id: z.string().min(1, "Recipient is required"),
+});
+
+export type GiftInput = z.infer<typeof giftSchema>;
+
+export const giftRules = {
+  amount: {
+    min: 0,
+    exclusive_min: true,
+    max: 10_000,
+    required: true,
+  },
+  currency: {
+    enum: ["STRFI", "USDC"],
+    required: true,
+  },
+  message: {
+    max: 200,
+    required: false,
+  },
+  recipient_id: {
+    required: true,
+  },
+};

--- a/app/api/routes-f/validation-rules/_schemas/stream.ts
+++ b/app/api/routes-f/validation-rules/_schemas/stream.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const streamSchema = z.object({
+  title: z
+    .string()
+    .min(3, "Title must be at least 3 characters")
+    .max(120, "Title must not exceed 120 characters"),
+  description: z
+    .string()
+    .max(500, "Description must not exceed 500 characters")
+    .optional(),
+  category: z.string().min(1, "Category is required"),
+  tags: z
+    .array(z.string().max(30))
+    .max(10, "You may add up to 10 tags")
+    .optional(),
+  is_mature: z.boolean().default(false),
+});
+
+export type StreamInput = z.infer<typeof streamSchema>;
+
+export const streamRules = {
+  title: {
+    min: 3,
+    max: 120,
+    required: true,
+  },
+  description: {
+    max: 500,
+    required: false,
+  },
+  category: {
+    required: true,
+  },
+  tags: {
+    max_items: 10,
+    item_max_length: 30,
+    required: false,
+  },
+  is_mature: {
+    type: "boolean",
+    default: false,
+  },
+};

--- a/app/api/routes-f/validation-rules/_schemas/user.ts
+++ b/app/api/routes-f/validation-rules/_schemas/user.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  username: z
+    .string()
+    .min(3, "Username must be at least 3 characters")
+    .max(30, "Username must not exceed 30 characters")
+    .regex(/^[a-zA-Z0-9_]+$/, "Username may only contain letters, numbers, and underscores"),
+  email: z
+    .string()
+    .min(1, "Email is required")
+    .email("Must be a valid email address"),
+  display_name: z
+    .string()
+    .min(1, "Display name is required")
+    .max(50, "Display name must not exceed 50 characters"),
+  bio: z.string().max(300, "Bio must not exceed 300 characters").optional(),
+  website_url: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+});
+
+export type UserInput = z.infer<typeof userSchema>;
+
+export const userRules = {
+  username: {
+    min: 3,
+    max: 30,
+    pattern: "^[a-zA-Z0-9_]+$",
+    description: "Letters, numbers, and underscores only",
+  },
+  email: {
+    format: "email",
+    required: true,
+  },
+  display_name: {
+    min: 1,
+    max: 50,
+    required: true,
+  },
+  bio: {
+    max: 300,
+    required: false,
+  },
+  website_url: {
+    format: "url",
+    required: false,
+  },
+};

--- a/app/api/routes-f/validation-rules/route.ts
+++ b/app/api/routes-f/validation-rules/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { chatRules } from "./_schemas/chat";
+import { giftRules } from "./_schemas/gift";
+import { streamRules } from "./_schemas/stream";
+import { userRules } from "./_schemas/user";
+
+const ALL_RULES = {
+  user: userRules,
+  stream: streamRules,
+  chat: chatRules,
+  gift: giftRules,
+};
+
+type Scope = keyof typeof ALL_RULES;
+
+const VALID_SCOPES = new Set<string>(Object.keys(ALL_RULES));
+
+export async function GET(request: NextRequest) {
+  const scope = request.nextUrl.searchParams.get("scope");
+
+  if (scope !== null) {
+    if (!VALID_SCOPES.has(scope)) {
+      return NextResponse.json(
+        { error: `Unknown scope '${scope}'. Valid values: ${[...VALID_SCOPES].join(", ")}` },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(
+      { rules: { [scope]: ALL_RULES[scope as Scope] } },
+      {
+        headers: { "Cache-Control": "public, max-age=3600" },
+      }
+    );
+  }
+
+  return NextResponse.json(
+    { rules: ALL_RULES },
+    {
+      headers: { "Cache-Control": "public, max-age=3600" },
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/routes-f/validation-rules` route handler that exposes form validation rules as a JSON endpoint
- Supports optional `?scope=` query param to return rules for a single domain (`user`, `stream`, `chat`, `gift`)
- Returns `400` with helpful error message for unknown scope values
- Sets `Cache-Control: public, max-age=3600` on all responses

## Schema modules

Each schema module exports two things:
1. A **Zod schema** (`*Schema`) used server-side for runtime validation
2. A plain **rules object** (`*Rules`) — safe to expose to clients (no logic, no banned words list)

| Module | Fields |
|--------|--------|
| `user` | username (regex), email, display_name, bio, website_url |
| `stream` | title, description, category, tags (max 10), is_mature |
| `chat` | message (1–500 chars), emote_only — banned-words check is server-side only and never sent to clients |
| `gift` | amount (0–10 000, exclusive), currency (STRFI\|USDC), message, recipient_id |

## Test plan

- [ ] `GET /api/routes-f/validation-rules` → 200 with all four scopes
- [ ] `GET /api/routes-f/validation-rules?scope=user` → 200 with only `user` key
- [ ] `GET /api/routes-f/validation-rules?scope=unknown` → 400 with error message listing valid scopes
- [ ] Response headers include `Cache-Control: public, max-age=3600`