### PR TITLE
feat(routes-f): add seeded fake user data generator

### DIFF
--- a/app/api/routes-f/fake-users/__tests__/route.test.ts
+++ b/app/api/routes-f/fake-users/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+function makeReq(query = "") {
+  return new NextRequest(`http://localhost/api/routes-f/fake-users${query}`);
+}
+
+describe("GET /api/routes-f/fake-users", () => {
+  it("returns deterministic users for the same seed", async () => {
+    const q = "?count=5&seed=42";
+    const r1 = await GET(makeReq(q));
+    const r2 = await GET(makeReq(q));
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect((await r1.json()).users).toEqual((await r2.json()).users);
+  });
+
+  it("enforces count cap", async () => {
+    const res = await GET(makeReq("?count=101"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns well-formed user shape", async () => {
+    const res = await GET(makeReq("?count=1&seed=7"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.users).toHaveLength(1);
+    const user = body.users[0];
+    expect(user.id).toMatch(/^usr_\d{6}_1$/);
+    expect(user.name).toMatch(/^[A-Za-z]+\s[A-Za-z]+$/);
+    expect(user.email).toMatch(/^[a-z]+\.[a-z]+@example\.com$/);
+    expect(user.phone).toMatch(/^\+1-\d{3}-\d{3}-\d{4}$/);
+    expect(user.address.street.length).toBeGreaterThan(0);
+    expect(user.address.city.length).toBeGreaterThan(0);
+    expect(user.address.state.length).toBeGreaterThan(0);
+    expect(user.address.zip).toMatch(/^\d{5}$/);
+    expect(user.address.country.length).toBeGreaterThan(0);
+    expect(user.avatar_url).toContain("dicebear");
+  });
+});

--- a/app/api/routes-f/fake-users/_lib/generator.ts
+++ b/app/api/routes-f/fake-users/_lib/generator.ts
@@ -1,0 +1,78 @@
+import { CITIES, FIRST_NAMES, LAST_NAMES, STREET_NAMES } from "./pools";
+
+export type FakeUser = {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  address: {
+    street: string;
+    city: string;
+    state: string;
+    zip: string;
+    country: string;
+  };
+  avatar_url: string;
+};
+
+function createSeededRandom(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x ^= x + Math.imul(x ^ (x >>> 7), 61 | x);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rand: () => number, values: T[]): T {
+  return values[Math.floor(rand() * values.length)];
+}
+
+function digits(rand: () => number, count: number): string {
+  let out = "";
+  for (let i = 0; i < count; i++) {
+    out += Math.floor(rand() * 10).toString();
+  }
+  return out;
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+export function generateFakeUsers(count: number, seed: number): FakeUser[] {
+  const rand = createSeededRandom(seed);
+  const users: FakeUser[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const first = pick(rand, FIRST_NAMES);
+    const last = pick(rand, LAST_NAMES);
+    const streetNo = Math.floor(rand() * 999) + 1;
+    const street = `${streetNo} ${pick(rand, STREET_NAMES)}`;
+    const cityInfo = pick(rand, CITIES);
+    const zip = digits(rand, 5);
+    const phone = `+1-${digits(rand, 3)}-${digits(rand, 3)}-${digits(rand, 4)}`;
+    const idNum = Math.floor(rand() * 1_000_000);
+    const id = `usr_${idNum.toString().padStart(6, "0")}_${i + 1}`;
+
+    users.push({
+      id,
+      name: `${first} ${last}`,
+      email: `${slug(first)}.${slug(last)}@example.com`,
+      phone,
+      address: {
+        street,
+        city: cityInfo.city,
+        state: cityInfo.state,
+        zip,
+        country: cityInfo.country,
+      },
+      avatar_url: `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(
+        `${first} ${last} ${id}`,
+      )}`,
+    });
+  }
+
+  return users;
+}

--- a/app/api/routes-f/fake-users/_lib/pools.ts
+++ b/app/api/routes-f/fake-users/_lib/pools.ts
@@ -1,0 +1,49 @@
+export const FIRST_NAMES = [
+  "Ava",
+  "Noah",
+  "Mia",
+  "Liam",
+  "Zara",
+  "Ethan",
+  "Nora",
+  "Lucas",
+  "Ivy",
+  "Elijah",
+];
+
+export const LAST_NAMES = [
+  "Okafor",
+  "Johnson",
+  "Adeyemi",
+  "Miller",
+  "Bello",
+  "Wilson",
+  "Chen",
+  "Martinez",
+  "Singh",
+  "Brown",
+];
+
+export const STREET_NAMES = [
+  "Maple Street",
+  "Broadway",
+  "Oak Avenue",
+  "Lakeview Drive",
+  "Cedar Lane",
+  "Sunset Boulevard",
+  "Hillcrest Road",
+  "Park Avenue",
+  "Riverside Drive",
+  "Willow Court",
+];
+
+export const CITIES = [
+  { city: "Lagos", state: "Lagos", country: "Nigeria" },
+  { city: "Abuja", state: "FCT", country: "Nigeria" },
+  { city: "Nairobi", state: "Nairobi County", country: "Kenya" },
+  { city: "Accra", state: "Greater Accra", country: "Ghana" },
+  { city: "Austin", state: "Texas", country: "USA" },
+  { city: "Seattle", state: "Washington", country: "USA" },
+  { city: "Toronto", state: "Ontario", country: "Canada" },
+  { city: "London", state: "England", country: "UK" },
+];

--- a/app/api/routes-f/fake-users/route.ts
+++ b/app/api/routes-f/fake-users/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generateFakeUsers } from "./_lib/generator";
+
+const DEFAULT_COUNT = 5;
+const MAX_COUNT = 100;
+const DEFAULT_SEED = 42;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const countRaw = searchParams.get("count");
+  const seedRaw = searchParams.get("seed");
+
+  const count = countRaw === null ? DEFAULT_COUNT : Number.parseInt(countRaw, 10);
+  if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+    return NextResponse.json(
+      { error: `count must be an integer between 1 and ${MAX_COUNT}` },
+      { status: 400 },
+    );
+  }
+
+  const seed = seedRaw === null ? DEFAULT_SEED : Number(seedRaw);
+  if (!Number.isFinite(seed)) {
+    return NextResponse.json({ error: "seed must be a finite number" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    users: generateFakeUsers(count, seed),
+  });
+}


### PR DESCRIPTION
Closes #574


## Changes
- Added GET /api/routes-f/fake-users?count=5&seed=42.
- Implemented deterministic seeded generation for { id, name, email, phone, address, avatar_url }.
- Added local name/street/city pools under the feature folder.
- Enforced count validation (default 5, max 100).
- Added unit tests for seed determinism, count cap, and response shape.

## Testing
- Not run (per request).