### PR TITLE
feat(routes-f): implement profanity filter, webhook demo, text diff and string similarity endpoints

### DIFF
--- a/app/api/routes-f/profanity/__tests__/route.test.ts
+++ b/app/api/routes-f/profanity/__tests__/route.test.ts
@@ -1,0 +1,15 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+describe("Profanity endpoint", () => {
+    it("handles leetspeak and repeated chars", async () => {
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ text: "This is shhiii11tt and b@d" })
+        });
+        const res = await POST(req);
+        const data = await res.json();
+        expect(data.has_profanity).toBe(true);
+        expect(data.cleaned).toContain("***");
+    });
+});

--- a/app/api/routes-f/profanity/route.ts
+++ b/app/api/routes-f/profanity/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+const WORD_LIST = [
+  "badword", "darn", "heck", "shoot", "crud", "crap", "dang", "freak",
+  "jerk", "idiot", "moron", "stupid", "dumb", "suck", "sucks",
+  "butt", "bum", "turd", "poop", "pee", "piss", "crapola", "shucks",
+  "dagnabbit", "fudge", "gosh", "golly", "jeez", "damn", "bitch", "shit",
+  "fuck", "ass"
+];
+
+function normalize(text: string): string {
+  return text.toLowerCase()
+    .replace(/@/g, 'a')
+    .replace(/0/g, 'o')
+    .replace(/1/g, 'i')
+    .replace(/3/g, 'e')
+    .replace(/4/g, 'a')
+    .replace(/5/g, 's')
+    .replace(/7/g, 't')
+    .replace(/8/g, 'b')
+    .replace(/(.)\1+/g, '$1');
+}
+
+export async function POST(req: Request) {
+  try {
+    const { text } = await req.json();
+    if (typeof text !== "string") {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+    }
+
+    const normalizedText = normalize(text);
+    const matches: string[] = [];
+    let cleaned = text;
+
+    for (const word of WORD_LIST) {
+      if (normalizedText.includes(word)) {
+        matches.push(word);
+        
+        const regexStr = [...word].map(c => {
+            switch(c) {
+                case 'a': return '[a@4]+';
+                case 'o': return '[o0]+';
+                case 'i': return '[i1]+';
+                case 'e': return '[e3]+';
+                case 's': return '[s5]+';
+                case 't': return '[t7]+';
+                case 'b': return '[b8]+';
+                default: return `${c}+`;
+            }
+        }).join('');
+        
+        const regex = new RegExp(regexStr, 'gi');
+        cleaned = cleaned.replace(regex, '***');
+      }
+    }
+
+    return NextResponse.json({
+      has_profanity: matches.length > 0,
+      matches,
+      cleaned
+    });
+  } catch (e) {
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/routes-f/similarity/__tests__/route.test.ts
+++ b/app/api/routes-f/similarity/__tests__/route.test.ts
@@ -1,0 +1,17 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+describe("Similarity endpoint", () => {
+    it("computes all algorithms", async () => {
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ a: "martha", b: "marhta" })
+        });
+        const res = await POST(req);
+        const data = await res.json();
+        expect(data.results.levenshtein.score).toBeGreaterThan(0);
+        expect(data.results.jaro.score).toBeGreaterThan(0);
+        expect(data.results.jaro_winkler.score).toBeGreaterThan(0);
+        expect(data.results.dice.score).toBeGreaterThan(0);
+    });
+});

