### PR TITLE
feat(routes-f): items catalog, creator referral program, viewer presence & onboarding checklist APIs

### DIFF
--- a/app/api/routes-f/items/[id]/route.ts
+++ b/app/api/routes-f/items/[id]/route.ts
@@ -1,54 +1,103 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ITEMS_CATALOG, invalidateCatalogCache, isAdmin } from "../_catalog";
+import { db } from "@/lib/db";
+import { redis } from "@/lib/redis";
+import { getAuthUser } from "@/lib/auth";
 
-// ----- GET /api/routes-f/items/[id] -----
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  const { id } = params;
-  const item = ITEMS_CATALOG.find((i) => i.id === id || i.slug === id);
+const CATALOG_CACHE_KEY = "items_catalog";
 
-  if (!item) {
-    return NextResponse.json({ error: "Item not found." }, { status: 404 });
-  }
-
-  if (!item.active) {
-    return NextResponse.json({ error: "Item not available." }, { status: 410 });
-  }
-
-  return NextResponse.json({ item }, { status: 200 });
+async function invalidateCatalogCache() {
+  await redis.del(CATALOG_CACHE_KEY);
+  const keys = await redis.keys("items_catalog:type:*");
+  if (keys.length > 0) await redis.del(...keys);
 }
 
-// ----- PATCH /api/routes-f/items/[id] (admin only) -----
-export async function PATCH(
-  request: NextRequest,
+/**
+ * GET /api/routes-f/items/[id]
+ * Returns a single catalog item by UUID.
+ */
+export async function GET(
+  _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  if (!isAdmin(request)) {
-    return NextResponse.json(
-      { error: "Forbidden: admin access required." },
-      { status: 403 }
-    );
+  const { id } = params;
+
+  const cacheKey = `items_catalog:item:${id}`;
+  const cached = await redis.get(cacheKey);
+  if (cached) {
+    return NextResponse.json(JSON.parse(cached as string), {
+      headers: { "X-Cache": "HIT" },
+    });
+  }
+
+  const { rows } = await db.query(
+    `SELECT id, type, name, slug, description, emoji, image_url,
+            price_usd, price_usdc, animation, tier, active, metadata
+     FROM items_catalog
+     WHERE id = $1`,
+    [id]
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Item not found" }, { status: 404 });
+  }
+
+  const response = { item: rows[0] };
+  await redis.setex(cacheKey, 300, JSON.stringify(response));
+
+  return NextResponse.json(response, { headers: { "X-Cache": "MISS" } });
+}
+
+/**
+ * PATCH /api/routes-f/items/[id]
+ * Admin-only: update a catalog item.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthUser(req);
+  if (!user || user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const { id } = params;
-  const index = ITEMS_CATALOG.findIndex((i) => i.id === id || i.slug === id);
+  const body = await req.json();
 
-  if (index === -1) {
-    return NextResponse.json({ error: "Item not found." }, { status: 404 });
+  const allowed = [
+    "type", "name", "slug", "description", "emoji", "image_url",
+    "price_usd", "price_usdc", "animation", "tier", "sort_order",
+    "active", "metadata",
+  ];
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  for (const key of allowed) {
+    if (key in body) {
+      fields.push(`${key} = $${idx}`);
+      values.push(key === "metadata" && body[key] ? JSON.stringify(body[key]) : body[key]);
+      idx++;
+    }
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  if (fields.length === 0) {
+    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
   }
 
-  // Merge updates
-  ITEMS_CATALOG[index] = { ...ITEMS_CATALOG[index], ...body };
-  invalidateCatalogCache();
+  values.push(id);
+  const { rows } = await db.query(
+    `UPDATE items_catalog SET ${fields.join(", ")} WHERE id = $${idx} RETURNING *`,
+    values
+  );
 
-  return NextResponse.json({ item: ITEMS_CATALOG[index] }, { status: 200 });
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Item not found" }, { status: 404 });
+  }
+
+  // Invalidate caches
+  await invalidateCatalogCache();
+  await redis.del(`items_catalog:item:${id}`);
+
+  return NextResponse.json({ item: rows[0] });
 }

--- a/app/api/routes-f/items/[id]/route.ts
+++ b/app/api/routes-f/items/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ITEMS_CATALOG, invalidateCatalogCache, isAdmin } from "../_catalog";
+
+// ----- GET /api/routes-f/items/[id] -----
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params;
+  const item = ITEMS_CATALOG.find((i) => i.id === id || i.slug === id);
+
+  if (!item) {
+    return NextResponse.json({ error: "Item not found." }, { status: 404 });
+  }
+
+  if (!item.active) {
+    return NextResponse.json({ error: "Item not available." }, { status: 410 });
+  }
+
+  return NextResponse.json({ item }, { status: 200 });
+}
+
+// ----- PATCH /api/routes-f/items/[id] (admin only) -----
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  if (!isAdmin(request)) {
+    return NextResponse.json(
+      { error: "Forbidden: admin access required." },
+      { status: 403 }
+    );
+  }
+
+  const { id } = params;
+  const index = ITEMS_CATALOG.findIndex((i) => i.id === id || i.slug === id);
+
+  if (index === -1) {
+    return NextResponse.json({ error: "Item not found." }, { status: 404 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  // Merge updates
+  ITEMS_CATALOG[index] = { ...ITEMS_CATALOG[index], ...body };
+  invalidateCatalogCache();
+
+  return NextResponse.json({ item: ITEMS_CATALOG[index] }, { status: 200 });
+}

--- a/app/api/routes-f/items/_catalog.ts
+++ b/app/api/routes-f/items/_catalog.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from "next/server";
+
+// ----- Shared catalog store -----
+export const ITEMS_CATALOG: {
+  id: string;
+  type: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  emoji: string | null;
+  image_url: string | null;
+  price_usd: number | null;
+  price_usdc: number | null;
+  animation: string | null;
+  tier: string | null;
+  sort_order: number;
+  active: boolean;
+  metadata: Record<string, unknown>;
+}[] = [
+  {
+    id: "a1b2c3d4-0001-0000-0000-000000000001",
+    type: "gift",
+    name: "Flower",
+    slug: "gift-flower",
+    description: "A beautiful flower gift.",
+    emoji: "🌸",
+    image_url: null,
+    price_usd: 1.0,
+    price_usdc: 1.0,
+    animation: "flower",
+    tier: "common",
+    sort_order: 1,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0002-0000-0000-000000000002",
+    type: "gift",
+    name: "Candy",
+    slug: "gift-candy",
+    description: "Sweet candy for your favourite streamer.",
+    emoji: "🍬",
+    image_url: null,
+    price_usd: 5.0,
+    price_usdc: 5.0,
+    animation: "candy",
+    tier: "common",
+    sort_order: 2,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0003-0000-0000-000000000003",
+    type: "gift",
+    name: "Crown",
+    slug: "gift-crown",
+    description: "A rare crown fit for royalty.",
+    emoji: "👑",
+    image_url: null,
+    price_usd: 25.0,
+    price_usdc: 25.0,
+    animation: "crown",
+    tier: "rare",
+    sort_order: 3,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0004-0000-0000-000000000004",
+    type: "gift",
+    name: "Lion",
+    slug: "gift-lion",
+    description: "A majestic lion gift.",
+    emoji: "🦁",
+    image_url: null,
+    price_usd: 100.0,
+    price_usdc: 100.0,
+    animation: "lion",
+    tier: "rare",
+    sort_order: 4,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0005-0000-0000-000000000005",
+    type: "gift",
+    name: "Dragon",
+    slug: "gift-dragon",
+    description: "The legendary dragon — the ultimate gift.",
+    emoji: "🐉",
+    image_url: null,
+    price_usd: 500.0,
+    price_usdc: 500.0,
+    animation: "dragon",
+    tier: "legendary",
+    sort_order: 5,
+    active: true,
+    metadata: {},
+  },
+];
+
+// Simulated Redis cache (in-memory, 5 min TTL)
+let catalogCache: { data: typeof ITEMS_CATALOG; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function getCachedCatalog() {
+  if (catalogCache && Date.now() < catalogCache.expiresAt) {
+    return catalogCache.data;
+  }
+  return null;
+}
+
+export function setCatalogCache(data: typeof ITEMS_CATALOG) {
+  catalogCache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+}
+
+export function invalidateCatalogCache() {
+  catalogCache = null;
+}
+
+export function isAdmin(request: NextRequest): boolean {
+  const adminToken = request.headers.get("x-admin-token");
+  return adminToken === process.env.ADMIN_SECRET_TOKEN;
+}

--- a/app/api/routes-f/items/route.ts
+++ b/app/api/routes-f/items/route.ts
@@ -1,192 +1,150 @@
 import { NextRequest, NextResponse } from "next/server";
 
-// ----- In-memory seed data (replaces DB + Redis in this frontend-only context) -----
-const ITEMS_CATALOG = [
-  {
-    id: "a1b2c3d4-0001-0000-0000-000000000001",
-    type: "gift",
-    name: "Flower",
-    slug: "gift-flower",
-    description: "A beautiful flower gift.",
-    emoji: "🌸",
-    image_url: null,
-    price_usd: 1.0,
-    price_usdc: 1.0,
-    animation: "flower",
-    tier: "common",
-    sort_order: 1,
-    active: true,
-    metadata: {},
-  },
-  {
-    id: "a1b2c3d4-0002-0000-0000-000000000002",
-    type: "gift",
-    name: "Candy",
-    slug: "gift-candy",
-    description: "Sweet candy for your favourite streamer.",
-    emoji: "🍬",
-    image_url: null,
-    price_usd: 5.0,
-    price_usdc: 5.0,
-    animation: "candy",
-    tier: "common",
-    sort_order: 2,
-    active: true,
-    metadata: {},
-  },
-  {
-    id: "a1b2c3d4-0003-0000-0000-000000000003",
-    type: "gift",
-    name: "Crown",
-    slug: "gift-crown",
-    description: "A rare crown fit for royalty.",
-    emoji: "👑",
-    image_url: null,
-    price_usd: 25.0,
-    price_usdc: 25.0,
-    animation: "crown",
-    tier: "rare",
-    sort_order: 3,
-    active: true,
-    metadata: {},
-  },
-  {
-    id: "a1b2c3d4-0004-0000-0000-000000000004",
-    type: "gift",
-    name: "Lion",
-    slug: "gift-lion",
-    description: "A majestic lion gift.",
-    emoji: "🦁",
-    image_url: null,
-    price_usd: 100.0,
-    price_usdc: 100.0,
-    animation: "lion",
-    tier: "rare",
-    sort_order: 4,
-    active: true,
-    metadata: {},
-  },
-  {
-    id: "a1b2c3d4-0005-0000-0000-000000000005",
-    type: "gift",
-    name: "Dragon",
-    slug: "gift-dragon",
-    description: "The legendary dragon — the ultimate gift.",
-    emoji: "🐉",
-    image_url: null,
-    price_usd: 500.0,
-    price_usdc: 500.0,
-    animation: "dragon",
-    tier: "legendary",
-    sort_order: 5,
-    active: true,
-    metadata: {},
-  },
-];
+// ---------------------------------------------------------------------------
+// DB schema (apply once via migration):
+//
+// CREATE TYPE item_type AS ENUM ('gift', 'sticker', 'effect', 'badge_frame', 'chat_color');
+//
+// CREATE TABLE items_catalog (
+//   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+//   type          item_type NOT NULL,
+//   name          TEXT NOT NULL,
+//   slug          TEXT NOT NULL UNIQUE,
+//   description   TEXT,
+//   emoji         TEXT,
+//   image_url     TEXT,
+//   price_usd     NUMERIC(10,2),
+//   price_usdc    NUMERIC(10,2),
+//   animation     TEXT,
+//   tier          TEXT,
+//   sort_order    INT DEFAULT 0,
+//   active        BOOLEAN DEFAULT true,
+//   metadata      JSONB
+// );
+//
+// Seed data (run once):
+// INSERT INTO items_catalog (type, name, slug, emoji, price_usd, price_usdc, animation, tier, sort_order)
+// VALUES
+//   ('gift', 'Flower', 'gift-flower', '🌸', 1.00,   1.00,   'flower',  'common',    1),
+//   ('gift', 'Candy',  'gift-candy',  '🍬', 5.00,   5.00,   'candy',   'common',    2),
+//   ('gift', 'Crown',  'gift-crown',  '👑', 25.00,  25.00,  'crown',   'rare',      3),
+//   ('gift', 'Lion',   'gift-lion',   '🦁', 100.00, 100.00, 'lion',    'rare',      4),
+//   ('gift', 'Dragon', 'gift-dragon', '🐉', 500.00, 500.00, 'dragon',  'legendary', 5);
+// ---------------------------------------------------------------------------
 
-// Simulated Redis cache (in-memory, 5 min TTL)
-let catalogCache: { data: typeof ITEMS_CATALOG; expiresAt: number } | null = null;
-const CACHE_TTL_MS = 5 * 60 * 1000;
+import { db } from "@/lib/db";
+import { redis } from "@/lib/redis";
+import { getAuthUser } from "@/lib/auth";
 
-function getCachedCatalog() {
-  if (catalogCache && Date.now() < catalogCache.expiresAt) {
-    return catalogCache.data;
-  }
-  return null;
+const CACHE_KEY = "items_catalog";
+const CACHE_TTL = 300; // 5 minutes
+
+async function invalidateCatalogCache() {
+  await redis.del(CACHE_KEY);
+  // Invalidate any type-scoped keys
+  const keys = await redis.keys("items_catalog:type:*");
+  if (keys.length > 0) await redis.del(...keys);
 }
 
-function setCatalogCache(data: typeof ITEMS_CATALOG) {
-  catalogCache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
-}
+/**
+ * GET /api/routes-f/items
+ * Returns all active items, optionally filtered by ?type=gift|sticker|effect|...
+ * Full catalog cached in Redis with 5-minute TTL.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get("type");
 
-function invalidateCatalogCache() {
-  catalogCache = null;
-}
+  const cacheKey = type ? `items_catalog:type:${type}` : CACHE_KEY;
 
-// ----- Helpers -----
-function isAdmin(request: NextRequest): boolean {
-  // In production, verify a session/JWT with admin role.
-  // For now, check a header: X-Admin-Token
-  const adminToken = request.headers.get("x-admin-token");
-  return adminToken === process.env.ADMIN_SECRET_TOKEN;
-}
-
-// ----- GET /api/routes-f/items -----
-export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const typeFilter = searchParams.get("type"); // gift | sticker | effect | ...
-
-  // Attempt to serve from cache (only for unfiltered full catalog)
-  let items = getCachedCatalog();
-  if (!items) {
-    items = ITEMS_CATALOG;
-    setCatalogCache(items);
+  // 1. Try cache
+  const cached = await redis.get(cacheKey);
+  if (cached) {
+    return NextResponse.json(JSON.parse(cached as string), {
+      headers: { "X-Cache": "HIT" },
+    });
   }
 
-  // Always filter out inactive items for public listing
-  let result = items.filter((item) => item.active);
+  // 2. Query DB
+  const params: unknown[] = [];
+  let query =
+    "SELECT id, type, name, slug, emoji, image_url, price_usd, price_usdc, animation, tier, active FROM items_catalog WHERE active = true";
 
-  if (typeFilter) {
-    result = result.filter((item) => item.type === typeFilter);
+  if (type) {
+    params.push(type);
+    query += ` AND type = $${params.length}`;
   }
 
-  return NextResponse.json({ items: result }, { status: 200 });
+  query += " ORDER BY sort_order ASC, name ASC";
+
+  const { rows } = await db.query(query, params);
+
+  const response = { items: rows };
+
+  // 3. Cache result
+  await redis.setex(cacheKey, CACHE_TTL, JSON.stringify(response));
+
+  return NextResponse.json(response, {
+    headers: { "X-Cache": "MISS" },
+  });
 }
 
-// ----- POST /api/routes-f/items (admin only) -----
-export async function POST(request: NextRequest) {
-  if (!isAdmin(request)) {
+/**
+ * POST /api/routes-f/items
+ * Admin-only: create a new catalog item.
+ */
+export async function POST(req: NextRequest) {
+  const user = await getAuthUser(req);
+  if (!user || user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await req.json();
+  const {
+    type,
+    name,
+    slug,
+    description,
+    emoji,
+    image_url,
+    price_usd,
+    price_usdc,
+    animation,
+    tier,
+    sort_order = 0,
+    metadata,
+  } = body;
+
+  if (!type || !name || !slug) {
     return NextResponse.json(
-      { error: "Forbidden: admin access required." },
-      { status: 403 }
+      { error: "type, name, and slug are required" },
+      { status: 400 }
     );
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
-  }
+  const { rows } = await db.query(
+    `INSERT INTO items_catalog
+       (type, name, slug, description, emoji, image_url, price_usd, price_usdc, animation, tier, sort_order, metadata)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+     RETURNING *`,
+    [
+      type,
+      name,
+      slug,
+      description ?? null,
+      emoji ?? null,
+      image_url ?? null,
+      price_usd ?? null,
+      price_usdc ?? null,
+      animation ?? null,
+      tier ?? null,
+      sort_order,
+      metadata ? JSON.stringify(metadata) : null,
+    ]
+  );
 
-  const requiredFields = ["type", "name", "slug"];
-  for (const field of requiredFields) {
-    if (!body[field]) {
-      return NextResponse.json(
-        { error: `Missing required field: ${field}` },
-        { status: 400 }
-      );
-    }
-  }
+  // Invalidate catalog cache
+  await invalidateCatalogCache();
 
-  // Check slug uniqueness
-  const slugExists = ITEMS_CATALOG.some((i) => i.slug === body.slug);
-  if (slugExists) {
-    return NextResponse.json(
-      { error: `Slug '${body.slug}' already exists.` },
-      { status: 409 }
-    );
-  }
-
-  const newItem = {
-    id: crypto.randomUUID(),
-    type: body.type as string,
-    name: body.name as string,
-    slug: body.slug as string,
-    description: (body.description as string) ?? null,
-    emoji: (body.emoji as string) ?? null,
-    image_url: (body.image_url as string) ?? null,
-    price_usd: (body.price_usd as number) ?? null,
-    price_usdc: (body.price_usdc as number) ?? null,
-    animation: (body.animation as string) ?? null,
-    tier: (body.tier as string) ?? null,
-    sort_order: (body.sort_order as number) ?? 0,
-    active: (body.active as boolean) ?? true,
-    metadata: (body.metadata as Record<string, unknown>) ?? {},
-  };
-
-  ITEMS_CATALOG.push(newItem);
-  invalidateCatalogCache();
-
-  return NextResponse.json({ item: newItem }, { status: 201 });
+  return NextResponse.json({ item: rows[0] }, { status: 201 });
 }

--- a/app/api/routes-f/items/route.ts
+++ b/app/api/routes-f/items/route.ts
@@ -1,0 +1,192 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ----- In-memory seed data (replaces DB + Redis in this frontend-only context) -----
+const ITEMS_CATALOG = [
+  {
+    id: "a1b2c3d4-0001-0000-0000-000000000001",
+    type: "gift",
+    name: "Flower",
+    slug: "gift-flower",
+    description: "A beautiful flower gift.",
+    emoji: "🌸",
+    image_url: null,
+    price_usd: 1.0,
+    price_usdc: 1.0,
+    animation: "flower",
+    tier: "common",
+    sort_order: 1,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0002-0000-0000-000000000002",
+    type: "gift",
+    name: "Candy",
+    slug: "gift-candy",
+    description: "Sweet candy for your favourite streamer.",
+    emoji: "🍬",
+    image_url: null,
+    price_usd: 5.0,
+    price_usdc: 5.0,
+    animation: "candy",
+    tier: "common",
+    sort_order: 2,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0003-0000-0000-000000000003",
+    type: "gift",
+    name: "Crown",
+    slug: "gift-crown",
+    description: "A rare crown fit for royalty.",
+    emoji: "👑",
+    image_url: null,
+    price_usd: 25.0,
+    price_usdc: 25.0,
+    animation: "crown",
+    tier: "rare",
+    sort_order: 3,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0004-0000-0000-000000000004",
+    type: "gift",
+    name: "Lion",
+    slug: "gift-lion",
+    description: "A majestic lion gift.",
+    emoji: "🦁",
+    image_url: null,
+    price_usd: 100.0,
+    price_usdc: 100.0,
+    animation: "lion",
+    tier: "rare",
+    sort_order: 4,
+    active: true,
+    metadata: {},
+  },
+  {
+    id: "a1b2c3d4-0005-0000-0000-000000000005",
+    type: "gift",
+    name: "Dragon",
+    slug: "gift-dragon",
+    description: "The legendary dragon — the ultimate gift.",
+    emoji: "🐉",
+    image_url: null,
+    price_usd: 500.0,
+    price_usdc: 500.0,
+    animation: "dragon",
+    tier: "legendary",
+    sort_order: 5,
+    active: true,
+    metadata: {},
+  },
+];
+
+// Simulated Redis cache (in-memory, 5 min TTL)
+let catalogCache: { data: typeof ITEMS_CATALOG; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function getCachedCatalog() {
+  if (catalogCache && Date.now() < catalogCache.expiresAt) {
+    return catalogCache.data;
+  }
+  return null;
+}
+
+function setCatalogCache(data: typeof ITEMS_CATALOG) {
+  catalogCache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+}
+
+function invalidateCatalogCache() {
+  catalogCache = null;
+}
+
+// ----- Helpers -----
+function isAdmin(request: NextRequest): boolean {
+  // In production, verify a session/JWT with admin role.
+  // For now, check a header: X-Admin-Token
+  const adminToken = request.headers.get("x-admin-token");
+  return adminToken === process.env.ADMIN_SECRET_TOKEN;
+}
+
+// ----- GET /api/routes-f/items -----
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const typeFilter = searchParams.get("type"); // gift | sticker | effect | ...
+
+  // Attempt to serve from cache (only for unfiltered full catalog)
+  let items = getCachedCatalog();
+  if (!items) {
+    items = ITEMS_CATALOG;
+    setCatalogCache(items);
+  }
+
+  // Always filter out inactive items for public listing
+  let result = items.filter((item) => item.active);
+
+  if (typeFilter) {
+    result = result.filter((item) => item.type === typeFilter);
+  }
+
+  return NextResponse.json({ items: result }, { status: 200 });
+}
+
+// ----- POST /api/routes-f/items (admin only) -----
+export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) {
+    return NextResponse.json(
+      { error: "Forbidden: admin access required." },
+      { status: 403 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const requiredFields = ["type", "name", "slug"];
+  for (const field of requiredFields) {
+    if (!body[field]) {
+      return NextResponse.json(
+        { error: `Missing required field: ${field}` },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Check slug uniqueness
+  const slugExists = ITEMS_CATALOG.some((i) => i.slug === body.slug);
+  if (slugExists) {
+    return NextResponse.json(
+      { error: `Slug '${body.slug}' already exists.` },
+      { status: 409 }
+    );
+  }
+
+  const newItem = {
+    id: crypto.randomUUID(),
+    type: body.type as string,
+    name: body.name as string,
+    slug: body.slug as string,
+    description: (body.description as string) ?? null,
+    emoji: (body.emoji as string) ?? null,
+    image_url: (body.image_url as string) ?? null,
+    price_usd: (body.price_usd as number) ?? null,
+    price_usdc: (body.price_usdc as number) ?? null,
+    animation: (body.animation as string) ?? null,
+    tier: (body.tier as string) ?? null,
+    sort_order: (body.sort_order as number) ?? 0,
+    active: (body.active as boolean) ?? true,
+    metadata: (body.metadata as Record<string, unknown>) ?? {},
+  };
+
+  ITEMS_CATALOG.push(newItem);
+  invalidateCatalogCache();
+
+  return NextResponse.json({ item: newItem }, { status: 201 });
+}

--- a/app/api/routes-f/onboarding/complete/route.ts
+++ b/app/api/routes-f/onboarding/complete/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ONBOARDING_STORE, USER_PROFILES } from "../route";
+
+const VALID_STEP_IDS = [
+  "set_avatar",
+  "set_bio",
+  "set_stream_title",
+  "add_category",
+  "first_stream",
+  "connect_wallet",
+  "first_follower",
+  "first_tip",
+];
+
+// ---------------------------------------------------------------------------
+// POST /api/routes-f/onboarding/complete
+// Manually mark a step complete (edge cases like wallet connection)
+// Body: { step_id: string } | { dismiss: true }
+// ---------------------------------------------------------------------------
+export async function POST(request: NextRequest) {
+  const userId = request.headers.get("x-user-id");
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  if (!USER_PROFILES.has(userId)) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+
+  let body: { step_id?: string; dismiss?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  // Ensure progress record exists
+  if (!ONBOARDING_STORE.has(userId)) {
+    ONBOARDING_STORE.set(userId, {
+      user_id: userId,
+      completed: [],
+      dismissed: false,
+      completed_at: null,
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  const progress = ONBOARDING_STORE.get(userId)!;
+
+  // Handle dismiss flag
+  if (body.dismiss === true) {
+    progress.dismissed = true;
+    progress.updated_at = new Date().toISOString();
+    return NextResponse.json({ success: true, dismissed: true });
+  }
+
+  // Handle step completion
+  const { step_id } = body;
+  if (!step_id) {
+    return NextResponse.json(
+      { error: "step_id or dismiss:true is required." },
+      { status: 400 }
+    );
+  }
+
+  if (!VALID_STEP_IDS.includes(step_id)) {
+    return NextResponse.json(
+      { error: `Unknown step_id: '${step_id}'.` },
+      { status: 400 }
+    );
+  }
+
+  if (!progress.completed.includes(step_id)) {
+    progress.completed.push(step_id);
+    progress.updated_at = new Date().toISOString();
+  }
+
+  return NextResponse.json({ success: true, step_id, already_completed: progress.completed.includes(step_id) });
+}

--- a/app/api/routes-f/onboarding/complete/route.ts
+++ b/app/api/routes-f/onboarding/complete/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ONBOARDING_STORE, USER_PROFILES } from "../route";
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 
-const VALID_STEP_IDS = [
+const VALID_STEPS = [
   "set_avatar",
   "set_bio",
   "set_stream_title",
@@ -12,68 +13,89 @@ const VALID_STEP_IDS = [
   "first_tip",
 ];
 
-// ---------------------------------------------------------------------------
-// POST /api/routes-f/onboarding/complete
-// Manually mark a step complete (edge cases like wallet connection)
-// Body: { step_id: string } | { dismiss: true }
-// ---------------------------------------------------------------------------
-export async function POST(request: NextRequest) {
-  const userId = request.headers.get("x-user-id");
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+/**
+ * POST /api/routes-f/onboarding/complete
+ * Mark a step as manually complete (for edge cases like wallet connection).
+ * Also handles { dismiss: true } to hide the checklist.
+ * When all 8 steps complete, awards the onboarding_complete badge.
+ */
+export async function POST(req: NextRequest) {
+  const user = await getAuthUser(req);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!USER_PROFILES.has(userId)) {
-    return NextResponse.json({ error: "User not found." }, { status: 404 });
-  }
+  const body = await req.json();
+  const { step_id, dismiss } = body;
 
-  let body: { step_id?: string; dismiss?: boolean };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
-  }
-
-  // Ensure progress record exists
-  if (!ONBOARDING_STORE.has(userId)) {
-    ONBOARDING_STORE.set(userId, {
-      user_id: userId,
-      completed: [],
-      dismissed: false,
-      completed_at: null,
-      updated_at: new Date().toISOString(),
-    });
-  }
-
-  const progress = ONBOARDING_STORE.get(userId)!;
-
-  // Handle dismiss flag
-  if (body.dismiss === true) {
-    progress.dismissed = true;
-    progress.updated_at = new Date().toISOString();
+  if (dismiss === true) {
+    // Upsert and set dismissed = true
+    await db.query(
+      `INSERT INTO onboarding_progress (user_id, dismissed, updated_at)
+       VALUES ($1, true, now())
+       ON CONFLICT (user_id) DO UPDATE SET dismissed = true, updated_at = now()`,
+      [user.id]
+    );
     return NextResponse.json({ success: true, dismissed: true });
   }
 
-  // Handle step completion
-  const { step_id } = body;
-  if (!step_id) {
+  if (!step_id || !VALID_STEPS.includes(step_id)) {
     return NextResponse.json(
-      { error: "step_id or dismiss:true is required." },
+      { error: `Invalid step_id. Must be one of: ${VALID_STEPS.join(", ")}` },
       { status: 400 }
     );
   }
 
-  if (!VALID_STEP_IDS.includes(step_id)) {
-    return NextResponse.json(
-      { error: `Unknown step_id: '${step_id}'.` },
-      { status: 400 }
+  // Upsert progress row and append step_id to completed array (idempotent)
+  await db.query(
+    `INSERT INTO onboarding_progress (user_id, completed, updated_at)
+     VALUES ($1, ARRAY[$2::TEXT], now())
+     ON CONFLICT (user_id) DO UPDATE
+       SET completed   = array_append(
+                           CASE WHEN $2 = ANY(onboarding_progress.completed)
+                                THEN onboarding_progress.completed
+                                ELSE onboarding_progress.completed
+                           END, $2),
+           updated_at  = now()`,
+    [user.id, step_id]
+  );
+
+  // Check if all steps are now complete
+  const { rows } = await db.query(
+    `SELECT completed FROM onboarding_progress WHERE user_id = $1`,
+    [user.id]
+  );
+
+  const completedSteps: string[] = rows[0]?.completed ?? [];
+  const allDone = VALID_STEPS.every((s) => completedSteps.includes(s));
+
+  if (allDone) {
+    // Mark completed_at if not already set
+    await db.query(
+      `UPDATE onboarding_progress
+       SET completed_at = COALESCE(completed_at, now())
+       WHERE user_id = $1 AND completed_at IS NULL`,
+      [user.id]
     );
+
+    // Award onboarding_complete badge (fire-and-forget; badge API handles idempotency)
+    try {
+      await fetch(
+        `${process.env.NEXT_PUBLIC_APP_URL}/api/routes-f/badges/award`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ user_id: user.id, badge_slug: "onboarding_complete" }),
+        }
+      );
+    } catch {
+      // Non-critical: badge award failure should not block the response
+    }
   }
 
-  if (!progress.completed.includes(step_id)) {
-    progress.completed.push(step_id);
-    progress.updated_at = new Date().toISOString();
-  }
-
-  return NextResponse.json({ success: true, step_id, already_completed: progress.completed.includes(step_id) });
+  return NextResponse.json({
+    success: true,
+    step_id,
+    all_complete: allDone,
+  });
 }

--- a/app/api/routes-f/onboarding/route.ts
+++ b/app/api/routes-f/onboarding/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Creator Onboarding Checklist API
+//
+// In production each step queries the relevant Postgres table.
+// Here we simulate the data store in-memory for the frontend layer.
+// ---------------------------------------------------------------------------
+
+type OnboardingProgress = {
+  user_id: string;
+  completed: string[];
+  dismissed: boolean;
+  completed_at: string | null;
+  updated_at: string;
+};
+
+type UserProfile = {
+  avatar: string | null;
+  bio: string | null;
+  wallet: string | null;
+  stream_title: string | null;
+  category: string | null;
+  total_streams: number;
+  follower_count: number;
+  total_tips_count: number;
+};
+
+// Simulated stores
+export const ONBOARDING_STORE: Map<string, OnboardingProgress> = new Map();
+export const USER_PROFILES: Map<string, UserProfile> = new Map();
+
+// Seed a demo user profile
+USER_PROFILES.set("user-demo-0001", {
+  avatar: "https://cdn.example.com/avatars/alice.jpg",
+  bio: null,
+  wallet: null,
+  stream_title: null,
+  category: null,
+  total_streams: 0,
+  follower_count: 0,
+  total_tips_count: 0,
+});
+
+// ---------------------------------------------------------------------------
+// Checklist step definitions
+// ---------------------------------------------------------------------------
+const CHECKLIST_STEPS: {
+  id: string;
+  title: string;
+  detect: (profile: UserProfile) => boolean;
+}[] = [
+  {
+    id: "set_avatar",
+    title: "Upload a profile photo",
+    detect: (p) => p.avatar !== null,
+  },
+  {
+    id: "set_bio",
+    title: "Write a bio",
+    detect: (p) => p.bio !== null,
+  },
+  {
+    id: "set_stream_title",
+    title: "Set a stream title",
+    detect: (p) => p.stream_title !== null,
+  },
+  {
+    id: "add_category",
+    title: "Pick a stream category",
+    detect: (p) => p.category !== null,
+  },
+  {
+    id: "first_stream",
+    title: "Go live for the first time",
+    detect: (p) => p.total_streams > 0,
+  },
+  {
+    id: "connect_wallet",
+    title: "Connect Stellar wallet",
+    detect: (p) => p.wallet !== null,
+  },
+  {
+    id: "first_follower",
+    title: "Get your first follower",
+    detect: (p) => p.follower_count >= 1,
+  },
+  {
+    id: "first_tip",
+    title: "Receive a tip",
+    detect: (p) => p.total_tips_count >= 1,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function getCurrentUserId(request: NextRequest): string | null {
+  return request.headers.get("x-user-id");
+}
+
+async function awardBadge(userId: string, badgeSlug: string) {
+  // In production: POST /api/routes-f/badges  { user_id, badge_slug }
+  console.log(`[onboarding] Awarding badge '${badgeSlug}' to user ${userId}`);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/routes-f/onboarding  — checklist progress for current user
+// ---------------------------------------------------------------------------
+export async function GET(request: NextRequest) {
+  const userId = getCurrentUserId(request);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const profile = USER_PROFILES.get(userId);
+  if (!profile) {
+    return NextResponse.json({ error: "User profile not found." }, { status: 404 });
+  }
+
+  // Ensure progress record exists
+  if (!ONBOARDING_STORE.has(userId)) {
+    ONBOARDING_STORE.set(userId, {
+      user_id: userId,
+      completed: [],
+      dismissed: false,
+      completed_at: null,
+      updated_at: new Date().toISOString(),
+    });
+  }
+  const progress = ONBOARDING_STORE.get(userId)!;
+
+  // Auto-evaluate each step
+  const steps = CHECKLIST_STEPS.map((step) => {
+    const auto = step.detect(profile);
+    const manual = progress.completed.includes(step.id);
+    return {
+      id: step.id,
+      title: step.title,
+      completed: auto || manual,
+    };
+  });
+
+  const completedCount = steps.filter((s) => s.completed).length;
+  const totalCount = steps.length;
+  const percentage = Math.round((completedCount / totalCount) * 100);
+
+  // Check for first-time full completion
+  if (completedCount === totalCount && !progress.completed_at) {
+    progress.completed_at = new Date().toISOString();
+    progress.updated_at = new Date().toISOString();
+    await awardBadge(userId, "onboarding_complete");
+  }
+
+  return NextResponse.json({
+    steps,
+    completed_count: completedCount,
+    total_count: totalCount,
+    percentage,
+    dismissed: progress.dismissed,
+    completed_at: progress.completed_at,
+  });
+}

--- a/app/api/routes-f/onboarding/route.ts
+++ b/app/api/routes-f/onboarding/route.ts
@@ -1,163 +1,104 @@
 import { NextRequest, NextResponse } from "next/server";
 
 // ---------------------------------------------------------------------------
-// Creator Onboarding Checklist API
+// DB schema (apply via migration):
 //
-// In production each step queries the relevant Postgres table.
-// Here we simulate the data store in-memory for the frontend layer.
+// CREATE TABLE onboarding_progress (
+//   user_id      UUID REFERENCES users(id) ON DELETE CASCADE PRIMARY KEY,
+//   completed    TEXT[] DEFAULT '{}',
+//   dismissed    BOOLEAN DEFAULT false,
+//   completed_at TIMESTAMPTZ,
+//   updated_at   TIMESTAMPTZ DEFAULT now()
+// );
 // ---------------------------------------------------------------------------
 
-type OnboardingProgress = {
-  user_id: string;
-  completed: string[];
-  dismissed: boolean;
-  completed_at: string | null;
-  updated_at: string;
-};
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 
-type UserProfile = {
-  avatar: string | null;
-  bio: string | null;
-  wallet: string | null;
-  stream_title: string | null;
-  category: string | null;
-  total_streams: number;
-  follower_count: number;
-  total_tips_count: number;
-};
-
-// Simulated stores
-export const ONBOARDING_STORE: Map<string, OnboardingProgress> = new Map();
-export const USER_PROFILES: Map<string, UserProfile> = new Map();
-
-// Seed a demo user profile
-USER_PROFILES.set("user-demo-0001", {
-  avatar: "https://cdn.example.com/avatars/alice.jpg",
-  bio: null,
-  wallet: null,
-  stream_title: null,
-  category: null,
-  total_streams: 0,
-  follower_count: 0,
-  total_tips_count: 0,
-});
-
-// ---------------------------------------------------------------------------
-// Checklist step definitions
-// ---------------------------------------------------------------------------
-const CHECKLIST_STEPS: {
-  id: string;
-  title: string;
-  detect: (profile: UserProfile) => boolean;
-}[] = [
-  {
-    id: "set_avatar",
-    title: "Upload a profile photo",
-    detect: (p) => p.avatar !== null,
-  },
-  {
-    id: "set_bio",
-    title: "Write a bio",
-    detect: (p) => p.bio !== null,
-  },
-  {
-    id: "set_stream_title",
-    title: "Set a stream title",
-    detect: (p) => p.stream_title !== null,
-  },
-  {
-    id: "add_category",
-    title: "Pick a stream category",
-    detect: (p) => p.category !== null,
-  },
-  {
-    id: "first_stream",
-    title: "Go live for the first time",
-    detect: (p) => p.total_streams > 0,
-  },
-  {
-    id: "connect_wallet",
-    title: "Connect Stellar wallet",
-    detect: (p) => p.wallet !== null,
-  },
-  {
-    id: "first_follower",
-    title: "Get your first follower",
-    detect: (p) => p.follower_count >= 1,
-  },
-  {
-    id: "first_tip",
-    title: "Receive a tip",
-    detect: (p) => p.total_tips_count >= 1,
-  },
+const STEPS = [
+  { id: "set_avatar",      title: "Upload a profile photo" },
+  { id: "set_bio",         title: "Write a bio" },
+  { id: "set_stream_title",title: "Set a stream title" },
+  { id: "add_category",    title: "Pick a stream category" },
+  { id: "first_stream",    title: "Go live for the first time" },
+  { id: "connect_wallet",  title: "Connect Stellar wallet" },
+  { id: "first_follower",  title: "Get your first follower" },
+  { id: "first_tip",       title: "Receive a tip" },
 ];
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function getCurrentUserId(request: NextRequest): string | null {
-  return request.headers.get("x-user-id");
+/**
+ * Auto-detect which steps are complete by querying user data.
+ */
+async function detectCompletedSteps(userId: string): Promise<string[]> {
+  const { rows } = await db.query(
+    `SELECT
+       u.avatar                                   AS avatar,
+       u.bio                                      AS bio,
+       u.wallet                                   AS wallet,
+       c.stream_title                             AS stream_title,
+       c.category                                 AS category,
+       (SELECT COUNT(*) FROM streams WHERE creator_id = u.id)         AS total_streams,
+       (SELECT COUNT(*) FROM follows  WHERE followed_id = u.id)       AS follower_count,
+       (SELECT COUNT(*) FROM tips     WHERE recipient_id = u.id)      AS total_tips_count,
+       op.completed                               AS manually_completed
+     FROM users u
+     LEFT JOIN creators c ON c.user_id = u.id
+     LEFT JOIN onboarding_progress op ON op.user_id = u.id
+     WHERE u.id = $1`,
+    [userId]
+  );
+
+  if (rows.length === 0) return [];
+  const row = rows[0];
+  const manual: string[] = row.manually_completed ?? [];
+
+  const auto: string[] = [];
+  if (row.avatar)                        auto.push("set_avatar");
+  if (row.bio)                           auto.push("set_bio");
+  if (row.stream_title)                  auto.push("set_stream_title");
+  if (row.category)                      auto.push("add_category");
+  if (Number(row.total_streams) > 0)     auto.push("first_stream");
+  if (row.wallet)                        auto.push("connect_wallet");
+  if (Number(row.follower_count) >= 1)   auto.push("first_follower");
+  if (Number(row.total_tips_count) >= 1) auto.push("first_tip");
+
+  // Merge auto-detected with manually marked (deduplicate)
+  return [...new Set([...auto, ...manual])];
 }
 
-async function awardBadge(userId: string, badgeSlug: string) {
-  // In production: POST /api/routes-f/badges  { user_id, badge_slug }
-  console.log(`[onboarding] Awarding badge '${badgeSlug}' to user ${userId}`);
-}
-
-// ---------------------------------------------------------------------------
-// GET /api/routes-f/onboarding  — checklist progress for current user
-// ---------------------------------------------------------------------------
-export async function GET(request: NextRequest) {
-  const userId = getCurrentUserId(request);
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+/**
+ * GET /api/routes-f/onboarding
+ * Returns the checklist progress for the authenticated user.
+ */
+export async function GET(req: NextRequest) {
+  const user = await getAuthUser(req);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const profile = USER_PROFILES.get(userId);
-  if (!profile) {
-    return NextResponse.json({ error: "User profile not found." }, { status: 404 });
-  }
+  const completed = await detectCompletedSteps(user.id);
 
-  // Ensure progress record exists
-  if (!ONBOARDING_STORE.has(userId)) {
-    ONBOARDING_STORE.set(userId, {
-      user_id: userId,
-      completed: [],
-      dismissed: false,
-      completed_at: null,
-      updated_at: new Date().toISOString(),
-    });
-  }
-  const progress = ONBOARDING_STORE.get(userId)!;
+  // Fetch dismissed state
+  const { rows: progressRows } = await db.query(
+    `SELECT dismissed, completed_at FROM onboarding_progress WHERE user_id = $1`,
+    [user.id]
+  );
+  const dismissed = progressRows[0]?.dismissed ?? false;
+  const completed_count = completed.length;
+  const total_count = STEPS.length;
+  const percentage = Math.round((completed_count / total_count) * 100);
 
-  // Auto-evaluate each step
-  const steps = CHECKLIST_STEPS.map((step) => {
-    const auto = step.detect(profile);
-    const manual = progress.completed.includes(step.id);
-    return {
-      id: step.id,
-      title: step.title,
-      completed: auto || manual,
-    };
-  });
-
-  const completedCount = steps.filter((s) => s.completed).length;
-  const totalCount = steps.length;
-  const percentage = Math.round((completedCount / totalCount) * 100);
-
-  // Check for first-time full completion
-  if (completedCount === totalCount && !progress.completed_at) {
-    progress.completed_at = new Date().toISOString();
-    progress.updated_at = new Date().toISOString();
-    await awardBadge(userId, "onboarding_complete");
-  }
+  const steps = STEPS.map((s) => ({
+    id: s.id,
+    title: s.title,
+    completed: completed.includes(s.id),
+  }));
 
   return NextResponse.json({
     steps,
-    completed_count: completedCount,
-    total_count: totalCount,
+    completed_count,
+    total_count,
     percentage,
-    dismissed: progress.dismissed,
-    completed_at: progress.completed_at,
+    dismissed,
   });
 }

--- a/app/api/routes-f/presence/[streamId]/heartbeat/route.ts
+++ b/app/api/routes-f/presence/[streamId]/heartbeat/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Re-use the same stores defined in the parent route module via a shared singleton.
+// For a full-stack implementation these would be Redis sorted set operations.
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __streamfi_presence: Map<string, Map<string, { lastSeen: number }>>;
+  // eslint-disable-next-line no-var
+  var __streamfi_peak: Map<string, number>;
+}
+
+globalThis.__streamfi_presence ??= new Map();
+globalThis.__streamfi_peak ??= new Map();
+
+const STALE_THRESHOLD_MS = 60_000;
+
+function getOrCreate(streamId: string) {
+  if (!globalThis.__streamfi_presence.has(streamId)) {
+    globalThis.__streamfi_presence.set(streamId, new Map());
+  }
+  return globalThis.__streamfi_presence.get(streamId)!;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/routes-f/presence/[streamId]/heartbeat
+// Body: { viewer_id: string }   (anonymous viewers pass a session-scoped ID)
+// ---------------------------------------------------------------------------
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { streamId: string } }
+) {
+  const { streamId } = params;
+
+  let body: { viewer_id?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const viewerId = body.viewer_id;
+  if (!viewerId || typeof viewerId !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const now = Date.now();
+  const viewers = getOrCreate(streamId);
+
+  // ZADD presence:{streamId} {now} {viewerId}  — update heartbeat
+  viewers.set(viewerId, { lastSeen: now });
+
+  // ZREMRANGEBYSCORE presence:{streamId} -inf {now - 60s}  — prune stale
+  const cutoff = now - STALE_THRESHOLD_MS;
+  for (const [id, entry] of viewers.entries()) {
+    if (entry.lastSeen < cutoff) viewers.delete(id);
+  }
+
+  // ZCOUNT  — count active
+  let count = 0;
+  for (const entry of viewers.values()) {
+    if (entry.lastSeen >= now - STALE_THRESHOLD_MS) count++;
+  }
+
+  // Update peak (mirrors Postgres ALTER TABLE stream_recordings peak_viewers)
+  const existingPeak = globalThis.__streamfi_peak.get(streamId) ?? 0;
+  if (count > existingPeak) {
+    globalThis.__streamfi_peak.set(streamId, count);
+  }
+
+  return NextResponse.json({ count }, { status: 200 });
+}

--- a/app/api/routes-f/presence/[streamId]/leave/route.ts
+++ b/app/api/routes-f/presence/[streamId]/leave/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/routes-f/presence/[streamId]/leave
+// Explicit viewer leave — removes them from the sorted set immediately.
+// ---------------------------------------------------------------------------
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { streamId: string } }
+) {
+  const { streamId } = params;
+
+  let body: { viewer_id?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const viewerId = body.viewer_id;
+  if (!viewerId) {
+    return NextResponse.json(
+      { error: "viewer_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const viewers: Map<string, { lastSeen: number }> | undefined =
+    (globalThis as any).__streamfi_presence?.get(streamId);
+
+  if (viewers) {
+    viewers.delete(viewerId);
+  }
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/routes-f/presence/[streamId]/route.ts
+++ b/app/api/routes-f/presence/[streamId]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Viewer Presence & Concurrent Viewer Tracking
+//
+// Storage strategy (in-memory substitute for Redis sorted sets):
+//   Map<streamId, Map<viewerId, lastHeartbeatMs>>
+//
+// Viewers are considered active if their last heartbeat was within 60 seconds.
+// Peak viewers are tracked per stream.
+// ---------------------------------------------------------------------------
+
+type PresenceEntry = { lastSeen: number };
+
+const presenceStore: Map<string, Map<string, PresenceEntry>> = new Map();
+const peakViewersStore: Map<string, number> = new Map();
+
+const STALE_THRESHOLD_MS = 60_000; // 60 seconds
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function getStreamPresence(streamId: string): Map<string, PresenceEntry> {
+  if (!presenceStore.has(streamId)) {
+    presenceStore.set(streamId, new Map());
+  }
+  return presenceStore.get(streamId)!;
+}
+
+function pruneStale(viewers: Map<string, PresenceEntry>) {
+  const cutoff = Date.now() - STALE_THRESHOLD_MS;
+  for (const [id, entry] of viewers.entries()) {
+    if (entry.lastSeen < cutoff) {
+      viewers.delete(id);
+    }
+  }
+}
+
+function countActiveViewers(viewers: Map<string, PresenceEntry>): number {
+  const cutoff = Date.now() - STALE_THRESHOLD_MS;
+  let count = 0;
+  for (const entry of viewers.values()) {
+    if (entry.lastSeen >= cutoff) count++;
+  }
+  return count;
+}
+
+function updatePeak(streamId: string, current: number) {
+  const existing = peakViewersStore.get(streamId) ?? 0;
+  if (current > existing) {
+    peakViewersStore.set(streamId, current);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/routes-f/presence/[streamId]  — current viewer count + peak
+// ---------------------------------------------------------------------------
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { streamId: string } }
+) {
+  const { streamId } = params;
+  const viewers = getStreamPresence(streamId);
+  pruneStale(viewers);
+
+  const count = countActiveViewers(viewers);
+  const peak = peakViewersStore.get(streamId) ?? count;
+
+  return NextResponse.json({ count, peak }, { status: 200 });
+}

--- a/app/api/routes-f/presence/[streamId]/route.ts
+++ b/app/api/routes-f/presence/[streamId]/route.ts
@@ -1,70 +1,121 @@
 import { NextRequest, NextResponse } from "next/server";
 
 // ---------------------------------------------------------------------------
-// Viewer Presence & Concurrent Viewer Tracking
+// DB schema (apply via migration):
 //
-// Storage strategy (in-memory substitute for Redis sorted sets):
-//   Map<streamId, Map<viewerId, lastHeartbeatMs>>
+// ALTER TABLE stream_recordings ADD COLUMN IF NOT EXISTS peak_viewers INT DEFAULT 0;
+// ---------------------------------------------------------------------------
 //
-// Viewers are considered active if their last heartbeat was within 60 seconds.
-// Peak viewers are tracked per stream.
+// Redis storage model:
+//   Key:   presence:{streamId}     — Sorted Set
+//   Score: Unix timestamp (last heartbeat)
+//   Member: viewerId or anonymousId
+//
+// Heartbeat flow:
+//   ZADD presence:{streamId} {now} {viewerId}
+//   ZREMRANGEBYSCORE presence:{streamId} -inf {now - 60}   (expire stale > 60s)
+//   ZCOUNT presence:{streamId} {now - 60} +inf             (current count)
 // ---------------------------------------------------------------------------
 
-type PresenceEntry = { lastSeen: number };
+import { redis } from "@/lib/redis";
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 
-const presenceStore: Map<string, Map<string, PresenceEntry>> = new Map();
-const peakViewersStore: Map<string, number> = new Map();
-
-const STALE_THRESHOLD_MS = 60_000; // 60 seconds
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function getStreamPresence(streamId: string): Map<string, PresenceEntry> {
-  if (!presenceStore.has(streamId)) {
-    presenceStore.set(streamId, new Map());
-  }
-  return presenceStore.get(streamId)!;
+function presenceKey(streamId: string) {
+  return `presence:${streamId}`;
 }
 
-function pruneStale(viewers: Map<string, PresenceEntry>) {
-  const cutoff = Date.now() - STALE_THRESHOLD_MS;
-  for (const [id, entry] of viewers.entries()) {
-    if (entry.lastSeen < cutoff) {
-      viewers.delete(id);
-    }
-  }
+function peakKey(streamId: string) {
+  return `presence:${streamId}:peak`;
 }
 
-function countActiveViewers(viewers: Map<string, PresenceEntry>): number {
-  const cutoff = Date.now() - STALE_THRESHOLD_MS;
-  let count = 0;
-  for (const entry of viewers.values()) {
-    if (entry.lastSeen >= cutoff) count++;
-  }
-  return count;
-}
-
-function updatePeak(streamId: string, current: number) {
-  const existing = peakViewersStore.get(streamId) ?? 0;
-  if (current > existing) {
-    peakViewersStore.set(streamId, current);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// GET /api/routes-f/presence/[streamId]  — current viewer count + peak
-// ---------------------------------------------------------------------------
+/**
+ * GET /api/routes-f/presence/[streamId]
+ * Returns current live viewer count and all-time peak for this stream.
+ */
 export async function GET(
-  _request: NextRequest,
+  _req: NextRequest,
   { params }: { params: { streamId: string } }
 ) {
   const { streamId } = params;
-  const viewers = getStreamPresence(streamId);
-  pruneStale(viewers);
+  const now = Math.floor(Date.now() / 1000);
+  const staleThreshold = now - 60;
 
-  const count = countActiveViewers(viewers);
-  const peak = peakViewersStore.get(streamId) ?? count;
+  const key = presenceKey(streamId);
 
-  return NextResponse.json({ count, peak }, { status: 200 });
+  // Count viewers whose last heartbeat was within the last 60 seconds
+  const count = await redis.zcount(key, staleThreshold, "+inf");
+
+  // Fetch peak from Postgres
+  const { rows } = await db.query(
+    `SELECT peak_viewers FROM stream_recordings WHERE stream_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [streamId]
+  );
+  const peak = rows[0]?.peak_viewers ?? count;
+
+  return NextResponse.json({ count, peak });
+}
+
+/**
+ * POST /api/routes-f/presence/[streamId]
+ * Body must include { viewer_id: string } — UUID for authed users, session ID for anon.
+ * Also used for explicit leave when action=leave is in the query string.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { streamId: string } }
+) {
+  const { streamId } = params;
+  const { searchParams } = new URL(req.url);
+  const action = searchParams.get("action"); // 'heartbeat' | 'leave'
+
+  const body = await req.json().catch(() => ({}));
+  const user = await getAuthUser(req);
+
+  // Use authenticated user ID if available, otherwise fall back to provided anonymous ID
+  const viewerId: string | undefined =
+    user?.id ?? body.viewer_id ?? body.anonymous_id;
+
+  if (!viewerId) {
+    return NextResponse.json(
+      { error: "viewer_id or anonymous_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const key = presenceKey(streamId);
+  const now = Math.floor(Date.now() / 1000);
+  const staleThreshold = now - 60;
+
+  // --- Explicit leave ---
+  if (action === "leave") {
+    await redis.zrem(key, viewerId);
+    return NextResponse.json({ success: true });
+  }
+
+  // --- Heartbeat (default) ---
+  // 1. Upsert viewer with current timestamp
+  await redis.zadd(key, now, viewerId);
+
+  // 2. Expire stale viewers (> 60s without a heartbeat)
+  await redis.zremrangebyscore(key, "-inf", staleThreshold);
+
+  // 3. Current live count
+  const count = await redis.zcount(key, staleThreshold, "+inf");
+
+  // 4. Update peak in Postgres if current count exceeds stored peak
+  const { rows } = await db.query(
+    `SELECT peak_viewers FROM stream_recordings WHERE stream_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [streamId]
+  );
+
+  const currentPeak = rows[0]?.peak_viewers ?? 0;
+  if (count > currentPeak) {
+    await db.query(
+      `UPDATE stream_recordings SET peak_viewers = $1 WHERE stream_id = $2`,
+      [count, streamId]
+    );
+  }
+
+  return NextResponse.json({ count });
 }

--- a/app/api/routes-f/presence/route.ts
+++ b/app/api/routes-f/presence/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 
-// Placeholder index route — individual stream presence is at /presence/[streamId]
+/**
+ * Base /api/routes-f/presence
+ * Redirects to stream-specific endpoints.
+ * All viewer presence operations are stream-scoped at /presence/[streamId].
+ */
 export async function GET() {
-  return NextResponse.json(
-    {
-      message:
-        "Use /api/routes-f/presence/[streamId] to get viewer count for a specific stream.",
-    },
-    { status: 200 }
-  );
+  return NextResponse.json({
+    message: "Use /api/routes-f/presence/[streamId] for stream-specific viewer counts.",
+  });
 }

--- a/app/api/routes-f/presence/route.ts
+++ b/app/api/routes-f/presence/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+// Placeholder index route — individual stream presence is at /presence/[streamId]
+export async function GET() {
+  return NextResponse.json(
+    {
+      message:
+        "Use /api/routes-f/presence/[streamId] to get viewer count for a specific stream.",
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/routes-f/referrals/[code]/apply/route.ts
+++ b/app/api/routes-f/referrals/[code]/apply/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { USERS_STORE } from "../../route";
+
+// ---------------------------------------------------------------------------
+// POST /api/routes-f/referrals/[code]/apply
+// Called during onboarding when ?ref= query param is present
+// ---------------------------------------------------------------------------
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { code: string } }
+) {
+  // Resolve current user
+  const userId = request.headers.get("x-user-id");
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const user = USERS_STORE.get(userId);
+  if (!user) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+
+  // Can only be applied once
+  if (user.referred_by) {
+    return NextResponse.json(
+      { error: "Referral code already applied." },
+      { status: 409 }
+    );
+  }
+
+  // Must be within 24h of signup
+  const hoursSinceSignup =
+    (Date.now() - user.created_at) / (1000 * 60 * 60);
+  if (hoursSinceSignup > 24) {
+    return NextResponse.json(
+      { error: "Referral window expired. Must be applied within 24h of signup." },
+      { status: 400 }
+    );
+  }
+
+  // Resolve referrer
+  const { code } = params;
+  const referrer = Array.from(USERS_STORE.values()).find(
+    (u) => u.referral_code === code
+  );
+
+  if (!referrer) {
+    return NextResponse.json(
+      { error: "Invalid referral code." },
+      { status: 404 }
+    );
+  }
+
+  if (referrer.id === userId) {
+    return NextResponse.json(
+      { error: "Cannot apply your own referral code." },
+      { status: 400 }
+    );
+  }
+
+  // Apply referral
+  user.referred_by = referrer.id;
+
+  return NextResponse.json(
+    { success: true, message: `Referral code '${code}' applied.` },
+    { status: 200 }
+  );
+}

--- a/app/api/routes-f/referrals/[code]/route.ts
+++ b/app/api/routes-f/referrals/[code]/route.ts
@@ -1,28 +1,96 @@
 import { NextRequest, NextResponse } from "next/server";
-import { USERS_STORE, REWARDS_STORE } from "../route";
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 
-// ---------------------------------------------------------------------------
-// GET /api/routes-f/referrals/[code]  — public code validation
-// ---------------------------------------------------------------------------
+/**
+ * GET /api/routes-f/referrals/[code]
+ * Public endpoint: validates whether a referral code exists.
+ * Used by the onboarding page to verify a ?ref= param.
+ */
 export async function GET(
-  _request: NextRequest,
+  _req: NextRequest,
   { params }: { params: { code: string } }
 ) {
   const { code } = params;
-  const referrer = Array.from(USERS_STORE.values()).find(
-    (u) => u.referral_code === code
+
+  const { rows } = await db.query(
+    `SELECT id, username FROM users WHERE referral_code = $1`,
+    [code]
   );
 
-  if (!referrer) {
-    return NextResponse.json(
-      { valid: false, error: "Referral code not found." },
-      { status: 404 }
-    );
+  if (rows.length === 0) {
+    return NextResponse.json({ valid: false, error: "Invalid referral code" }, { status: 404 });
   }
 
   return NextResponse.json({
     valid: true,
-    referrer_username: referrer.username,
-    code,
+    referrer: rows[0].username,
   });
+}
+
+/**
+ * POST /api/routes-f/referrals/[code]/apply
+ * Apply a referral code for the authenticated user.
+ * Can only be applied once and within 24h of signup.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
+  const user = await getAuthUser(req);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { code } = params;
+
+  // Ensure the current user hasn't already been referred
+  const { rows: currentUser } = await db.query(
+    `SELECT id, referred_by, created_at FROM users WHERE id = $1`,
+    [user.id]
+  );
+
+  if (currentUser.length === 0) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  if (currentUser[0].referred_by) {
+    return NextResponse.json(
+      { error: "Referral code has already been applied" },
+      { status: 409 }
+    );
+  }
+
+  // Enforce 24h signup window
+  const signedUpAt = new Date(currentUser[0].created_at);
+  const hoursSinceSignup =
+    (Date.now() - signedUpAt.getTime()) / (1000 * 60 * 60);
+  if (hoursSinceSignup > 24) {
+    return NextResponse.json(
+      { error: "Referral code can only be applied within 24 hours of signup" },
+      { status: 403 }
+    );
+  }
+
+  // Resolve referral code to a referrer
+  const { rows: referrer } = await db.query(
+    `SELECT id FROM users WHERE referral_code = $1`,
+    [code]
+  );
+
+  if (referrer.length === 0) {
+    return NextResponse.json({ error: "Invalid referral code" }, { status: 404 });
+  }
+
+  // Prevent self-referral
+  if (referrer[0].id === user.id) {
+    return NextResponse.json({ error: "Cannot refer yourself" }, { status: 400 });
+  }
+
+  await db.query(`UPDATE users SET referred_by = $1 WHERE id = $2`, [
+    referrer[0].id,
+    user.id,
+  ]);
+
+  return NextResponse.json({ success: true, message: "Referral code applied" });
 }

--- a/app/api/routes-f/referrals/[code]/route.ts
+++ b/app/api/routes-f/referrals/[code]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { USERS_STORE, REWARDS_STORE } from "../route";
+
+// ---------------------------------------------------------------------------
+// GET /api/routes-f/referrals/[code]  — public code validation
+// ---------------------------------------------------------------------------
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { code: string } }
+) {
+  const { code } = params;
+  const referrer = Array.from(USERS_STORE.values()).find(
+    (u) => u.referral_code === code
+  );
+
+  if (!referrer) {
+    return NextResponse.json(
+      { valid: false, error: "Referral code not found." },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    valid: true,
+    referrer_username: referrer.username,
+    code,
+  });
+}

--- a/app/api/routes-f/referrals/route.ts
+++ b/app/api/routes-f/referrals/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Simulated in-memory store (replace with Postgres + Stellar SDK in production)
+// ---------------------------------------------------------------------------
+type User = {
+  id: string;
+  username: string;
+  referral_code: string;
+  referred_by: string | null;
+  created_at: number; // epoch ms
+  total_earnings_usd: number;
+};
+
+type ReferralReward = {
+  id: string;
+  referrer_id: string;
+  referred_id: string;
+  trigger: "signup" | "first_earnings" | "milestone_100usd";
+  reward_usdc: number;
+  tx_hash: string | null;
+  created_at: number;
+};
+
+export const USERS_STORE: Map<string, User> = new Map();
+export const REWARDS_STORE: ReferralReward[] = [];
+
+// Seed a demo user
+const DEMO_USER: User = {
+  id: "user-demo-0001",
+  username: "alice",
+  referral_code: "alice-X7K2",
+  referred_by: null,
+  created_at: Date.now() - 1000 * 60 * 60 * 24 * 10,
+  total_earnings_usd: 0,
+};
+USERS_STORE.set(DEMO_USER.id, DEMO_USER);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function generateReferralCode(username: string): string {
+  const prefix = username.slice(0, 6).toLowerCase();
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const suffix = Array.from({ length: 4 }, () =>
+    chars.charAt(Math.floor(Math.random() * chars.length))
+  ).join("");
+  return `${prefix}-${suffix}`;
+}
+
+function getCurrentUserId(request: NextRequest): string | null {
+  // In production: decode JWT / session cookie.
+  // For demo, accept X-User-Id header.
+  return request.headers.get("x-user-id");
+}
+
+function buildShareUrl(code: string): string {
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.streamfi.media";
+  return `${base}/join?ref=${code}`;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/routes-f/referrals  — current user's referral code + stats
+// ---------------------------------------------------------------------------
+export async function GET(request: NextRequest) {
+  const userId = getCurrentUserId(request);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
+  }
+
+  const user = USERS_STORE.get(userId);
+  if (!user) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+
+  // Ensure referral code exists (idempotent generation)
+  if (!user.referral_code) {
+    user.referral_code = generateReferralCode(user.username);
+  }
+
+  // Build referral list
+  const referred = Array.from(USERS_STORE.values()).filter(
+    (u) => u.referred_by === userId
+  );
+
+  const myRewards = REWARDS_STORE.filter((r) => r.referrer_id === userId);
+  const totalEarnedUsdc = myRewards.reduce((s, r) => s + r.reward_usdc, 0);
+  const pendingUsdc = myRewards
+    .filter((r) => !r.tx_hash)
+    .reduce((s, r) => s + r.reward_usdc, 0);
+
+  const referrals = referred.map((u) => {
+    const earned = myRewards
+      .filter((r) => r.referred_id === u.id)
+      .reduce((s, r) => s + r.reward_usdc, 0);
+    return {
+      username: u.username,
+      joined_at: new Date(u.created_at).toISOString(),
+      status: u.total_earnings_usd >= 10 ? "active" : "pending",
+      earned_usdc: earned.toFixed(2),
+    };
+  });
+
+  return NextResponse.json({
+    code: user.referral_code,
+    share_url: buildShareUrl(user.referral_code),
+    stats: {
+      total_referred: referred.length,
+      active_referrals: referred.filter((u) => u.total_earnings_usd >= 10)
+        .length,
+      total_earned_usdc: totalEarnedUsdc.toFixed(2),
+      pending_usdc: pendingUsdc.toFixed(2),
+    },
+    referrals,
+  });
+}

--- a/app/api/routes-f/referrals/route.ts
+++ b/app/api/routes-f/referrals/route.ts
@@ -1,117 +1,110 @@
 import { NextRequest, NextResponse } from "next/server";
 
 // ---------------------------------------------------------------------------
-// Simulated in-memory store (replace with Postgres + Stellar SDK in production)
+// DB schema (apply via migration):
+//
+// ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code TEXT UNIQUE;
+// ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by   UUID REFERENCES users(id);
+//
+// CREATE TABLE referral_rewards (
+//   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+//   referrer_id   UUID REFERENCES users(id),
+//   referred_id   UUID REFERENCES users(id),
+//   trigger       TEXT NOT NULL,  -- 'signup' | 'first_earnings' | 'milestone_100usd'
+//   reward_usdc   NUMERIC(10,2),
+//   tx_hash       TEXT,
+//   created_at    TIMESTAMPTZ DEFAULT now()
+// );
 // ---------------------------------------------------------------------------
-type User = {
-  id: string;
-  username: string;
-  referral_code: string;
-  referred_by: string | null;
-  created_at: number; // epoch ms
-  total_earnings_usd: number;
-};
 
-type ReferralReward = {
-  id: string;
-  referrer_id: string;
-  referred_id: string;
-  trigger: "signup" | "first_earnings" | "milestone_100usd";
-  reward_usdc: number;
-  tx_hash: string | null;
-  created_at: number;
-};
+import { db } from "@/lib/db";
+import { getAuthUser } from "@/lib/auth";
 
-export const USERS_STORE: Map<string, User> = new Map();
-export const REWARDS_STORE: ReferralReward[] = [];
-
-// Seed a demo user
-const DEMO_USER: User = {
-  id: "user-demo-0001",
-  username: "alice",
-  referral_code: "alice-X7K2",
-  referred_by: null,
-  created_at: Date.now() - 1000 * 60 * 60 * 24 * 10,
-  total_earnings_usd: 0,
-};
-USERS_STORE.set(DEMO_USER.id, DEMO_USER);
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-function generateReferralCode(username: string): string {
-  const prefix = username.slice(0, 6).toLowerCase();
+/**
+ * Generates a referral code: first 6 chars of username + 4 random alphanumeric chars.
+ * e.g. 'alice-X7K2'
+ */
+export function generateReferralCode(username: string): string {
+  const base = username.slice(0, 6).toLowerCase();
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   const suffix = Array.from({ length: 4 }, () =>
     chars.charAt(Math.floor(Math.random() * chars.length))
   ).join("");
-  return `${prefix}-${suffix}`;
+  return `${base}-${suffix}`;
 }
 
-function getCurrentUserId(request: NextRequest): string | null {
-  // In production: decode JWT / session cookie.
-  // For demo, accept X-User-Id header.
-  return request.headers.get("x-user-id");
-}
-
-function buildShareUrl(code: string): string {
-  const base =
-    process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.streamfi.media";
-  return `${base}/join?ref=${code}`;
-}
-
-// ---------------------------------------------------------------------------
-// GET /api/routes-f/referrals  — current user's referral code + stats
-// ---------------------------------------------------------------------------
-export async function GET(request: NextRequest) {
-  const userId = getCurrentUserId(request);
-  if (!userId) {
-    return NextResponse.json({ error: "Unauthorised." }, { status: 401 });
-  }
-
-  const user = USERS_STORE.get(userId);
+/**
+ * GET /api/routes-f/referrals
+ * Returns the authenticated user's referral code, share URL, and stats.
+ */
+export async function GET(req: NextRequest) {
+  const user = await getAuthUser(req);
   if (!user) {
-    return NextResponse.json({ error: "User not found." }, { status: 404 });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Ensure referral code exists (idempotent generation)
-  if (!user.referral_code) {
-    user.referral_code = generateReferralCode(user.username);
-  }
-
-  // Build referral list
-  const referred = Array.from(USERS_STORE.values()).filter(
-    (u) => u.referred_by === userId
+  // Fetch or lazily create a referral code
+  let { rows: userRows } = await db.query(
+    `SELECT id, username, referral_code FROM users WHERE id = $1`,
+    [user.id]
   );
 
-  const myRewards = REWARDS_STORE.filter((r) => r.referrer_id === userId);
-  const totalEarnedUsdc = myRewards.reduce((s, r) => s + r.reward_usdc, 0);
-  const pendingUsdc = myRewards
-    .filter((r) => !r.tx_hash)
-    .reduce((s, r) => s + r.reward_usdc, 0);
+  if (userRows.length === 0) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
 
-  const referrals = referred.map((u) => {
-    const earned = myRewards
-      .filter((r) => r.referred_id === u.id)
-      .reduce((s, r) => s + r.reward_usdc, 0);
-    return {
-      username: u.username,
-      joined_at: new Date(u.created_at).toISOString(),
-      status: u.total_earnings_usd >= 10 ? "active" : "pending",
-      earned_usdc: earned.toFixed(2),
-    };
-  });
+  let { referral_code } = userRows[0];
+
+  if (!referral_code) {
+    referral_code = generateReferralCode(userRows[0].username);
+    await db.query(`UPDATE users SET referral_code = $1 WHERE id = $2`, [
+      referral_code,
+      user.id,
+    ]);
+  }
+
+  // Aggregate stats
+  const { rows: statsRows } = await db.query(
+    `SELECT
+       COUNT(DISTINCT u.id)                                           AS total_referred,
+       COUNT(DISTINCT CASE WHEN u.created_at > NOW() - INTERVAL '30 days' THEN u.id END) AS active_referrals,
+       COALESCE(SUM(rr.reward_usdc), 0)                              AS total_earned_usdc,
+       COALESCE(SUM(CASE WHEN rr.tx_hash IS NULL THEN rr.reward_usdc END), 0) AS pending_usdc
+     FROM users u
+     LEFT JOIN referral_rewards rr ON rr.referrer_id = $1 AND rr.referred_id = u.id
+     WHERE u.referred_by = $1`,
+    [user.id]
+  );
+
+  // Individual referrals list
+  const { rows: referrals } = await db.query(
+    `SELECT u.username, u.created_at AS joined_at,
+            CASE WHEN u.created_at > NOW() - INTERVAL '30 days' THEN 'active' ELSE 'inactive' END AS status,
+            COALESCE(SUM(rr.reward_usdc), 0) AS earned_usdc
+     FROM users u
+     LEFT JOIN referral_rewards rr ON rr.referrer_id = $1 AND rr.referred_id = u.id
+     WHERE u.referred_by = $1
+     GROUP BY u.id, u.username, u.created_at
+     ORDER BY u.created_at DESC`,
+    [user.id]
+  );
+
+  const stats = statsRows[0];
 
   return NextResponse.json({
-    code: user.referral_code,
-    share_url: buildShareUrl(user.referral_code),
+    code: referral_code,
+    share_url: `https://www.streamfi.media/join?ref=${referral_code}`,
     stats: {
-      total_referred: referred.length,
-      active_referrals: referred.filter((u) => u.total_earnings_usd >= 10)
-        .length,
-      total_earned_usdc: totalEarnedUsdc.toFixed(2),
-      pending_usdc: pendingUsdc.toFixed(2),
+      total_referred: Number(stats.total_referred),
+      active_referrals: Number(stats.active_referrals),
+      total_earned_usdc: String(Number(stats.total_earned_usdc).toFixed(2)),
+      pending_usdc: String(Number(stats.pending_usdc).toFixed(2)),
     },
-    referrals,
+    referrals: referrals.map((r) => ({
+      username: r.username,
+      joined_at: r.joined_at,
+      status: r.status,
+      earned_usdc: String(Number(r.earned_usdc).toFixed(2)),
+    })),
   });
 }


### PR DESCRIPTION
## Overview

This PR implements four new `routes-f` API modules that power key StreamFi platform features: a purchasable digital items catalog (for gifts and other goods), a creator referral program, real-time viewer presence tracking, and a guided creator onboarding checklist.

---

## What's Been Done

### 🎁 Items Catalog API — Issue #419

**Files:**
- `app/api/routes-f/items/route.ts`
- `app/api/routes-f/items/[id]/route.ts`

**Endpoints implemented:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/routes-f/items` | List all active items; supports `?type=gift\|sticker\|effect` filter |
| `GET` | `/api/routes-f/items/[id]` | Fetch a single item by UUID |
| `POST` | `/api/routes-f/items` | Create a new item **(admin only)** |
| `PATCH` | `/api/routes-f/items/[id]` | Update an item **(admin only)** |

**Key details:**
- `items_catalog` table schema + seed SQL for 5 gift tiers (Flower $1, Candy $5, Crown $25, Lion $100, Dragon $500) included as migration comments at the top of each file.
- `active: false` items are excluded from all public listings.
- Full catalog cached in Redis with a **5-minute TTL** (`items_catalog` and `items_catalog:type:{type}` keys).
- Cache is invalidated on every admin write (`POST` / `PATCH`).
- Both `price_usd` and `price_usdc` fields supported for fiat and on-chain pricing.

---

### 🔗 Creator Referral Program API — Issue #414

**Files:**
- `app/api/routes-f/referrals/route.ts`
- `app/api/routes-f/referrals/[code]/route.ts`

**Endpoints implemented:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/routes-f/referrals` | Get current user's referral code, share URL & stats |
| `GET` | `/api/routes-f/referrals/[code]` | Validate a referral code (public — for onboarding page) |
| `POST` | `/api/routes-f/referrals/[code]/apply` | Apply a referral code at signup |

**Key details:**
- Referral codes are auto-generated on first `GET` (format: `first6chars-XXXX`, e.g. `alice-X7K2`).
- `POST /apply` enforces: one application per user, 24-hour signup window, and self-referral prevention.
- DB schema for `users.referral_code`, `users.referred_by`, and `referral_rewards` table included as migration comments.
- Stats response includes `total_referred`, `active_referrals`, `total_earned_usdc`, and `pending_usdc`.
- Reward rows (`referral_rewards`) are designed to be inserted externally when a referred user hits the $10 or $100 earnings milestones, with USDC payouts via Stellar.

---

### 👁️ Viewer Presence & Concurrent Viewer Tracking API — Issue #406

**Files:**
- `app/api/routes-f/presence/route.ts`
- `app/api/routes-f/presence/[streamId]/route.ts`

**Endpoints implemented:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/routes-f/presence/[streamId]` | Current viewer count + peak viewers |
| `POST` | `/api/routes-f/presence/[streamId]` | Viewer heartbeat (every 30s) |
| `POST` | `/api/routes-f/presence/[streamId]?action=leave` | Explicit viewer leave |

**Key details:**
- Uses Redis **sorted sets** (`ZADD`/`ZREMRANGEBYSCORE`/`ZCOUNT`) for O(1) concurrent viewer tracking.
- Key pattern: `presence:{streamId}` — score = Unix timestamp, member = viewerId or anonymousId.
- Heartbeat automatically expires stale viewers older than 60 seconds via `ZREMRANGEBYSCORE`.
- Anonymous viewers (not logged in) are counted via a session-scoped ID sent in the request body.
- Peak viewers stored in Postgres (`stream_recordings.peak_viewers`) and updated on every heartbeat batch.
- Migration SQL: `ALTER TABLE stream_recordings ADD COLUMN IF NOT EXISTS peak_viewers INT DEFAULT 0;`

---

### ✅ Creator Onboarding Checklist API — Issue #412

**Files:**
- `app/api/routes-f/onboarding/route.ts`
- `app/api/routes-f/onboarding/complete/route.ts`

**Endpoints implemented:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/routes-f/onboarding` | Get checklist progress for current user |
| `POST` | `/api/routes-f/onboarding/complete` | Mark a step complete or dismiss the checklist |

**Checklist steps (8 total):**
| Step ID | Title | Auto-detected via |
|---------|-------|-------------------|
| `set_avatar` | Upload a profile photo | `users.avatar IS NOT NULL` |
| `set_bio` | Write a bio | `users.bio IS NOT NULL` |
| `set_stream_title` | Set a stream title | `creators.stream_title IS NOT NULL` |
| `add_category` | Pick a stream category | `creators.category IS NOT NULL` |
| `first_stream` | Go live for the first time | `total_streams > 0` |
| `connect_wallet` | Connect Stellar wallet | `users.wallet IS NOT NULL` |
| `first_follower` | Get your first follower | `follower_count >= 1` |
| `first_tip` | Receive a tip | `total_tips_count >= 1` |

**Key details:**
- `GET` auto-evaluates all steps by querying user/creator/streams/follows/tips tables on each request — no manual tracking needed for most steps.
- `POST /complete` allows manual step completion for edge cases (e.g., wallet connection) and supports `{ dismiss: true }` to hide the checklist from the UI.
- Dismissed state is persisted but steps remain visible from settings.
- When all 8 steps are complete, `completed_at` is recorded and the `onboarding_complete` badge is awarded via the badges API (fire-and-forget, non-blocking).
- `onboarding_progress` table schema included as migration comments.

---

## Database Migrations Required

All migration SQL is included as comments at the top of each route file. Before deploying, run the following:

```sql
-- Items catalog
CREATE TYPE item_type AS ENUM ('gift', 'sticker', 'effect', 'badge_frame', 'chat_color');
CREATE TABLE items_catalog ( ... );  -- see items/route.ts
-- seed 5 gift items

-- Referrals
ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code TEXT UNIQUE;
ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by UUID REFERENCES users(id);
CREATE TABLE referral_rewards ( ... );  -- see referrals/route.ts

-- Presence
ALTER TABLE stream_recordings ADD COLUMN IF NOT EXISTS peak_viewers INT DEFAULT 0;

-- Onboarding
CREATE TABLE onboarding_progress ( ... );  -- see onboarding/route.ts
```

---

## Closes

Closes #419
Closes #414
Closes #406
Closes #412