### PR TITLE
feat(routes-f): add semver and CIDR utility endpoints

### DIFF
--- a/app/api/routes-f/cidr/__tests__/route.test.ts
+++ b/app/api/routes-f/cidr/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+function makeReq(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/cidr", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/cidr", () => {
+  describe("IPv4", () => {
+    it("calculates /24 network correctly", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.0/24" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("192.168.1.0");
+      expect(body.broadcast).toBe("192.168.1.255");
+      expect(body.first_host).toBe("192.168.1.1");
+      expect(body.last_host).toBe("192.168.1.254");
+      expect(body.host_count).toBe(254);
+      expect(body.netmask).toBe("255.255.255.0");
+      expect(body.prefix_length).toBe(24);
+      expect(body.version).toBe(4);
+    });
+
+    it("calculates /16 network correctly", async () => {
+      const res = await POST(makeReq({ cidr: "10.0.0.0/16" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("10.0.0.0");
+      expect(body.broadcast).toBe("10.0.255.255");
+      expect(body.host_count).toBe(65534);
+      expect(body.netmask).toBe("255.255.0.0");
+    });
+
+    it("calculates /8 network correctly", async () => {
+      const res = await POST(makeReq({ cidr: "10.0.0.0/8" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("10.0.0.0");
+      expect(body.broadcast).toBe("10.255.255.255");
+      expect(body.host_count).toBe(16777214);
+    });
+
+    it("handles /32 (single host)", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.1/32" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("192.168.1.1");
+      expect(body.broadcast).toBe("192.168.1.1");
+      expect(body.first_host).toBe("192.168.1.1");
+      expect(body.last_host).toBe("192.168.1.1");
+      expect(body.host_count).toBe(1);
+    });
+
+    it("handles /31 (point-to-point, RFC 3021)", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.0/31" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.host_count).toBe(2);
+      expect(body.first_host).toBe("192.168.1.0");
+      expect(body.last_host).toBe("192.168.1.1");
+    });
+
+    it("handles /0 (entire internet)", async () => {
+      const res = await POST(makeReq({ cidr: "0.0.0.0/0" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("0.0.0.0");
+      expect(body.broadcast).toBe("255.255.255.255");
+    });
+
+    it("masks host bits from input IP", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.100/24" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.network).toBe("192.168.1.0");
+    });
+  });
+
+  describe("IPv6", () => {
+    it("calculates /64 network correctly", async () => {
+      const res = await POST(makeReq({ cidr: "2001:db8::/64" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.version).toBe(6);
+      expect(body.prefix_length).toBe(64);
+      expect(body.network).toContain("2001");
+    });
+
+    it("calculates /128 (single host)", async () => {
+      const res = await POST(makeReq({ cidr: "::1/128" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.host_count).toBe(1);
+      expect(body.version).toBe(6);
+    });
+
+    it("calculates /48 network", async () => {
+      const res = await POST(makeReq({ cidr: "2001:db8:abcd::/48" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.version).toBe(6);
+      expect(body.prefix_length).toBe(48);
+    });
+  });
+
+  describe("validation", () => {
+    it("returns 400 for missing cidr", async () => {
+      const res = await POST(makeReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid CIDR (no slash)", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.0" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid IPv4 address", async () => {
+      const res = await POST(makeReq({ cidr: "999.168.1.0/24" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for prefix out of range (IPv4)", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.0/33" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for prefix out of range (IPv6)", async () => {
+      const res = await POST(makeReq({ cidr: "2001:db8::/129" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for non-numeric prefix", async () => {
+      const res = await POST(makeReq({ cidr: "192.168.1.0/abc" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new NextRequest("http://localhost/api/routes-f/cidr", {
+        method: "POST",
+        body: "not json",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/cidr/route.ts
+++ b/app/api/routes-f/cidr/route.ts
@@ -1,0 +1,307 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ── IPv4 helpers ──────────────────────────────────────────────────────────────
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split(".").map(Number);
+  return ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+}
+
+function intToIpv4(n: number): string {
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+  ].join(".");
+}
+
+function isValidIpv4(ip: string): boolean {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return false;
+  return parts.every((p) => /^\d+$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+}
+
+function calcIpv4(ip: string, prefix: number) {
+  const ipInt = ipv4ToInt(ip);
+  const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+  const network = (ipInt & mask) >>> 0;
+  const broadcast = (network | (~mask >>> 0)) >>> 0;
+  const netmask = intToIpv4(mask);
+
+  let firstHost: string;
+  let lastHost: string;
+  let hostCount: number;
+
+  if (prefix === 32) {
+    firstHost = intToIpv4(network);
+    lastHost = intToIpv4(network);
+    hostCount = 1;
+  } else if (prefix === 31) {
+    // Point-to-point (RFC 3021): both addresses usable
+    firstHost = intToIpv4(network);
+    lastHost = intToIpv4(broadcast);
+    hostCount = 2;
+  } else {
+    firstHost = intToIpv4(network + 1);
+    lastHost = intToIpv4(broadcast - 1);
+    hostCount = Math.pow(2, 32 - prefix) - 2;
+  }
+
+  return {
+    network: intToIpv4(network),
+    broadcast: intToIpv4(broadcast),
+    first_host: firstHost,
+    last_host: lastHost,
+    host_count: hostCount,
+    netmask,
+    prefix_length: prefix,
+    version: 4 as const,
+  };
+}
+
+// ── IPv6 helpers (128-bit via two 64-bit halves as numbers) ───────────────────
+// We represent a 128-bit address as [hi, lo] where each is a 32-bit unsigned int
+// (4 x 32-bit words: [w0, w1, w2, w3], w0 = most significant)
+
+type U128 = [number, number, number, number]; // four 32-bit words, big-endian
+
+function isValidIpv6(ip: string): boolean {
+  if (ip.includes(":::")) return false;
+  const doubleColons = (ip.match(/::/g) || []).length;
+  if (doubleColons > 1) return false;
+  const expanded = expandIpv6(ip);
+  if (!expanded) return false;
+  const groups = expanded.split(":");
+  return groups.length === 8 && groups.every((g) => /^[0-9a-fA-F]{1,4}$/.test(g));
+}
+
+function expandIpv6(ip: string): string | null {
+  if (ip.includes("::")) {
+    const [left, right] = ip.split("::");
+    const leftParts = left ? left.split(":") : [];
+    const rightParts = right ? right.split(":") : [];
+    const missing = 8 - leftParts.length - rightParts.length;
+    if (missing < 0) return null;
+    return [...leftParts, ...Array(missing).fill("0"), ...rightParts].join(":");
+  }
+  return ip;
+}
+
+function ipv6ToU128(ip: string): U128 {
+  const expanded = expandIpv6(ip)!;
+  const groups = expanded.split(":").map((g) => parseInt(g || "0", 16));
+  return [
+    ((groups[0] << 16) | groups[1]) >>> 0,
+    ((groups[2] << 16) | groups[3]) >>> 0,
+    ((groups[4] << 16) | groups[5]) >>> 0,
+    ((groups[6] << 16) | groups[7]) >>> 0,
+  ];
+}
+
+function u128ToIpv6(w: U128): string {
+  const groups: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    groups.push(((w[i] >>> 16) & 0xffff).toString(16));
+    groups.push((w[i] & 0xffff).toString(16));
+  }
+  // Compress longest run of "0" groups
+  let best = { start: -1, len: 0 };
+  let cur = { start: -1, len: 0 };
+  for (let i = 0; i < groups.length; i++) {
+    if (groups[i] === "0") {
+      if (cur.start === -1) cur = { start: i, len: 1 };
+      else cur.len++;
+      if (cur.len > best.len) best = { ...cur };
+    } else {
+      cur = { start: -1, len: 0 };
+    }
+  }
+  if (best.len > 1) {
+    const left = groups.slice(0, best.start).join(":");
+    const right = groups.slice(best.start + best.len).join(":");
+    const result = `${left}::${right}`;
+    return result.replace(/^:([^:])/, "::$1").replace(/([^:]):$/, "$1::");
+  }
+  return groups.join(":");
+}
+
+// Build a 128-bit mask from prefix length
+function prefixToMask(prefix: number): U128 {
+  const mask: U128 = [0, 0, 0, 0];
+  let remaining = prefix;
+  for (let i = 0; i < 4; i++) {
+    if (remaining >= 32) {
+      mask[i] = 0xffffffff >>> 0;
+      remaining -= 32;
+    } else if (remaining > 0) {
+      mask[i] = (~0 << (32 - remaining)) >>> 0;
+      remaining = 0;
+    } else {
+      mask[i] = 0;
+    }
+  }
+  return mask;
+}
+
+function andU128(a: U128, b: U128): U128 {
+  return [a[0] & b[0], a[1] & b[1], a[2] & b[2], a[3] & b[3]].map((v) => v >>> 0) as U128;
+}
+
+function orU128(a: U128, b: U128): U128 {
+  return [a[0] | b[0], a[1] | b[1], a[2] | b[2], a[3] | b[3]].map((v) => v >>> 0) as U128;
+}
+
+function notU128(a: U128): U128 {
+  return [~a[0], ~a[1], ~a[2], ~a[3]].map((v) => v >>> 0) as U128;
+}
+
+function addOneU128(a: U128): U128 {
+  const result: U128 = [...a] as U128;
+  for (let i = 3; i >= 0; i--) {
+    result[i] = (result[i] + 1) >>> 0;
+    if (result[i] !== 0) break;
+  }
+  return result;
+}
+
+function subOneU128(a: U128): U128 {
+  const result: U128 = [...a] as U128;
+  for (let i = 3; i >= 0; i--) {
+    if (result[i] > 0) {
+      result[i] = (result[i] - 1) >>> 0;
+      break;
+    }
+    result[i] = 0xffffffff >>> 0;
+  }
+  return result;
+}
+
+// Count of addresses = 2^hostBits; return as string if > MAX_SAFE_INTEGER
+function hostCount(prefix: number): number | string {
+  const hostBits = 128 - prefix;
+  if (prefix === 128) return 1;
+  if (hostBits >= 53) {
+    // Too large for safe integer — compute as string via repeated doubling
+    // 2^hostBits - 2
+    let val = "2";
+    for (let i = 1; i < hostBits; i++) {
+      // multiply by 2
+      let carry = 0;
+      const digits = val.split("").reverse().map(Number);
+      const result: number[] = [];
+      for (const d of digits) {
+        const prod = d * 2 + carry;
+        result.push(prod % 10);
+        carry = Math.floor(prod / 10);
+      }
+      if (carry) result.push(carry);
+      val = result.reverse().join("");
+    }
+    // subtract 2
+    const digits = val.split("").map(Number);
+    let borrow = 2;
+    for (let i = digits.length - 1; i >= 0 && borrow > 0; i--) {
+      const diff = digits[i] - borrow;
+      if (diff < 0) {
+        digits[i] = diff + 10;
+        borrow = 1;
+      } else {
+        digits[i] = diff;
+        borrow = 0;
+      }
+    }
+    return digits.join("").replace(/^0+/, "") || "0";
+  }
+  return Math.pow(2, hostBits) - 2;
+}
+
+function calcIpv6(ip: string, prefix: number) {
+  const addr = ipv6ToU128(ip);
+  const mask = prefixToMask(prefix);
+  const network = andU128(addr, mask);
+  const broadcast = orU128(network, notU128(mask));
+  const netmask = `/${prefix}`;
+
+  let firstHost: string;
+  let lastHost: string;
+  let hCount: number | string;
+
+  if (prefix === 128) {
+    firstHost = u128ToIpv6(network);
+    lastHost = u128ToIpv6(network);
+    hCount = 1;
+  } else {
+    firstHost = u128ToIpv6(addOneU128(network));
+    lastHost = u128ToIpv6(subOneU128(broadcast));
+    hCount = hostCount(prefix);
+  }
+
+  return {
+    network: u128ToIpv6(network),
+    broadcast: u128ToIpv6(broadcast),
+    first_host: firstHost,
+    last_host: lastHost,
+    host_count: hCount,
+    netmask,
+    prefix_length: prefix,
+    version: 6 as const,
+  };
+}
+
+// ── Route handler ─────────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { cidr } = body;
+
+  if (typeof cidr !== "string" || !cidr.trim()) {
+    return NextResponse.json({ error: "cidr must be a non-empty string." }, { status: 400 });
+  }
+
+  const slashIdx = cidr.lastIndexOf("/");
+  if (slashIdx === -1) {
+    return NextResponse.json({ error: `Invalid CIDR notation: "${cidr}"` }, { status: 400 });
+  }
+
+  const ip = cidr.slice(0, slashIdx);
+  const prefixStr = cidr.slice(slashIdx + 1);
+
+  if (!/^\d+$/.test(prefixStr)) {
+    return NextResponse.json({ error: `Invalid prefix length: "${prefixStr}"` }, { status: 400 });
+  }
+
+  const prefix = parseInt(prefixStr, 10);
+
+  if (ip.includes(":")) {
+    // IPv6
+    if (!isValidIpv6(ip)) {
+      return NextResponse.json({ error: `Invalid IPv6 address: "${ip}"` }, { status: 400 });
+    }
+    if (prefix < 0 || prefix > 128) {
+      return NextResponse.json(
+        { error: "IPv6 prefix length must be between 0 and 128." },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(calcIpv6(ip, prefix));
+  } else {
+    // IPv4
+    if (!isValidIpv4(ip)) {
+      return NextResponse.json({ error: `Invalid IPv4 address: "${ip}"` }, { status: 400 });
+    }
+    if (prefix < 0 || prefix > 32) {
+      return NextResponse.json(
+        { error: "IPv4 prefix length must be between 0 and 32." },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json(calcIpv4(ip, prefix));
+  }
+}

--- a/app/api/routes-f/semver/__tests__/route.test.ts
+++ b/app/api/routes-f/semver/__tests__/route.test.ts
@@ -1,0 +1,215 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+function makeReq(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/semver", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/semver", () => {
+  describe("parse", () => {
+    it("parses a simple version", async () => {
+      const res = await POST(makeReq({ action: "parse", version: "1.2.3" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ major: 1, minor: 2, patch: 3 });
+    });
+
+    it("parses version with prerelease", async () => {
+      const res = await POST(makeReq({ action: "parse", version: "1.0.0-alpha.1" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.major).toBe(1);
+      expect(body.prerelease).toBe("alpha.1");
+    });
+
+    it("parses version with build metadata", async () => {
+      const res = await POST(makeReq({ action: "parse", version: "1.0.0+build.123" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.build).toBe("build.123");
+    });
+
+    it("parses version with prerelease and build", async () => {
+      const res = await POST(makeReq({ action: "parse", version: "2.0.0-rc.1+sha.abc" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.prerelease).toBe("rc.1");
+      expect(body.build).toBe("sha.abc");
+    });
+
+    it("returns 400 for invalid version", async () => {
+      const res = await POST(makeReq({ action: "parse", version: "not-a-version" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for missing version", async () => {
+      const res = await POST(makeReq({ action: "parse" }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("compare", () => {
+    it("returns 0 for equal versions", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "1.0.0", b: "1.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(0);
+    });
+
+    it("returns -1 when a < b", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "1.0.0", b: "2.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(-1);
+    });
+
+    it("returns 1 when a > b", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "2.0.0", b: "1.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(1);
+    });
+
+    it("prerelease is less than release", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "1.0.0-alpha", b: "1.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(-1);
+    });
+
+    it("compares prerelease identifiers numerically", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "1.0.0-alpha.1", b: "1.0.0-alpha.2" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(-1);
+    });
+
+    it("numeric prerelease < alphanumeric", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "1.0.0-1", b: "1.0.0-alpha" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).result).toBe(-1);
+    });
+
+    it("returns 400 for invalid version a", async () => {
+      const res = await POST(makeReq({ action: "compare", a: "bad", b: "1.0.0" }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("bump", () => {
+    it("bumps major", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.2.3", level: "major" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).next).toBe("2.0.0");
+    });
+
+    it("bumps minor", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.2.3", level: "minor" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).next).toBe("1.3.0");
+    });
+
+    it("bumps patch", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.2.3", level: "patch" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).next).toBe("1.2.4");
+    });
+
+    it("bumps prerelease from release", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.2.3", level: "prerelease" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).next).toBe("1.2.3-0");
+    });
+
+    it("bumps existing numeric prerelease", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.2.3-alpha.1", level: "prerelease" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).next).toBe("1.2.3-alpha.2");
+    });
+
+    it("returns 400 for invalid level", async () => {
+      const res = await POST(makeReq({ action: "bump", version: "1.0.0", level: "invalid" }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("satisfies", () => {
+    it("exact version match", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "1.2.3", range: "1.2.3" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("caret range ^1.2.3 allows patch/minor bumps", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "1.9.9", range: "^1.2.3" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("caret range ^1.2.3 rejects major bump", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "2.0.0", range: "^1.2.3" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(false);
+    });
+
+    it("tilde range ~1.2.3 allows patch bumps", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "1.2.9", range: "~1.2.3" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("tilde range ~1.2.3 rejects minor bump", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "1.3.0", range: "~1.2.3" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(false);
+    });
+
+    it(">= range", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "2.0.0", range: ">=1.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("< range", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "0.9.0", range: "<1.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("compound range >=1.0.0 <2.0.0", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "1.5.0", range: ">=1.0.0 <2.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(true);
+    });
+
+    it("compound range rejects out-of-range", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "2.0.0", range: ">=1.0.0 <2.0.0" }));
+      expect(res.status).toBe(200);
+      expect((await res.json()).satisfies).toBe(false);
+    });
+
+    it("returns 400 for invalid version", async () => {
+      const res = await POST(makeReq({ action: "satisfies", version: "bad", range: "^1.0.0" }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("validation", () => {
+    it("returns 400 for missing action", async () => {
+      const res = await POST(makeReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for unknown action", async () => {
+      const res = await POST(makeReq({ action: "unknown" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new NextRequest("http://localhost/api/routes-f/semver", {
+        method: "POST",
+        body: "not json",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/semver/route.ts
+++ b/app/api/routes-f/semver/route.ts
@@ -1,0 +1,232 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Semver regex per semver.org spec
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+interface Parsed {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+  build?: string;
+}
+
+function parse(version: string): Parsed | null {
+  const m = SEMVER_RE.exec(version.trim());
+  if (!m) return null;
+  const result: Parsed = {
+    major: parseInt(m[1], 10),
+    minor: parseInt(m[2], 10),
+    patch: parseInt(m[3], 10),
+  };
+  if (m[4] !== undefined) result.prerelease = m[4];
+  if (m[5] !== undefined) result.build = m[5];
+  return result;
+}
+
+function comparePrerelease(a?: string, b?: string): number {
+  // No prerelease > has prerelease (1.0.0 > 1.0.0-alpha)
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+
+  const aParts = a.split(".");
+  const bParts = b.split(".");
+  const len = Math.max(aParts.length, bParts.length);
+
+  for (let i = 0; i < len; i++) {
+    if (i >= aParts.length) return -1;
+    if (i >= bParts.length) return 1;
+    const ap = aParts[i];
+    const bp = bParts[i];
+    const aNum = /^\d+$/.test(ap);
+    const bNum = /^\d+$/.test(bp);
+    if (aNum && bNum) {
+      const diff = parseInt(ap, 10) - parseInt(bp, 10);
+      if (diff !== 0) return diff < 0 ? -1 : 1;
+    } else if (aNum) {
+      return -1; // numeric < alphanumeric
+    } else if (bNum) {
+      return 1;
+    } else {
+      if (ap < bp) return -1;
+      if (ap > bp) return 1;
+    }
+  }
+  return 0;
+}
+
+function compare(a: Parsed, b: Parsed): -1 | 0 | 1 {
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (a[key] < b[key]) return -1;
+    if (a[key] > b[key]) return 1;
+  }
+  const pre = comparePrerelease(a.prerelease, b.prerelease);
+  return pre < 0 ? -1 : pre > 0 ? 1 : 0;
+}
+
+function bump(parsed: Parsed, level: string): string {
+  let { major, minor, patch } = parsed;
+  switch (level) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+    case "prerelease": {
+      const pre = parsed.prerelease;
+      if (!pre) return `${major}.${minor}.${patch}-0`;
+      // increment last numeric identifier
+      const parts = pre.split(".");
+      const last = parts[parts.length - 1];
+      if (/^\d+$/.test(last)) {
+        parts[parts.length - 1] = String(parseInt(last, 10) + 1);
+      } else {
+        parts.push("0");
+      }
+      return `${major}.${minor}.${patch}-${parts.join(".")}`;
+    }
+    default:
+      throw new Error(`Unknown level: ${level}`);
+  }
+}
+
+// Range satisfies: supports ^, ~, >=, <=, >, <, =, and plain version
+function satisfies(version: Parsed, range: string): boolean {
+  const trimmed = range.trim();
+
+  // Handle space-separated AND ranges (e.g. ">=1.0.0 <2.0.0")
+  if (/\s+/.test(trimmed) && !trimmed.startsWith("^") && !trimmed.startsWith("~")) {
+    return trimmed.split(/\s+/).every((r) => satisfies(version, r));
+  }
+
+  // Caret range: ^1.2.3
+  if (trimmed.startsWith("^")) {
+    const base = parse(trimmed.slice(1));
+    if (!base) return false;
+    const lower = compare(version, base);
+    if (lower < 0) return false;
+    // Upper bound: next breaking change
+    if (base.major !== 0) {
+      return version.major === base.major;
+    } else if (base.minor !== 0) {
+      return version.major === 0 && version.minor === base.minor;
+    } else {
+      return version.major === 0 && version.minor === 0 && version.patch === base.patch;
+    }
+  }
+
+  // Tilde range: ~1.2.3
+  if (trimmed.startsWith("~")) {
+    const base = parse(trimmed.slice(1));
+    if (!base) return false;
+    if (compare(version, base) < 0) return false;
+    return version.major === base.major && version.minor === base.minor;
+  }
+
+  // Comparison operators
+  const opMatch = /^(>=|<=|>|<|=)(.+)$/.exec(trimmed);
+  if (opMatch) {
+    const op = opMatch[1];
+    const base = parse(opMatch[2].trim());
+    if (!base) return false;
+    const cmp = compare(version, base);
+    switch (op) {
+      case ">=": return cmp >= 0;
+      case "<=": return cmp <= 0;
+      case ">":  return cmp > 0;
+      case "<":  return cmp < 0;
+      case "=":  return cmp === 0;
+    }
+  }
+
+  // Plain version (exact match)
+  const base = parse(trimmed);
+  if (!base) return false;
+  return compare(version, base) === 0;
+}
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { action } = body;
+
+  if (!action || typeof action !== "string") {
+    return NextResponse.json(
+      { error: "action must be one of: parse, compare, bump, satisfies" },
+      { status: 400 }
+    );
+  }
+
+  switch (action) {
+    case "parse": {
+      const { version } = body;
+      if (typeof version !== "string") {
+        return NextResponse.json({ error: "version must be a string." }, { status: 400 });
+      }
+      const parsed = parse(version);
+      if (!parsed) {
+        return NextResponse.json({ error: `Invalid semver: "${version}"` }, { status: 400 });
+      }
+      return NextResponse.json(parsed);
+    }
+
+    case "compare": {
+      const { a, b } = body;
+      if (typeof a !== "string" || typeof b !== "string") {
+        return NextResponse.json({ error: "a and b must be strings." }, { status: 400 });
+      }
+      const pa = parse(a);
+      const pb = parse(b);
+      if (!pa) return NextResponse.json({ error: `Invalid semver: "${a}"` }, { status: 400 });
+      if (!pb) return NextResponse.json({ error: `Invalid semver: "${b}"` }, { status: 400 });
+      return NextResponse.json({ result: compare(pa, pb) });
+    }
+
+    case "bump": {
+      const { version, level } = body;
+      if (typeof version !== "string") {
+        return NextResponse.json({ error: "version must be a string." }, { status: 400 });
+      }
+      if (!["major", "minor", "patch", "prerelease"].includes(level as string)) {
+        return NextResponse.json(
+          { error: "level must be one of: major, minor, patch, prerelease" },
+          { status: 400 }
+        );
+      }
+      const parsed = parse(version);
+      if (!parsed) {
+        return NextResponse.json({ error: `Invalid semver: "${version}"` }, { status: 400 });
+      }
+      return NextResponse.json({ next: bump(parsed, level as string) });
+    }
+
+    case "satisfies": {
+      const { version, range } = body;
+      if (typeof version !== "string") {
+        return NextResponse.json({ error: "version must be a string." }, { status: 400 });
+      }
+      if (typeof range !== "string") {
+        return NextResponse.json({ error: "range must be a string." }, { status: 400 });
+      }
+      const parsed = parse(version);
+      if (!parsed) {
+        return NextResponse.json({ error: `Invalid semver: "${version}"` }, { status: 400 });
+      }
+      return NextResponse.json({ satisfies: satisfies(parsed, range) });
+    }
+
+    default:
+      return NextResponse.json(
+        { error: "action must be one of: parse, compare, bump, satisfies" },
+        { status: 400 }
+      );
+  }
+}


### PR DESCRIPTION
feat(routes-f): add semver and CIDR utility endpoints

- implement semver utility endpoint at app/api/routes-f/semver/route.ts
  - support actions: parse, compare, bump, satisfies
  - parse version into major, minor, patch, prerelease, and build metadata
  - compare versions returning -1, 0, or 1
  - bump versions by major, minor, patch, or prerelease
  - evaluate version ranges (^, ~, >=, etc.) per semver spec
  - ensure compliance with semver.org specification
  - add tests covering all actions, prerelease handling, and range matching

- implement CIDR calculator endpoint at app/api/routes-f/cidr/route.ts
  - accept CIDR input and compute network details
  - return network, broadcast, first/last host, host count, netmask, prefix length, and IP version
  - support both IPv4 and IPv6 CIDR notation
  - handle edge cases (/31, /32) with documented host count behavior
  - validate input and return 400 for invalid CIDR
  - add tests for IPv4, IPv6, and edge cases

- ensure strict scope isolation
  - keep all logic, helpers, types, and tests داخل app/api/routes-f/
  - avoid cross-folder imports to maintain task independence
  
closes #673 
closes #674 