### PR TITLE
feat(routes-f): viewer watch history — paginated list, delete single, delete all

### DIFF
--- a/app/api/routes-f/viewer/history/[id]/route.ts
+++ b/app/api/routes-f/viewer/history/[id]/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  const { id } = await params;
+
+  try {
+    const { rows } = await sql`
+      DELETE FROM watch_history
+      WHERE id = ${id} AND user_id = ${session.userId}
+      RETURNING id
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "History entry not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ deleted: true, id });
+  } catch (error) {
+    console.error("[routes-f viewer/history/[id] DELETE]", error);
+    return NextResponse.json({ error: "Failed to delete history entry" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/viewer/history/all/route.ts
+++ b/app/api/routes-f/viewer/history/all/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export async function DELETE(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  try {
+    const { rowCount } = await sql`
+      DELETE FROM watch_history WHERE user_id = ${session.userId}
+    `;
+
+    return NextResponse.json({ deleted: true, count: rowCount ?? 0 });
+  } catch (error) {
+    console.error("[routes-f viewer/history/all DELETE]", error);
+    return NextResponse.json({ error: "Failed to clear watch history" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/viewer/history/route.ts
+++ b/app/api/routes-f/viewer/history/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  const session = await verifySession(request);
+  if (!session.ok) return session.response;
+
+  try {
+    // Respect privacy setting
+    const { rows: privacyRows } = await sql`
+      SELECT show_watch_history FROM user_privacy_settings WHERE user_id = ${session.userId} LIMIT 1
+    `;
+    if (privacyRows[0]?.show_watch_history === false) {
+      return NextResponse.json(
+        { error: "Watch history is disabled for this account" },
+        { status: 403 }
+      );
+    }
+
+    const params = request.nextUrl.searchParams;
+    const cursor = params.get("cursor") ?? null;
+    const limitRaw = Number(params.get("limit") ?? DEFAULT_LIMIT);
+    const limit = Math.min(Math.max(1, limitRaw), MAX_LIMIT);
+
+    const { rows } = cursor
+      ? await sql`
+          SELECT
+            wh.id,
+            wh.stream_id,
+            u.username        AS creator_username,
+            wh.watched_at,
+            wh.watch_duration_seconds,
+            s.thumbnail_url
+          FROM watch_history wh
+          JOIN streams s ON s.id = wh.stream_id
+          JOIN users u   ON u.id = s.creator_id
+          WHERE wh.user_id = ${session.userId}
+            AND wh.watched_at < (SELECT watched_at FROM watch_history WHERE id = ${cursor} LIMIT 1)
+          ORDER BY wh.watched_at DESC
+          LIMIT ${limit + 1}
+        `
+      : await sql`
+          SELECT
+            wh.id,
+            wh.stream_id,
+            u.username        AS creator_username,
+            wh.watched_at,
+            wh.watch_duration_seconds,
+            s.thumbnail_url
+          FROM watch_history wh
+          JOIN streams s ON s.id = wh.stream_id
+          JOIN users u   ON u.id = s.creator_id
+          WHERE wh.user_id = ${session.userId}
+          ORDER BY wh.watched_at DESC
+          LIMIT ${limit + 1}
+        `;
+
+    const hasMore = rows.length > limit;
+    const entries = rows.slice(0, limit);
+
+    return NextResponse.json({
+      entries,
+      nextCursor: hasMore ? entries[entries.length - 1].id : null,
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/history GET]", error);
+    return NextResponse.json({ error: "Failed to fetch watch history" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes #521

## Summary

- `GET /api/routes-f/viewer/history` — cursor-based paginated list of watch history entries, newest first; each entry includes `stream_id`, `creator_username`, `watched_at`, `watch_duration_seconds`, `thumbnail_url`
- `DELETE /api/routes-f/viewer/history/[id]` — removes a single history entry; 404 if not found or not owned by the caller
- `DELETE /api/routes-f/viewer/history/all` — clears the entire watch history for the authenticated user; returns deleted count

## Implementation notes

- Respects `show_watch_history` privacy setting — returns 403 if disabled
- Cursor pagination uses `watched_at` ordering: fetches `limit + 1` rows, sets `nextCursor` to last entry's ID when `hasMore`, null otherwise
- Default page size: 20; max: 100 (clamped server-side)
- All routes require a valid session via `verifySession`
- Files are self-contained within `app/api/routes-f/viewer/history/` — no files outside this folder were modified

## Test plan

- [ ] `GET /history` → 200 with entries array and `nextCursor`
- [ ] `GET /history?cursor=<id>&limit=5` → 200 with next page
- [ ] `GET /history` when `show_watch_history = false` → 403
- [ ] `DELETE /history/<id>` → 200 with `{ deleted: true, id }`
- [ ] `DELETE /history/<other-user-id>` → 404
- [ ] `DELETE /history/all` → 200 with `{ deleted: true, count: N }`
- [ ] Subsequent `GET /history` after delete all → empty entries array