### PR TITLE
feat(routes-f): TOTP 2FA — setup, verify, status, disable

### DIFF
--- a/app/api/routes-f/2fa/_lib/totp.ts
+++ b/app/api/routes-f/2fa/_lib/totp.ts
@@ -1,0 +1,130 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+} from "crypto";
+
+// ── Base32 (RFC 4648, no padding needed for otpauth) ──────────────────────────
+
+const B32_ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+export function base32Encode(buf: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+  for (const byte of buf) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += B32_ALPHA[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) output += B32_ALPHA[(value << (5 - bits)) & 31];
+  return output;
+}
+
+export function base32Decode(input: string): Buffer {
+  const clean = input.toUpperCase().replace(/=+$/, "");
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+  for (const ch of clean) {
+    const idx = B32_ALPHA.indexOf(ch);
+    if (idx === -1) throw new Error("Invalid base32 character: " + ch);
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(output);
+}
+
+// ── TOTP (RFC 6238 / RFC 4226) ────────────────────────────────────────────────
+
+function hotpCode(keyBuf: Buffer, counter: bigint): string {
+  const msg = Buffer.alloc(8);
+  msg.writeBigUInt64BE(counter);
+  const hmac = createHmac("sha1", keyBuf).update(msg).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    (hmac[offset + 1] << 16) |
+    (hmac[offset + 2] << 8) |
+    hmac[offset + 3];
+  return String(code % 1_000_000).padStart(6, "0");
+}
+
+export function generateTotpCode(secret: string, windowOffset = 0): string {
+  const counter = BigInt(Math.floor(Date.now() / 1000 / 30)) + BigInt(windowOffset);
+  return hotpCode(base32Decode(secret), counter);
+}
+
+export function verifyTotpToken(secret: string, token: string): boolean {
+  for (const w of [-1, 0, 1]) {
+    if (generateTotpCode(secret, w) === token) return true;
+  }
+  return false;
+}
+
+export function generateTotpSecret(): string {
+  return base32Encode(randomBytes(20));
+}
+
+export function buildOtpauthUri(secret: string, account: string, issuer = "StreamFi"): string {
+  const label = encodeURIComponent(`${issuer}:${account}`);
+  return `otpauth://totp/${label}?secret=${secret}&issuer=${encodeURIComponent(issuer)}&algorithm=SHA1&digits=6&period=30`;
+}
+
+// ── AES-256-GCM secret encryption ────────────────────────────────────────────
+
+function resolveKey(): Buffer {
+  const raw =
+    process.env.TWO_FA_ENCRYPTION_KEY ??
+    process.env.STELLAR_ENCRYPTION_KEY ??
+    process.env.SESSION_SECRET;
+  if (!raw) throw new Error("Missing encryption key env var");
+  if (/^[0-9a-fA-F]{64}$/.test(raw)) return Buffer.from(raw, "hex");
+  // SHA-256 of passphrase → 32-byte key
+  const { createHash } = require("crypto") as typeof import("crypto");
+  return createHash("sha256").update(raw).digest();
+}
+
+export interface EncryptedSecret {
+  ciphertext: string;
+  iv: string;
+  tag: string;
+}
+
+export function encryptSecret(plaintext: string): EncryptedSecret {
+  const key = resolveKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return {
+    ciphertext: ciphertext.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: (cipher as ReturnType<typeof createCipheriv> & { getAuthTag(): Buffer }).getAuthTag().toString("base64"),
+  };
+}
+
+export function decryptSecret(enc: EncryptedSecret): string {
+  const key = resolveKey();
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(enc.iv, "base64"));
+  (decipher as ReturnType<typeof createDecipheriv> & { setAuthTag(t: Buffer): void }).setAuthTag(Buffer.from(enc.tag, "base64"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(enc.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+// ── Backup codes ──────────────────────────────────────────────────────────────
+
+export function generateBackupCodes(count = 5): string[] {
+  return Array.from({ length: count }, () =>
+    randomBytes(5).toString("hex").toUpperCase().match(/.{1,5}/g)!.join("-")
+  );
+}

--- a/app/api/routes-f/2fa/disable/route.ts
+++ b/app/api/routes-f/2fa/disable/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { sql } from "@vercel/postgres";
+import { createHash } from "crypto";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { decryptSecret, verifyTotpToken } from "../_lib/totp";
+
+const disableSchema = z.object({
+  token: z
+    .string()
+    .length(6)
+    .regex(/^\d{6}$/)
+    .optional(),
+  backupCode: z.string().min(1).optional(),
+}).refine((d) => d.token !== undefined || d.backupCode !== undefined, {
+  message: "Provide either a TOTP token or a backup code",
+});
+
+export async function POST(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  const body = await validateBody(request, disableSchema);
+  if (body instanceof NextResponse) return body;
+
+  try {
+    const { rows } = await sql`
+      SELECT totp_secret_ciphertext, totp_secret_iv, totp_secret_tag,
+             totp_enabled, backup_code_hashes
+      FROM user_two_factor
+      WHERE user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (!rows[0]?.totp_enabled) {
+      return NextResponse.json(
+        { error: "2FA is not currently enabled." },
+        { status: 400 }
+      );
+    }
+
+    const row = rows[0];
+    let authorized = false;
+
+    if (body.data.token) {
+      const secret = decryptSecret({
+        ciphertext: row.totp_secret_ciphertext,
+        iv: row.totp_secret_iv,
+        tag: row.totp_secret_tag,
+      });
+      authorized = verifyTotpToken(secret, body.data.token);
+    } else if (body.data.backupCode) {
+      const stored: string[] = JSON.parse(row.backup_code_hashes ?? "[]");
+      const hash = createHash("sha256")
+        .update(body.data.backupCode.toUpperCase())
+        .digest("hex");
+      const idx = stored.indexOf(hash);
+      if (idx !== -1) {
+        authorized = true;
+        stored.splice(idx, 1);
+        await sql`
+          UPDATE user_two_factor
+          SET backup_code_hashes = ${JSON.stringify(stored)}, updated_at = NOW()
+          WHERE user_id = ${session.userId}
+        `;
+      }
+    }
+
+    if (!authorized) {
+      return NextResponse.json({ error: "Invalid token or backup code" }, { status: 401 });
+    }
+
+    await sql`
+      UPDATE user_two_factor
+      SET totp_enabled           = false,
+          totp_secret_ciphertext = NULL,
+          totp_secret_iv         = NULL,
+          totp_secret_tag        = NULL,
+          backup_code_hashes     = NULL,
+          updated_at             = NOW()
+      WHERE user_id = ${session.userId}
+    `;
+
+    return NextResponse.json({ disabled: true });
+  } catch (error) {
+    console.error("[routes-f 2fa/disable POST]", error);
+    return NextResponse.json({ error: "Failed to disable 2FA" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/2fa/setup/route.ts
+++ b/app/api/routes-f/2fa/setup/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import {
+  generateTotpSecret,
+  buildOtpauthUri,
+  encryptSecret,
+} from "../_lib/totp";
+
+export async function POST(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  try {
+    const { rows } = await sql`
+      SELECT totp_enabled FROM user_two_factor WHERE user_id = ${session.userId} LIMIT 1
+    `;
+
+    if (rows[0]?.totp_enabled) {
+      return NextResponse.json(
+        { error: "2FA is already enabled. Disable it before setting up again." },
+        { status: 409 }
+      );
+    }
+
+    const secret = generateTotpSecret();
+    const enc = encryptSecret(secret);
+    const otpauthUri = buildOtpauthUri(secret, session.userId);
+
+    await sql`
+      INSERT INTO user_two_factor (user_id, totp_secret_ciphertext, totp_secret_iv, totp_secret_tag, totp_enabled, updated_at)
+      VALUES (
+        ${session.userId},
+        ${enc.ciphertext},
+        ${enc.iv},
+        ${enc.tag},
+        false,
+        NOW()
+      )
+      ON CONFLICT (user_id) DO UPDATE SET
+        totp_secret_ciphertext = EXCLUDED.totp_secret_ciphertext,
+        totp_secret_iv         = EXCLUDED.totp_secret_iv,
+        totp_secret_tag        = EXCLUDED.totp_secret_tag,
+        totp_enabled           = false,
+        updated_at             = NOW()
+    `;
+
+    return NextResponse.json({ otpauthUri }, { status: 200 });
+  } catch (error) {
+    console.error("[routes-f 2fa/setup POST]", error);
+    return NextResponse.json({ error: "Failed to initiate 2FA setup" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/2fa/status/route.ts
+++ b/app/api/routes-f/2fa/status/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function GET(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  try {
+    const { rows } = await sql`
+      SELECT totp_enabled, updated_at
+      FROM user_two_factor
+      WHERE user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    const row = rows[0];
+
+    return NextResponse.json({
+      enabled: row?.totp_enabled ?? false,
+      configuredAt: row?.updated_at ?? null,
+    });
+  } catch (error) {
+    console.error("[routes-f 2fa/status GET]", error);
+    return NextResponse.json({ error: "Failed to fetch 2FA status" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/2fa/verify/route.ts
+++ b/app/api/routes-f/2fa/verify/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import {
+  decryptSecret,
+  verifyTotpToken,
+  generateBackupCodes,
+  encryptSecret,
+} from "../_lib/totp";
+import { createHash } from "crypto";
+
+const verifySchema = z.object({
+  token: z.string().length(6, "Token must be exactly 6 digits").regex(/^\d{6}$/),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  const body = await validateBody(request, verifySchema);
+  if (body instanceof NextResponse) return body;
+
+  try {
+    const { rows } = await sql`
+      SELECT totp_secret_ciphertext, totp_secret_iv, totp_secret_tag, totp_enabled
+      FROM user_two_factor
+      WHERE user_id = ${session.userId}
+      LIMIT 1
+    `;
+
+    if (!rows[0]) {
+      return NextResponse.json(
+        { error: "2FA setup not initiated. Call /api/routes-f/2fa/setup first." },
+        { status: 400 }
+      );
+    }
+
+    if (rows[0].totp_enabled) {
+      return NextResponse.json(
+        { error: "2FA is already verified and active." },
+        { status: 409 }
+      );
+    }
+
+    const secret = decryptSecret({
+      ciphertext: rows[0].totp_secret_ciphertext,
+      iv: rows[0].totp_secret_iv,
+      tag: rows[0].totp_secret_tag,
+    });
+
+    if (!verifyTotpToken(secret, body.data.token)) {
+      return NextResponse.json({ error: "Invalid TOTP token" }, { status: 400 });
+    }
+
+    const codes = generateBackupCodes(5);
+    const hashedCodes = codes.map((c) =>
+      createHash("sha256").update(c).digest("hex")
+    );
+
+    await sql`
+      UPDATE user_two_factor
+      SET totp_enabled       = true,
+          backup_code_hashes = ${JSON.stringify(hashedCodes)},
+          updated_at         = NOW()
+      WHERE user_id = ${session.userId}
+    `;
+
+    return NextResponse.json(
+      {
+        enabled: true,
+        backupCodes: codes,
+        message: "2FA enabled. Store these backup codes securely — they will not be shown again.",
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("[routes-f 2fa/verify POST]", error);
+    return NextResponse.json({ error: "Failed to verify 2FA token" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes #525

## Summary

- `POST /api/routes-f/2fa/setup` — generates a TOTP secret, encrypts it with AES-256-GCM, stores it as pending (not yet enabled), returns `otpauth://` URI for authenticator apps
- `POST /api/routes-f/2fa/verify` — validates the first TOTP token to confirm the user scanned correctly, activates 2FA, returns 5 one-time backup codes (SHA-256 hashed in DB, shown once)
- `GET /api/routes-f/2fa/status` — returns `{ enabled: boolean, configuredAt }` for the authenticated user
- `POST /api/routes-f/2fa/disable` — accepts either a live TOTP token or a backup code; wipes the secret and backup codes from the DB on success

## Implementation notes

- TOTP implemented from scratch (RFC 6238 / RFC 4226) using Node.js built-in `crypto` — no external OTP library needed
- Secret encrypted at rest with AES-256-GCM; key resolved from `TWO_FA_ENCRYPTION_KEY` → `STELLAR_ENCRYPTION_KEY` → `SESSION_SECRET`
- Backup codes are 5-segment hex strings (e.g. `A1B2C-3D4E5`), stored as SHA-256 hashes; each code is single-use and consumed on disable
- All routes require a valid session via `verifySession`

## Test plan

- [ ] `POST /api/routes-f/2fa/setup` → 200 with `otpauth://` URI; calling again before verify resets the pending secret
- [ ] `POST /api/routes-f/2fa/verify` with correct token → 200 with 5 backup codes
- [ ] `POST /api/routes-f/2fa/verify` with wrong token → 400
- [ ] `POST /api/routes-f/2fa/verify` when already enabled → 409
- [ ] `GET /api/routes-f/2fa/status` → `{ enabled: true }` after verify
- [ ] `POST /api/routes-f/2fa/disable` with valid TOTP → 200, status returns `{ enabled: false }`
- [ ] `POST /api/routes-f/2fa/disable` with valid backup code → 200; same code rejected on reuse
- [ ] `POST /api/routes-f/2fa/disable` with invalid token → 401