### PR TITLE
feat(routes-f): add cron validator, coin-flip streak, tic-tac-toe val…

### DIFF
--- a/app/api/routes-f/coin-flip/__tests__/route.test.ts
+++ b/app/api/routes-f/coin-flip/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+type FlipResponse = {
+  flips: Array<"H" | "T">;
+  heads_count: number;
+  tails_count: number;
+  longest_streak: { side: "H" | "T"; length: number; start_index: number };
+};
+
+function makePost(body: object): NextRequest {
+  return new Request("http://localhost/api/routes-f/coin-flip", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/routes-f/coin-flip", () => {
+  it("returns one flip by default", async () => {
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(200);
+    const data = await res.json() as FlipResponse;
+    expect(data.flips).toHaveLength(1);
+    expect(data.heads_count + data.tails_count).toBe(1);
+  });
+
+  it("supports deterministic flips with a seed", async () => {
+    const first = await POST(makePost({ count: 5, seed: 123, bias: 0.5 }));
+    const second = await POST(makePost({ count: 5, seed: 123, bias: 0.5 }));
+    expect(await first.json()).toEqual(await second.json());
+  });
+
+  it("respects bias values of 0 and 1", async () => {
+    const allHeads = await POST(makePost({ count: 4, seed: 1, bias: 1 }));
+    const headsData = await allHeads.json() as FlipResponse;
+    expect(headsData.flips.every((f) => f === "H")).toBe(true);
+
+    const allTails = await POST(makePost({ count: 4, seed: 1, bias: 0 }));
+    const tailsData = await allTails.json() as FlipResponse;
+    expect(tailsData.flips.every((f) => f === "T")).toBe(true);
+  });
+
+  it("computes the longest streak correctly", async () => {
+    const res = await POST(makePost({ count: 6, seed: 999, bias: 0.5 }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as FlipResponse;
+    expect(data.longest_streak.length).toBeGreaterThanOrEqual(1);
+    expect(data.longest_streak.start_index).toBeGreaterThanOrEqual(0);
+    expect(data.longest_streak.side).toMatch(/H|T/);
+  });
+
+  it("rejects invalid counts", async () => {
+    const res = await POST(makePost({ count: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid bias values", async () => {
+    const res = await POST(makePost({ bias: 1.5 }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/coin-flip/_lib/coinFlip.ts
+++ b/app/api/routes-f/coin-flip/_lib/coinFlip.ts
@@ -1,0 +1,68 @@
+export type FlipResult = {
+  flips: Array<"H" | "T">;
+  heads_count: number;
+  tails_count: number;
+  longest_streak: {
+    side: "H" | "T";
+    length: number;
+    start_index: number;
+  };
+};
+
+function createRandomGenerator(seed?: number): () => number {
+  let state = seed === undefined || Number.isNaN(Number(seed)) ? Math.floor(Math.random() * 0xffffffff) : Number(seed) >>> 0;
+  if (state === 0) {
+    state = 1;
+  }
+
+  return () => {
+    state ^= (state << 13) >>> 0;
+    state ^= state >>> 17;
+    state ^= (state << 5) >>> 0;
+    return ((state >>> 0) % 0x100000000) / 0x100000000;
+  };
+}
+
+export function coinFlip(count: number, bias: number, seed?: number): FlipResult {
+  const random = createRandomGenerator(seed);
+  const flips: Array<"H" | "T"> = [];
+  let heads_count = 0;
+  let tails_count = 0;
+
+  for (let i = 0; i < count; i += 1) {
+    const flip = random() < bias ? "H" : "T";
+    flips.push(flip);
+    if (flip === "H") {
+      heads_count += 1;
+    } else {
+      tails_count += 1;
+    }
+  }
+
+  let longest_streak = { side: flips[0] ?? "H", length: flips.length > 0 ? 1 : 0, start_index: 0 };
+  let current_side: "H" | "T" | null = null;
+  let current_length = 0;
+  let current_start = 0;
+
+  for (let i = 0; i < flips.length; i += 1) {
+    const flip = flips[i];
+    if (flip === current_side) {
+      current_length += 1;
+    } else {
+      current_side = flip;
+      current_length = 1;
+      current_start = i;
+    }
+
+    if (current_length > longest_streak.length) {
+      longest_streak = { side: current_side, length: current_length, start_index: current_start };
+    }
+  }
+
+  return {
+    flips,
+    heads_count,
+    tails_count,
+    longest_streak,
+  };
+}

--- a/app/api/routes-f/coin-flip/route.ts
+++ b/app/api/routes-f/coin-flip/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from "next/server";
+import { coinFlip } from "./_lib/coinFlip";
+
+const DEFAULT_COUNT = 1;
+const MAX_COUNT = 1000;
+const DEFAULT_BIAS = 0.5;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  let body: { count?: unknown; seed?: unknown; bias?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const count = body?.count === undefined ? DEFAULT_COUNT : Number(body.count);
+  if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+    return jsonResponse({ error: `'count' must be an integer between 1 and ${MAX_COUNT}` }, 400);
+  }
+
+  const bias = body?.bias === undefined ? DEFAULT_BIAS : Number(body.bias);
+  if (typeof bias !== "number" || Number.isNaN(bias) || bias < 0 || bias > 1) {
+    return jsonResponse({ error: "'bias' must be a number between 0 and 1" }, 400);
+  }
+
+  const seed = body?.seed === undefined ? undefined : Number(body.seed);
+  if (body?.seed !== undefined && (typeof seed !== "number" || Number.isNaN(seed))) {
+    return jsonResponse({ error: "'seed' must be a numeric value" }, 400);
+  }
+
+  const result = coinFlip(count, bias, seed);
+  return jsonResponse(result);
+}

--- a/app/api/routes-f/cron/__tests__/route.test.ts
+++ b/app/api/routes-f/cron/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+type CronResponse = { valid: boolean; description: string; next_runs: string[] };
+
+function makePost(body: object): NextRequest {
+  return new Request("http://localhost/api/routes-f/cron", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/routes-f/cron", () => {
+  it("returns 5 upcoming run times for a simple schedule", async () => {
+    const now = new Date(Date.UTC(2026, 0, 1, 8, 0, 0)).toISOString();
+    const res = await POST(makePost({ expression: "0 9 * * *", count: 3, from: now }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as CronResponse;
+    expect(data.valid).toBe(true);
+    expect(data.description).toContain("Every day at");
+    expect(data.next_runs).toHaveLength(3);
+    expect(data.next_runs[0]).toBe("2026-01-01T09:00:00.000Z");
+    expect(data.next_runs[1]).toBe("2026-01-02T09:00:00.000Z");
+  });
+
+  it("supports step values and lists", async () => {
+    const now = new Date(Date.UTC(2026, 0, 5, 9, 7, 0)).toISOString();
+    const res = await POST(makePost({ expression: "*/15 9-10 * * 1-5", count: 4, from: now }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as CronResponse;
+    expect(data.next_runs).toEqual([
+      "2026-01-05T09:15:00.000Z",
+      "2026-01-05T09:30:00.000Z",
+      "2026-01-05T09:45:00.000Z",
+      "2026-01-05T10:00:00.000Z",
+    ]);
+  });
+
+  it("rejects invalid cron expressions", async () => {
+    const res = await POST(makePost({ expression: "* * *", count: 3 }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/5 fields/);
+  });
+
+  it("rejects out-of-range values", async () => {
+    const res = await POST(makePost({ expression: "61 0 * * *" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/Invalid minute range/);
+  });
+
+  it("defaults count to 5 and returns valid response", async () => {
+    const now = new Date(Date.UTC(2026, 0, 1, 9, 0, 0)).toISOString();
+    const res = await POST(makePost({ expression: "0 9 * * *", from: now }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as CronResponse;
+    expect(data.next_runs).toHaveLength(5);
+  });
+});

--- a/app/api/routes-f/cron/_lib/cron.ts
+++ b/app/api/routes-f/cron/_lib/cron.ts
@@ -1,0 +1,266 @@
+export interface CronSchedule {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+  anyDayOfMonth: boolean;
+  anyDayOfWeek: boolean;
+}
+
+const FIELD_DEFINITIONS = [
+  { name: "minute", min: 0, max: 59 },
+  { name: "hour", min: 0, max: 23 },
+  { name: "dayOfMonth", min: 1, max: 31 },
+  { name: "month", min: 1, max: 12 },
+  { name: "dayOfWeek", min: 0, max: 7 },
+] as const;
+
+function normalizeDayOfWeek(value: number): number {
+  return value === 7 ? 0 : value;
+}
+
+function parseInteger(value: string, fieldName: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`Invalid ${fieldName} token: ${value}`);
+  }
+  return parsed;
+}
+
+function parseField(value: string, min: number, max: number, fieldName: string): Set<number> {
+  const tokens = value.split(",").map((token) => token.trim());
+  if (tokens.length === 0) {
+    throw new Error(`Empty ${fieldName} field`);
+  }
+
+  const values = new Set<number>();
+
+  for (const token of tokens) {
+    if (token === "") {
+      throw new Error(`Invalid ${fieldName} token: ${token}`);
+    }
+
+    const [rangePart, stepPart] = token.split("/");
+    const step = stepPart === undefined ? 1 : parseInteger(stepPart, fieldName);
+    if (step < 1) {
+      throw new Error(`Step must be at least 1 for ${fieldName}`);
+    }
+
+    let start: number;
+    let end: number;
+
+    if (rangePart === "*") {
+      start = min;
+      end = max;
+    } else if (rangePart.includes("-")) {
+      const [startStr, endStr] = rangePart.split("-").map((piece) => piece.trim());
+      if (startStr === "" || endStr === "") {
+        throw new Error(`Invalid ${fieldName} range: ${rangePart}`);
+      }
+      start = parseInteger(startStr, fieldName);
+      end = parseInteger(endStr, fieldName);
+    } else {
+      start = parseInteger(rangePart, fieldName);
+      end = start;
+    }
+
+    if (fieldName === "dayOfWeek") {
+      start = normalizeDayOfWeek(start);
+      end = normalizeDayOfWeek(end);
+    }
+
+    if (fieldName === "dayOfWeek" && start === 0 && end === 7) {
+      end = 0;
+    }
+
+    if (start < min || start > max || end < min || end > max) {
+      throw new Error(`Invalid ${fieldName} range: ${rangePart}`);
+    }
+
+    if (end < start) {
+      throw new Error(`Invalid ${fieldName} range: ${rangePart}`);
+    }
+
+    for (let current = start; current <= end; current += step) {
+      values.add(fieldName === "dayOfWeek" ? normalizeDayOfWeek(current) : current);
+    }
+  }
+
+  return values;
+}
+
+export function parseCronExpression(expression: string): CronSchedule {
+  const trimmed = expression.trim();
+  const parts = trimmed.split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error("Cron expression must contain exactly 5 fields");
+  }
+
+  const [minuteExpr, hourExpr, domExpr, monthExpr, dowExpr] = parts;
+
+  const minute = parseField(minuteExpr, 0, 59, "minute");
+  const hour = parseField(hourExpr, 0, 23, "hour");
+  const dayOfMonth = parseField(domExpr, 1, 31, "dayOfMonth");
+  const month = parseField(monthExpr, 1, 12, "month");
+  const dayOfWeek = parseField(dowExpr, 0, 7, "dayOfWeek");
+
+  return {
+    minute,
+    hour,
+    dayOfMonth,
+    month,
+    dayOfWeek,
+    anyDayOfMonth: domExpr === "*",
+    anyDayOfWeek: dowExpr === "*",
+  };
+}
+
+function formatNumberList(values: Set<number>, label: string): string {
+  const sorted = Array.from(values).sort((a, b) => a - b);
+  if (sorted.length === 1) {
+    return `${label} ${sorted[0]}`;
+  }
+  return `${label}s ${sorted.join(", ")}`;
+}
+
+function formatTimeValue(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function describeSchedule(schedule: CronSchedule): string {
+  const minuteAny = schedule.minute.size === 60;
+  const hourAny = schedule.hour.size === 24;
+  const monthAny = schedule.month.size === 12;
+  const domAny = schedule.anyDayOfMonth;
+  const dowAny = schedule.anyDayOfWeek;
+
+  if (minuteAny && hourAny && monthAny && domAny && dowAny) {
+    return "Every minute";
+  }
+
+  if (minuteAny && hourAny && monthAny && domAny && !dowAny) {
+    return `Every ${Array.from(schedule.dayOfWeek).map(describeWeekDay).join(", ")}`;
+  }
+
+  if (!minuteAny && hourAny && monthAny && domAny && dowAny) {
+    return schedule.minute.size === 1
+      ? `Every hour at minute ${Array.from(schedule.minute)[0]}`
+      : `Every ${Array.from(schedule.minute).sort((a, b) => a - b).join(", ")} minutes of every hour`;
+  }
+
+  if (schedule.minute.size === 1 && schedule.hour.size === 1 && monthAny && domAny && dowAny) {
+    return `Every day at ${formatTimeValue(Array.from(schedule.hour)[0])}:${formatTimeValue(Array.from(schedule.minute)[0])}`;
+  }
+
+  const parts: string[] = [];
+  if (!minuteAny) {
+    if (schedule.minute.size === 1) {
+      parts.push(`minute ${Array.from(schedule.minute)[0]}`);
+    } else {
+      parts.push(formatNumberList(schedule.minute, "minute"));
+    }
+  }
+
+  if (!hourAny) {
+    parts.push(hourAny ? "every hour" : formatNumberList(schedule.hour, "hour"));
+  }
+
+  if (!domAny) {
+    parts.push(formatNumberList(schedule.dayOfMonth, "day"));
+  }
+
+  if (!dowAny) {
+    parts.push(`on ${Array.from(schedule.dayOfWeek).map(describeWeekDay).join(", ")}`);
+  }
+
+  if (!monthAny) {
+    parts.push(`in ${Array.from(schedule.month).map(describeMonth).join(", ")}`);
+  }
+
+  return parts.length > 0 ? `Every ${parts.join(" ")}` : "Custom schedule";
+}
+
+function describeMonth(monthNumber: number): string {
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  return months[monthNumber - 1] ?? monthNumber.toString();
+}
+
+function describeWeekDay(value: number): string {
+  const normalized = normalizeDayOfWeek(value);
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  return days[normalized];
+}
+
+function matchesSchedule(date: Date, schedule: CronSchedule): boolean {
+  const minute = date.getUTCMinutes();
+  const hour = date.getUTCHours();
+  const day = date.getUTCDate();
+  const month = date.getUTCMonth() + 1;
+  const dow = date.getUTCDay();
+
+  if (!schedule.minute.has(minute) || !schedule.hour.has(hour) || !schedule.month.has(month)) {
+    return false;
+  }
+
+  const dayOfMonthMatches = schedule.dayOfMonth.has(day);
+  const dayOfWeekMatches = schedule.dayOfWeek.has(dow);
+
+  if (schedule.anyDayOfMonth && schedule.anyDayOfWeek) {
+    return true;
+  }
+
+  if (schedule.anyDayOfMonth) {
+    return dayOfWeekMatches;
+  }
+
+  if (schedule.anyDayOfWeek) {
+    return dayOfMonthMatches;
+  }
+
+  return dayOfMonthMatches || dayOfWeekMatches;
+}
+
+export function getNextCronRuns(schedule: CronSchedule, from: Date, count: number): string[] {
+  const runs: string[] = [];
+  const next = new Date(from.getTime());
+  next.setUTCSeconds(0, 0);
+  next.setUTCMinutes(next.getUTCMinutes() + 1);
+
+  while (runs.length < count) {
+    if (matchesSchedule(next, schedule)) {
+      runs.push(next.toISOString());
+    }
+    next.setUTCMinutes(next.getUTCMinutes() + 1);
+  }
+
+  return runs;
+}
+
+export function formatCronDescription(schedule: CronSchedule): string {
+  return describeSchedule(schedule);
+}
+
+export function parseDateFromIso(from?: string): Date {
+  if (!from) {
+    return new Date();
+  }
+  const parsed = new Date(from);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Invalid 'from' timestamp");
+  }
+  return parsed;
+}

--- a/app/api/routes-f/cron/route.ts
+++ b/app/api/routes-f/cron/route.ts
@@ -1,0 +1,53 @@
+import type { NextRequest } from "next/server";
+import {
+  formatCronDescription,
+  getNextCronRuns,
+  parseCronExpression,
+  parseDateFromIso,
+  type CronSchedule,
+} from "./_lib/cron";
+
+const DEFAULT_COUNT = 5;
+const MAX_COUNT = 50;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  let body: { expression?: unknown; count?: unknown; from?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const expression = typeof body?.expression === "string" ? body.expression.trim() : "";
+  if (!expression) {
+    return jsonResponse({ error: "'expression' is required and must be a non-empty string" }, 400);
+  }
+
+  const count = body?.count === undefined ? DEFAULT_COUNT : Number(body.count);
+  if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+    return jsonResponse({ error: `'count' must be an integer between 1 and ${MAX_COUNT}` }, 400);
+  }
+
+  const from = body?.from === undefined ? undefined : String(body.from);
+
+  let schedule: CronSchedule;
+  let fromDate: Date;
+  try {
+    schedule = parseCronExpression(expression);
+    fromDate = parseDateFromIso(from);
+  } catch (error) {
+    return jsonResponse({ error: error instanceof Error ? error.message : "Invalid cron expression" }, 400);
+  }
+
+  const next_runs = getNextCronRuns(schedule, fromDate, count);
+  const description = formatCronDescription(schedule);
+
+  return jsonResponse({ valid: true, description, next_runs });
+}

--- a/app/api/routes-f/ip-info/__tests__/route.test.ts
+++ b/app/api/routes-f/ip-info/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { GET } from "../route";
+
+describe("GET /api/routes-f/ip-info", () => {
+  it("returns deterministic geolocation for a valid IPv4 address", async () => {
+    const first = await GET(new Request("http://localhost/api/routes-f/ip-info?ip=8.8.8.8"));
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+    expect(firstBody.ip).toBe("8.8.8.8");
+    expect(typeof firstBody.country).toBe("string");
+    expect(typeof firstBody.lat).toBe("number");
+    expect(typeof firstBody.lng).toBe("number");
+
+    const second = await GET(new Request("http://localhost/api/routes-f/ip-info?ip=8.8.8.8"));
+    const secondBody = await second.json();
+    expect(secondBody).toEqual(firstBody);
+  });
+
+  it("treats private IPv4 addresses as private", async () => {
+    const res = await GET(new Request("http://localhost/api/routes-f/ip-info?ip=192.168.1.1"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.is_private).toBe(true);
+  });
+
+  it("returns private for loopback IPv6", async () => {
+    const res = await GET(new Request("http://localhost/api/routes-f/ip-info?ip=::1"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.is_private).toBe(true);
+  });
+
+  it("rejects malformed IP addresses", async () => {
+    const res = await GET(new Request("http://localhost/api/routes-f/ip-info?ip=999.999.999.999"));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid IP address");
+  });
+});

--- a/app/api/routes-f/ip-info/_lib/data.ts
+++ b/app/api/routes-f/ip-info/_lib/data.ts
@@ -1,0 +1,90 @@
+export const MOCK_LOCATIONS = [
+  {
+    country: "United States",
+    country_code: "US",
+    region: "California",
+    city: "San Francisco",
+    timezone: "America/Los_Angeles",
+    isp: "Mockwest Fiber",
+    lat: 37.7749,
+    lng: -122.4194,
+  },
+  {
+    country: "Canada",
+    country_code: "CA",
+    region: "Ontario",
+    city: "Toronto",
+    timezone: "America/Toronto",
+    isp: "Northern Grid",
+    lat: 43.6532,
+    lng: -79.3832,
+  },
+  {
+    country: "United Kingdom",
+    country_code: "GB",
+    region: "England",
+    city: "London",
+    timezone: "Europe/London",
+    isp: "BritSat Networks",
+    lat: 51.5074,
+    lng: -0.1278,
+  },
+  {
+    country: "Australia",
+    country_code: "AU",
+    region: "New South Wales",
+    city: "Sydney",
+    timezone: "Australia/Sydney",
+    isp: "Down Under Connect",
+    lat: -33.8688,
+    lng: 151.2093,
+  },
+  {
+    country: "Germany",
+    country_code: "DE",
+    region: "Bavaria",
+    city: "Munich",
+    timezone: "Europe/Berlin",
+    isp: "EuroLink ISP",
+    lat: 48.1351,
+    lng: 11.5820,
+  },
+  {
+    country: "Japan",
+    country_code: "JP",
+    region: "Tokyo",
+    city: "Tokyo",
+    timezone: "Asia/Tokyo",
+    isp: "Sakura Net",
+    lat: 35.6895,
+    lng: 139.6917,
+  },
+  {
+    country: "Brazil",
+    country_code: "BR",
+    region: "São Paulo",
+    city: "São Paulo",
+    timezone: "America/Sao_Paulo",
+    isp: "RioWave",
+    lat: -23.5505,
+    lng: -46.6333,
+  },
+  {
+    country: "South Africa",
+    country_code: "ZA",
+    region: "Gauteng",
+    city: "Johannesburg",
+    timezone: "Africa/Johannesburg",
+    isp: "PanAfrican Nets",
+    lat: -26.2041,
+    lng: 28.0473,
+  },
+];
+
+export function stableHash(value: string): number {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}

--- a/app/api/routes-f/ip-info/route.ts
+++ b/app/api/routes-f/ip-info/route.ts
@@ -1,0 +1,77 @@
+import type { NextRequest } from "next/server";
+import { isIP } from "net";
+import { MOCK_LOCATIONS, stableHash } from "./_lib/data";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function parseIPv4(ip: string): number {
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    throw new Error("Invalid IPv4 address");
+  }
+  return parts.reduce((acc, part) => {
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < 0 || value > 255) {
+      throw new Error("Invalid IPv4 address");
+    }
+    return (acc << 8) + value;
+  }, 0);
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const value = parseIPv4(ip);
+  return (
+    (value >>> 24) === 0x0a ||
+    (value >>> 20) === 0xac1 ||
+    (value >>> 16) === 0xc0a8
+  );
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  return normalized === "::1" || normalized.startsWith("fc") || normalized.startsWith("fd");
+}
+
+function makeLocation(ip: string) {
+  const hash = stableHash(ip);
+  const pick = MOCK_LOCATIONS[hash % MOCK_LOCATIONS.length];
+  const offset = (hash >>> 8) / 0xffffffff;
+  const lat = Number((pick.lat + (offset * 2 - 1) * 1.2).toFixed(6));
+  const lng = Number((pick.lng + (offset * 2 - 1) * 1.2).toFixed(6));
+  const isp = `${pick.isp} ${hash % 100}`;
+
+  return {
+    country: pick.country,
+    country_code: pick.country_code,
+    region: pick.region,
+    city: pick.city,
+    timezone: pick.timezone,
+    isp,
+    lat,
+    lng,
+  };
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const ip = url.searchParams.get("ip")?.trim();
+
+  if (!ip) {
+    return jsonResponse({ error: "'ip' query parameter is required" }, 400);
+  }
+
+  const version = isIP(ip);
+  if (version !== 4 && version !== 6) {
+    return jsonResponse({ error: "Invalid IP address" }, 400);
+  }
+
+  const is_private = version === 4 ? isPrivateIPv4(ip) : isPrivateIPv6(ip);
+  const location = makeLocation(ip);
+
+  return jsonResponse({ ip, is_private, ...location });
+}

--- a/app/api/routes-f/tic-tac-toe/__tests__/route.test.ts
+++ b/app/api/routes-f/tic-tac-toe/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+type TicTacToeResponse = {
+  valid: boolean;
+  winner: "X" | "O" | null;
+  line: number[] | null;
+  status: "in_progress" | "won" | "draw" | "invalid";
+  next_turn: "X" | "O" | null;
+};
+
+function makePost(body: object): NextRequest {
+  return new Request("http://localhost/api/routes-f/tic-tac-toe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/routes-f/tic-tac-toe", () => {
+  it("returns in_progress for an empty board", async () => {
+    const res = await POST(makePost({ board: Array(9).fill(null) }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as TicTacToeResponse;
+    expect(data.valid).toBe(true);
+    expect(data.status).toBe("in_progress");
+    expect(data.next_turn).toBe("X");
+  });
+
+  it("detects an X win", async () => {
+    const res = await POST(makePost({ board: ["X", "X", "X", null, "O", null, "O", null, null] }));
+    const data = await res.json() as TicTacToeResponse;
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.winner).toBe("X");
+    expect(data.line).toEqual([0, 1, 2]);
+    expect(data.status).toBe("won");
+    expect(data.next_turn).toBeNull();
+  });
+
+  it("detects an O win", async () => {
+    const res = await POST(makePost({ board: ["X", "X", "O", "X", "O", null, "O", null, null] }));
+    const data = await res.json() as TicTacToeResponse;
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.winner).toBe("O");
+    expect(data.line).toEqual([2, 4, 6]);
+    expect(data.status).toBe("won");
+    expect(data.next_turn).toBeNull();
+  });
+
+  it("detects a draw", async () => {
+    const res = await POST(makePost({ board: ["X", "O", "X", "X", "O", "O", "O", "X", "X"] }));
+    expect(res.status).toBe(200);
+    const data = await res.json() as TicTacToeResponse;
+    expect(data.valid).toBe(true);
+    expect(data.status).toBe("draw");
+    expect(data.winner).toBeNull();
+    expect(data.next_turn).toBeNull();
+  });
+
+  it("rejects invalid boards with both winners", async () => {
+    const res = await POST(makePost({ board: ["X", "X", "X", "O", "O", "O", null, null, null] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects impossible move counts", async () => {
+    const res = await POST(makePost({ board: ["O", null, null, null, null, null, null, null, null] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/tic-tac-toe/_lib/ticTacToe.ts
+++ b/app/api/routes-f/tic-tac-toe/_lib/ticTacToe.ts
@@ -1,0 +1,70 @@
+export type TicTacToeMark = "X" | "O" | null;
+export type TicTacToeBoard = TicTacToeMark[];
+
+const WIN_LINES: number[][] = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+export type TicTacToeResult = {
+  valid: boolean;
+  winner: "X" | "O" | null;
+  line: number[] | null;
+  status: "in_progress" | "won" | "draw" | "invalid";
+  next_turn: "X" | "O" | null;
+};
+
+function getWinningLines(board: TicTacToeBoard, mark: "X" | "O"): number[] | null {
+  for (const line of WIN_LINES) {
+    if (line.every((index) => board[index] === mark)) {
+      return line;
+    }
+  }
+  return null;
+}
+
+export function evaluateTicTacToe(board: TicTacToeBoard): TicTacToeResult {
+  if (!Array.isArray(board) || board.length !== 9) {
+    return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+  }
+
+  const counts = { X: 0, O: 0 };
+  for (const value of board) {
+    if (value === "X") counts.X += 1;
+    else if (value === "O") counts.O += 1;
+    else if (value !== null) {
+      return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+    }
+  }
+
+  if (!(counts.X === counts.O || counts.X === counts.O + 1)) {
+    return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+  }
+
+  const xLine = getWinningLines(board, "X");
+  const oLine = getWinningLines(board, "O");
+
+  if (xLine && oLine) {
+    return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+  }
+
+  if (xLine && counts.X !== counts.O + 1) {
+    return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+  }
+
+  if (oLine && counts.X !== counts.O) {
+    return { valid: false, winner: null, line: null, status: "invalid", next_turn: null };
+  }
+
+  const winner = xLine ? "X" : oLine ? "O" : null;
+  const status = winner ? "won" : board.includes(null) ? "in_progress" : "draw";
+  const next_turn = status === "in_progress" ? (counts.X === counts.O ? "X" : "O") : null;
+
+  return { valid: true, winner, line: winner ? xLine ?? oLine : null, status, next_turn };
+}

--- a/app/api/routes-f/tic-tac-toe/route.ts
+++ b/app/api/routes-f/tic-tac-toe/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from "next/server";
+import { evaluateTicTacToe, type TicTacToeBoard } from "./_lib/ticTacToe";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  let body: { board?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  const board = body?.board;
+  if (!Array.isArray(board)) {
+    return jsonResponse({ error: "'board' is required and must be an array of length 9" }, 400);
+  }
+
+  const result = evaluateTicTacToe(board as TicTacToeBoard);
+  if (!result.valid) {
+    return jsonResponse({ error: "Invalid tic-tac-toe board state" }, 400);
+  }
+
+  return jsonResponse(result);
+}


### PR DESCRIPTION
Adds four isolated App Router routes under app/api/routes-f: cron expression validation with next run calculation, coin flip batch flips with deterministic seed and streak tracking, tic-tac-toe state validation / winner detection, and mock deterministic IP geolocation.\n\nAll files remain inside app/api/routes-f as required.

Closes #630 
Closes #631 
Closes #620 
Closes #627 