--- a/app/api/routes-f/similarity/route.ts
+++ b/app/api/routes-f/similarity/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+
+function levenshtein(a: string, b: string) {
+    const matrix = [];
+    for (let i = 0; i <= b.length; i++) {
+        matrix[i] = [i];
+    }
+    for (let j = 0; j <= a.length; j++) {
+        matrix[0][j] = j;
+    }
+    for (let i = 1; i <= b.length; i++) {
+        for (let j = 1; j <= a.length; j++) {
+            if (b.charAt(i - 1) === a.charAt(j - 1)) {
+                matrix[i][j] = matrix[i - 1][j - 1];
+            } else {
+                matrix[i][j] = Math.min(matrix[i - 1][j - 1] + 1, Math.min(matrix[i][j - 1] + 1, matrix[i - 1][j] + 1));
+            }
+        }
+    }
+    return matrix[b.length][a.length];
+}
+
+function jaro(s1: string, s2: string) {
+    if (s1 === s2) return 1;
+    const len1 = s1.length, len2 = s2.length;
+    if (len1 === 0 || len2 === 0) return 0;
+    const matchDistance = Math.floor(Math.max(len1, len2) / 2) - 1;
+    const s1Matches = new Array(len1).fill(false);
+    const s2Matches = new Array(len2).fill(false);
+    let matches = 0, transpositions = 0;
+
+    for (let i = 0; i < len1; i++) {
+        const start = Math.max(0, i - matchDistance);
+        const end = Math.min(i + matchDistance + 1, len2);
+        for (let j = start; j < end; j++) {
+            if (s2Matches[j]) continue;
+            if (s1[i] !== s2[j]) continue;
+            s1Matches[i] = true;
+            s2Matches[j] = true;
+            matches++;
+            break;
+        }
+    }
+    if (matches === 0) return 0;
+    let k = 0;
+    for (let i = 0; i < len1; i++) {
+        if (!s1Matches[i]) continue;
+        while (!s2Matches[k] && k < len2) k++;
+        if (k < len2 && s1[i] !== s2[k]) transpositions++;
+        k++;
+    }
+    return ((matches / len1) + (matches / len2) + ((matches - transpositions / 2) / matches)) / 3;
+}
+
+function jaroWinkler(s1: string, s2: string) {
+    let j = jaro(s1, s2);
+    let prefix = 0;
+    for (let i = 0; i < Math.min(4, s1.length, s2.length); i++) {
+        if (s1[i] === s2[i]) prefix++;
+        else break;
+    }
+    return j + prefix * 0.1 * (1 - j);
+}
+
+function dice(s1: string, s2: string) {
+    if (s1 === s2) return 1;
+    if (s1.length < 2 || s2.length < 2) return 0;
+    const bigrams = (s: string) => {
+        const res = new Set<string>();
+        for (let i = 0; i < s.length - 1; i++) {
+            res.add(s.slice(i, i + 2));
+        }
+        return res;
+    };
+    const b1 = bigrams(s1);
+    const b2 = bigrams(s2);
+    let intersection = 0;
+    for (const bg of b1) {
+        if (b2.has(bg)) intersection++;
+    }
+    return (2 * intersection) / (b1.size + b2.size);
+}
+
+export async function POST(req: Request) {
+    const { a, b, algorithms = ["levenshtein", "jaro", "jaro_winkler", "dice"] } = await req.json();
+    if (a.length > 10000 || b.length > 10000) {
+        return NextResponse.json({ error: "String too large" }, { status: 413 });
+    }
+
+    const results: any = {};
+    if (algorithms.includes("levenshtein")) {
+        const dist = levenshtein(a, b);
+        results.levenshtein = { distance: dist, score: 1 - dist / Math.max(a.length, b.length) };
+    }
+    if (algorithms.includes("jaro")) {
+        results.jaro = { score: jaro(a, b) };
+    }
+    if (algorithms.includes("jaro_winkler")) {
+        results.jaro_winkler = { score: jaroWinkler(a, b) };
+    }
+    if (algorithms.includes("dice")) {
+        results.dice = { score: dice(a, b) };
+    }
+
+    return NextResponse.json({ results });
+}

--- a/app/api/routes-f/text-diff/__tests__/route.test.ts
+++ b/app/api/routes-f/text-diff/__tests__/route.test.ts
@@ -1,0 +1,16 @@
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+describe("Text diff endpoint", () => {
+    it("diffs lines", async () => {
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ a: "a\nb", b: "a\nc", mode: "line" })
+        });
+        const res = await POST(req);
+        const data = await res.json();
+        expect(data.stats.added).toBe(1);
+        expect(data.stats.removed).toBe(1);
+        expect(data.stats.unchanged).toBe(1);
+    });
+});

--- a/app/api/routes-f/text-diff/route.ts
+++ b/app/api/routes-f/text-diff/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    const { a, b, mode = "line" } = await req.json();
+
+    if (a.length > 100000 || b.length > 100000) {
+        return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    let aTokens = mode === "word" ? a.split(/\b/) : a.split('\n');
+    let bTokens = mode === "word" ? b.split(/\b/) : b.split('\n');
+
+    // Prevent OOM for very large inputs
+    if (aTokens.length > 2000) aTokens = aTokens.slice(0, 2000);
+    if (bTokens.length > 2000) bTokens = bTokens.slice(0, 2000);
+
+    const dp = Array(aTokens.length + 1).fill(null).map(() => Array(bTokens.length + 1).fill(0));
+    for (let i = 1; i <= aTokens.length; i++) {
+        for (let j = 1; j <= bTokens.length; j++) {
+            if (aTokens[i-1] === bTokens[j-1]) {
+                dp[i][j] = dp[i-1][j-1] + 1;
+            } else {
+                dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]);
+            }
+        }
+    }
+    
+    const changes: { type: "add"|"remove"|"unchanged", value: string }[] = [];
+    let i = aTokens.length, j = bTokens.length;
+    let added = 0, removed = 0, unchanged = 0;
+    
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && aTokens[i-1] === bTokens[j-1]) {
+            changes.unshift({ type: "unchanged", value: aTokens[i-1] });
+            unchanged++;
+            i--; j--;
+        } else if (j > 0 && (i === 0 || dp[i][j-1] >= dp[i-1][j])) {
+            changes.unshift({ type: "add", value: bTokens[j-1] });
+            added++;
+            j--;
+        } else if (i > 0 && (j === 0 || dp[i][j-1] < dp[i-1][j])) {
+            changes.unshift({ type: "remove", value: aTokens[i-1] });
+            removed++;
+            i--;
+        }
+    }
+
+    return NextResponse.json({ changes, stats: { added, removed, unchanged } });
+}

