### PR TITLE
feat(routes-f): add palette and distance endpoints

### DIFF
--- a/app/api/routes-f/distance/__tests__/route.test.ts
+++ b/app/api/routes-f/distance/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/distance", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/distance", () => {
+  it("calculates known city-pair distance (NYC to LA)", async () => {
+    const res = await POST(
+      makeReq({
+        from: [40.7128, -74.006],
+        to: [34.0522, -118.2437],
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.total_km).toBeCloseTo(3935.746, 0);
+    expect(body.total_mi).toBeCloseTo(2445.559, 0);
+    expect(body.segments).toHaveLength(1);
+  });
+
+  it("sums segments when waypoints are provided", async () => {
+    const res = await POST(
+      makeReq({
+        from: [0, 0],
+        waypoints: [[0, 1], [1, 1]],
+        to: [1, 2],
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.segments).toHaveLength(3);
+    expect(body.total_km).toBeCloseTo(333.568, 0);
+  });
+
+  it("rejects out-of-range coordinates", async () => {
+    const res = await POST(
+      makeReq({
+        from: [91, 0],
+        to: [10, 10],
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/distance/_lib/haversine.ts
+++ b/app/api/routes-f/distance/_lib/haversine.ts
@@ -1,0 +1,36 @@
+export type Point = [number, number];
+
+const EARTH_RADIUS_KM = 6371;
+const KM_TO_MI = 0.621371;
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+export function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+export function isValidPoint(point: unknown): point is Point {
+  if (!Array.isArray(point) || point.length !== 2) return false;
+  const [lat, lng] = point;
+  if (typeof lat !== "number" || typeof lng !== "number") return false;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return false;
+  return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+}
+
+export function haversineKm(from: Point, to: Point): number {
+  const [lat1, lng1] = from;
+  const [lat2, lng2] = to;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+export function kmToMi(km: number): number {
+  return km * KM_TO_MI;
+}

--- a/app/api/routes-f/distance/route.ts
+++ b/app/api/routes-f/distance/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { haversineKm, isValidPoint, kmToMi, Point, round3 } from "./_lib/haversine";
+
+const MAX_WAYPOINTS = 100;
+
+type DistanceBody = {
+  from?: unknown;
+  to?: unknown;
+  waypoints?: unknown;
+};
+
+export async function POST(req: NextRequest) {
+  let body: DistanceBody;
+  try {
+    body = (await req.json()) as DistanceBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!isValidPoint(body.from) || !isValidPoint(body.to)) {
+    return NextResponse.json(
+      { error: "from and to must be valid [lat, lng] points in range" },
+      { status: 400 },
+    );
+  }
+
+  let waypoints: Point[] = [];
+  if (body.waypoints !== undefined) {
+    if (!Array.isArray(body.waypoints)) {
+      return NextResponse.json({ error: "waypoints must be an array" }, { status: 400 });
+    }
+    if (body.waypoints.length > MAX_WAYPOINTS) {
+      return NextResponse.json(
+        { error: `waypoints must contain at most ${MAX_WAYPOINTS} points` },
+        { status: 400 },
+      );
+    }
+    if (!body.waypoints.every(isValidPoint)) {
+      return NextResponse.json(
+        { error: "each waypoint must be a valid [lat, lng] point in range" },
+        { status: 400 },
+      );
+    }
+    waypoints = body.waypoints;
+  }
+
+  const points: Point[] = [body.from, ...waypoints, body.to];
+  const segments = [];
+  let totalKm = 0;
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const from = points[i];
+    const to = points[i + 1];
+    const km = haversineKm(from, to);
+    const mi = kmToMi(km);
+    totalKm += km;
+    segments.push({
+      from,
+      to,
+      km: round3(km),
+      mi: round3(mi),
+    });
+  }
+
+  return NextResponse.json({
+    total_km: round3(totalKm),
+    total_mi: round3(kmToMi(totalKm)),
+    segments,
+  });
+}

--- a/app/api/routes-f/palette/__tests__/route.test.ts
+++ b/app/api/routes-f/palette/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+function makeReq(query: string) {
+  return new NextRequest(`http://localhost/api/routes-f/palette${query}`);
+}
+
+describe("GET /api/routes-f/palette", () => {
+  it("generates a triadic palette from a known seed", async () => {
+    const res = await GET(makeReq("?seed=%23ff6600&scheme=triadic&count=5"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.palette).toEqual(["#ff6600", "#00ff66", "#6600ff", "#ff6600", "#00ff66"]);
+  });
+
+  it("generates a known complementary palette", async () => {
+    const res = await GET(makeReq("?seed=%23ff6600&scheme=complementary&count=4"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.palette).toEqual(["#ff6600", "#0099ff", "#ff6600", "#0099ff"]);
+  });
+
+  it("rejects invalid seed", async () => {
+    const res = await GET(makeReq("?seed=red&scheme=triadic"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid count", async () => {
+    const res = await GET(makeReq("?seed=%23ff6600&count=99"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/palette/_lib/colors.ts
+++ b/app/api/routes-f/palette/_lib/colors.ts
@@ -1,0 +1,123 @@
+export type PaletteScheme =
+  | "complementary"
+  | "analogous"
+  | "triadic"
+  | "monochrome";
+
+type Hsl = {
+  h: number;
+  s: number;
+  l: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeHue(hue: number): number {
+  const mod = hue % 360;
+  return mod < 0 ? mod + 360 : mod;
+}
+
+export function isHexColor(value: string): boolean {
+  return /^#[\da-fA-F]{6}$/.test(value);
+}
+
+export function hexToRgb(hex: string): [number, number, number] {
+  return [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export function rgbToHsl(r: number, g: number, b: number): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) h = ((gn - bn) / delta) % 6;
+    else if (max === gn) h = (bn - rn) / delta + 2;
+    else h = (rn - gn) / delta + 4;
+    h *= 60;
+  }
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  return { h: normalizeHue(h), s, l };
+}
+
+export function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = normalizeHue(h) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+
+  if (hp >= 0 && hp < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hp < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hp < 3) [r1, g1, b1] = [0, c, x];
+  else if (hp < 4) [r1, g1, b1] = [0, x, c];
+  else if (hp < 5) [r1, g1, b1] = [x, 0, c];
+  else [r1, g1, b1] = [c, 0, x];
+
+  const m = l - c / 2;
+  return [
+    Math.round((r1 + m) * 255),
+    Math.round((g1 + m) * 255),
+    Math.round((b1 + m) * 255),
+  ];
+}
+
+function rotateHue(base: Hsl, delta: number): string {
+  const [r, g, b] = hslToRgb(base.h + delta, base.s, base.l);
+  return rgbToHex(r, g, b);
+}
+
+function monochrome(base: Hsl, count: number): string[] {
+  if (count === 1) {
+    const [r, g, b] = hslToRgb(base.h, base.s, base.l);
+    return [rgbToHex(r, g, b)];
+  }
+  const start = clamp(base.l - 0.3, 0.05, 0.95);
+  const end = clamp(base.l + 0.3, 0.05, 0.95);
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const t = i / (count - 1);
+    const l = start + (end - start) * t;
+    const [r, g, b] = hslToRgb(base.h, base.s, l);
+    out.push(rgbToHex(r, g, b));
+  }
+  return out;
+}
+
+export function generatePalette(seed: string, scheme: PaletteScheme, count: number): string[] {
+  const [r, g, b] = hexToRgb(seed);
+  const base = rgbToHsl(r, g, b);
+
+  if (scheme === "monochrome") return monochrome(base, count);
+
+  const deltas =
+    scheme === "complementary"
+      ? [0, 180]
+      : scheme === "analogous"
+        ? [-30, 0, 30]
+        : [0, 120, 240];
+
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push(rotateHue(base, deltas[i % deltas.length]));
+  }
+  return out;
+}

--- a/app/api/routes-f/palette/route.ts
+++ b/app/api/routes-f/palette/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generatePalette, isHexColor, PaletteScheme } from "./_lib/colors";
+
+const DEFAULT_COUNT = 5;
+const MAX_COUNT = 12;
+const SCHEMES: PaletteScheme[] = [
+  "complementary",
+  "analogous",
+  "triadic",
+  "monochrome",
+];
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const seed = searchParams.get("seed");
+  const schemeRaw = searchParams.get("scheme") ?? "complementary";
+  const countRaw = searchParams.get("count");
+
+  if (!seed || !isHexColor(seed)) {
+    return NextResponse.json(
+      { error: "seed must be a valid 6-digit hex color like #ff6600" },
+      { status: 400 },
+    );
+  }
+
+  if (!SCHEMES.includes(schemeRaw as PaletteScheme)) {
+    return NextResponse.json(
+      { error: "scheme must be one of: complementary, analogous, triadic, monochrome" },
+      { status: 400 },
+    );
+  }
+
+  const count = countRaw === null ? DEFAULT_COUNT : Number.parseInt(countRaw, 10);
+  if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+    return NextResponse.json(
+      { error: `count must be an integer between 1 and ${MAX_COUNT}` },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({
+    palette: generatePalette(seed.toLowerCase(), schemeRaw as PaletteScheme, count),
+  });
+}


### PR DESCRIPTION
Closes #565
Closes #586
Closes #586

## Changes
- Added GET /api/routes-f/palette with complementary, analogous, triadic, and monochrome palette generation.
- Added POST /api/routes-f/distance with Haversine distance calculation, waypoint support, and coordinate validation.
- Added unit tests for both endpoints under pp/api/routes-f/.
