### PR TITLE
feat(routes-f): feature flags, event ingestion, UUID generator, slugify, avatar-initials (#560-563 #582)

### DIFF
--- a/app/api/routes-f/avatar-initials/__tests__/route.test.ts
+++ b/app/api/routes-f/avatar-initials/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+import { GET } from "../route";
+import { extractInitials, clampSize, buildAvatar } from "../_lib/avatar";
+import { NextRequest } from "next/server";
+
+function makeGet(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-f/avatar-initials${query}`);
+}
+
+// ── Helper unit tests ─────────────────────────────────────────────────────────
+
+describe("extractInitials()", () => {
+  it("two-word name → first letters", () => expect(extractInitials("John Doe")).toBe("JD"));
+  it("single word → first letter", () => expect(extractInitials("Alice")).toBe("A"));
+  it("three words → first and last", () => expect(extractInitials("Mary Jane Watson")).toBe("MW"));
+  it("extra whitespace handled", () => expect(extractInitials("  Bob   Lee  ")).toBe("BL"));
+  it("empty string → ?", () => expect(extractInitials("")).toBe("?"));
+  it("uppercase preserved", () => expect(extractInitials("john doe")).toBe("JD"));
+});
+
+describe("clampSize()", () => {
+  it("defaults to 128 when undefined", () => expect(clampSize(undefined)).toBe(128));
+  it("clamps below min to 32", () => expect(clampSize(10)).toBe(32));
+  it("clamps above max to 512", () => expect(clampSize(9999)).toBe(512));
+  it("accepts value in range", () => expect(clampSize(256)).toBe(256));
+  it("accepts boundary 32", () => expect(clampSize(32)).toBe(32));
+  it("accepts boundary 512", () => expect(clampSize(512)).toBe(512));
+  it("falls back to 128 for NaN", () => expect(clampSize("abc")).toBe(128));
+});
+
+describe("buildAvatar() — determinism", () => {
+  it("same name always produces identical SVG", () => {
+    const s1 = buildAvatar({ name: "John Doe", size: 128 });
+    const s2 = buildAvatar({ name: "John Doe", size: 128 });
+    expect(s1).toBe(s2);
+  });
+
+  it("different names produce different background colors", () => {
+    const s1 = buildAvatar({ name: "Alice Smith", size: 128 });
+    const s2 = buildAvatar({ name: "Bob Jones", size: 128 });
+    // Extract fill color from rect element
+    const fill1 = s1.match(/fill="(rgb\([^"]+\))"/)?.[1];
+    const fill2 = s2.match(/fill="(rgb\([^"]+\))"/)?.[1];
+    expect(fill1).not.toBe(fill2);
+  });
+
+  it("SVG contains correct initials", () => {
+    const svg = buildAvatar({ name: "Jane Smith", size: 128 });
+    expect(svg).toContain(">JS<");
+  });
+
+  it("SVG reflects requested size", () => {
+    const svg = buildAvatar({ name: "Test User", size: 64 });
+    expect(svg).toContain('width="64"');
+    expect(svg).toContain('height="64"');
+  });
+});
+
+describe("buildAvatar() — contrast", () => {
+  const NAMES = ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank"];
+
+  it("foreground is always white or black", () => {
+    for (const name of NAMES) {
+      const svg = buildAvatar({ name, size: 128 });
+      const fg = svg.match(/fill="(#(?:ffffff|000000))"/g);
+      // The text element fill should be white or black
+      expect(fg?.some((f) => f.includes("#ffffff") || f.includes("#000000"))).toBe(true);
+    }
+  });
+});
+
+// ── Route handler tests ───────────────────────────────────────────────────────
+
+describe("GET /api/routes-f/avatar-initials", () => {
+  it("returns SVG content-type", async () => {
+    const res = await GET(makeGet("?name=John%20Doe"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+  });
+
+  it("SVG body is valid XML opening", async () => {
+    const res = await GET(makeGet("?name=John%20Doe"));
+    const body = await res.text();
+    expect(body.startsWith("<svg")).toBe(true);
+  });
+
+  it("sets long-lived Cache-Control header", async () => {
+    const res = await GET(makeGet("?name=Test"));
+    expect(res.headers.get("Cache-Control")).toContain("max-age=31536000");
+  });
+
+  it("same name is deterministic across requests", async () => {
+    const r1 = await (await GET(makeGet("?name=Steady%20State"))).text();
+    const r2 = await (await GET(makeGet("?name=Steady%20State"))).text();
+    expect(r1).toBe(r2);
+  });
+
+  it("respects size param", async () => {
+    const body = await (await GET(makeGet("?name=Size%20Test&size=64"))).text();
+    expect(body).toContain('width="64"');
+  });
+
+  it("clamps size below min to 32", async () => {
+    const body = await (await GET(makeGet("?name=Min%20Test&size=10"))).text();
+    expect(body).toContain('width="32"');
+  });
+
+  it("clamps size above max to 512", async () => {
+    const body = await (await GET(makeGet("?name=Max%20Test&size=9999"))).text();
+    expect(body).toContain('width="512"');
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const res = await GET(makeGet(""));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when name is whitespace only", async () => {
+    const res = await GET(makeGet("?name=%20%20"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/avatar-initials/_lib/avatar.ts
+++ b/app/api/routes-f/avatar-initials/_lib/avatar.ts
@@ -1,0 +1,80 @@
+/**
+ * Avatar-from-initials helpers (#582).
+ * All logic scoped to this folder — no external imports.
+ */
+
+const DEFAULT_SIZE = 128;
+const MIN_SIZE = 32;
+const MAX_SIZE = 512;
+
+/** Extract up to 2 initials from a full name. */
+export function extractInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0][0].toUpperCase();
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+}
+
+/** Clamp size to [MIN_SIZE, MAX_SIZE]. */
+export function clampSize(raw: unknown): number {
+  const n = parseInt(String(raw ?? DEFAULT_SIZE), 10);
+  if (isNaN(n)) return DEFAULT_SIZE;
+  return Math.min(MAX_SIZE, Math.max(MIN_SIZE, n));
+}
+
+/** djb2 hash → deterministic hue for a given name. */
+function nameToHue(name: string): number {
+  let hash = 5381;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) + hash) ^ name.charCodeAt(i);
+    hash = hash >>> 0;
+  }
+  return hash % 360;
+}
+
+/** HSL → { r, g, b } (0–255). */
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  s /= 100;
+  l /= 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+  return { r: Math.round(f(0) * 255), g: Math.round(f(8) * 255), b: Math.round(f(4) * 255) };
+}
+
+/** Relative luminance per WCAG 2.1. */
+function luminance(r: number, g: number, b: number): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** Pick white or black foreground based on contrast ratio. */
+function foregroundColor(r: number, g: number, b: number): string {
+  const l = luminance(r, g, b);
+  const whiteCR = (1.05) / (l + 0.05);
+  const blackCR = (l + 0.05) / 0.05;
+  return whiteCR >= blackCR ? "#ffffff" : "#000000";
+}
+
+export interface AvatarParams {
+  name: string;
+  size: number;
+}
+
+export function buildAvatar({ name, size }: AvatarParams): string {
+  const initials = extractInitials(name);
+  const hue = nameToHue(name);
+  const { r, g, b } = hslToRgb(hue, 55, 45);
+  const bg = `rgb(${r},${g},${b})`;
+  const fg = foregroundColor(r, g, b);
+  const fontSize = Math.round(size * 0.4);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
+  <rect width="${size}" height="${size}" fill="${bg}" rx="${Math.round(size * 0.1)}"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
+        font-family="system-ui,sans-serif" font-size="${fontSize}" font-weight="600" fill="${fg}">${initials}</text>
+</svg>`;
+}

--- a/app/api/routes-f/avatar-initials/route.ts
+++ b/app/api/routes-f/avatar-initials/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildAvatar, clampSize } from "./_lib/avatar";
+
+// GET /api/routes-f/avatar-initials?name=John%20Doe&size=128
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const name = searchParams.get("name") ?? "";
+
+  if (!name.trim()) {
+    return NextResponse.json({ error: "'name' query param is required" }, { status: 400 });
+  }
+
+  const size = clampSize(searchParams.get("size"));
+  const svg = buildAvatar({ name, size });
+
+  return new NextResponse(svg, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}