--- a/app/api/routes-f/webhook-demo/__tests__/route.test.ts
+++ b/app/api/routes-f/webhook-demo/__tests__/route.test.ts
@@ -1,0 +1,38 @@
+import { POST, GET } from "../route";
+import { NextRequest } from "next/server";
+import crypto from "crypto";
+
+describe("Webhook endpoint", () => {
+    it("valid signature", async () => {
+        const body = JSON.stringify({ test: 1 });
+        const sig = crypto.createHmac("sha256", "dev-secret-key-123").update(body).digest("hex");
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body,
+            headers: { "X-Signature": "sha256=" + sig }
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+    });
+
+    it("invalid signature", async () => {
+        const body = JSON.stringify({ test: 1 });
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body,
+            headers: { "X-Signature": "sha256=invalid" }
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(401);
+    });
+    
+    it("missing signature", async () => {
+        const body = JSON.stringify({ test: 1 });
+        const req = new NextRequest("http://localhost", {
+            method: "POST",
+            body
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(401);
+    });
+});

--- a/app/api/routes-f/webhook-demo/route.ts
+++ b/app/api/routes-f/webhook-demo/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+
+const SECRET = "dev-secret-key-123";
+const buffer: any[] = [];
+
+export async function GET() {
+    return NextResponse.json({ payloads: buffer.slice(-100) });
+}
+
+export async function POST(req: Request) {
+    const signature = req.headers.get("X-Signature");
+    if (!signature || !signature.startsWith("sha256=")) {
+        return NextResponse.json({ error: "Missing or invalid signature header" }, { status: 401 });
+    }
+
+    const rawBody = await req.text();
+    const expectedSig = crypto.createHmac("sha256", SECRET).update(rawBody).digest("hex");
+    const providedSig = signature.slice(7);
+
+    try {
+        const expectedBuffer = Buffer.from(expectedSig);
+        const providedBuffer = Buffer.from(providedSig);
+
+        if (expectedBuffer.length !== providedBuffer.length || !crypto.timingSafeEqual(expectedBuffer, providedBuffer)) {
+            return NextResponse.json({ error: "Signature mismatch" }, { status: 401 });
+        }
+    } catch(e) {
+        return NextResponse.json({ error: "Signature mismatch" }, { status: 401 });
+    }
+
+    let parsed = {};
+    try {
+        parsed = JSON.parse(rawBody);
+    } catch(e) {
+        parsed = { rawBody };
+    }
+
+    buffer.push(parsed);
+    if (buffer.length > 100) {
+        buffer.shift();
+    }
+
+    return NextResponse.json({ success: true });
+}


### PR DESCRIPTION


This PR introduces four new utility endpoints under the `app/api/routes-f/` directory. Each endpoint has been built as an isolated, standalone service with no external dependencies and includes its own unit tests. 
**Profanity Filter Endpoint**
Added a `/profanity` endpoint that validates text against a bundled, PG-rated wordlist. It handles common obfuscation techniques like leetspeak substitutions (e.g., `a -> @`, `o -> 0`) and repeated characters (e.g., `baaaad`). Matched words are returned alongside a cleaned version of the string where profanities are masked with `***`.
Closes #567
**Webhook Receiver Demo**
Added a `/webhook-demo` endpoint to act as a receiver for testing webhook producers. It mandates an `X-Signature` header (HMAC-SHA256) and verifies it using constant-time comparison to prevent timing attacks. Successfully validated payloads are logged to an in-memory ring buffer, which can be retrieved via a GET request.
Closes #569
**Text Diff Endpoint**
Added a `/text-diff` endpoint that computes structural differences between two strings. It implements a dynamic programming LCS (Longest Common Subsequence) algorithm inline to calculate additions, removals, and unchanged tokens. It supports both `line` (default) and `word` level diffing modes, and includes safety caps to prevent OOM errors on massive payloads.
Closes #584
**String Similarity Endpoint**
Added a `/similarity` endpoint capable of scoring string likeness from 0 to 1. It features inline implementations of four distinct algorithms: Levenshtein distance, Jaro distance, Jaro-Winkler distance, and the Dice coefficient. Users can specify which algorithms to run or receive scores for all four simultaneously.
Closes #585