### PR DESCRIPTION
Fixes #560
Fixes #561
Fixes #562
Fixes #563
Fixes #582

All files are strictly scoped to `app/api/routes-f/` — no modifications to `lib/`, `utils/`, `types/`, `components/`, or any shared folders.

## What changed

### #560 — Feature flag store
- `feature-flags/route.ts` — GET (all / single / per-user rollout), PUT (create/update), DELETE
- `feature-flags/_lib/store.ts` — in-memory Map + deterministic djb2 rollout hash
- Tests cover CRUD, validation, 0%/100% edge cases, ~50% distribution over 200 users

### #561 — Event ingestion with batching
- `events/route.ts` — POST `{ event }` or `{ events: [...] }`, validates schema, rejects batches > 100; GET paginated
- `events/_lib/buffer.ts` — bounded 10k ring-buffer with oldest-first eviction
- Tests cover submit, validation, eviction, non-overlapping pages

### #562 — UUID generator (v4 and v7)
- `uuid/route.ts` — GET `?version=v4|v7&count=1..100`
- `uuid/_lib/generators.ts` — inline v4 and v7 via `crypto.getRandomValues()`; no external libs
- Tests verify format, version nibble, variant bits, uniqueness, time-ordering

### #563 — Slugify endpoint
- `slugify/route.ts` — POST `{ text, separator?, maxLength? }` → `{ slug }`
- `slugify/_lib/slugify.ts` — NFD + diacritic strip, emoji removal, word-boundary truncation
- 15+ tests: diacritics, emoji, punctuation, truncation edge cases

### #582 — Avatar-from-initials SVG generator
- `avatar-initials/route.ts` — GET `?name=...&size=128` returns `image/svg+xml` with `Cache-Control: public, max-age=31536000`
- `avatar-initials/_lib/avatar.ts` — extracts up to 2 initials, djb2 hash → deterministic HSL background, WCAG luminance → white/black foreground
- Tests: initials, size clamping (32–512), SVG determinism, contrast, content-type, cache header, 400 on blank name