### PR TITLE
feat: add routes-f utilities and subscription gating

### DIFF
--- a/app/[username]/watch/page.tsx
+++ b/app/[username]/watch/page.tsx
@@ -6,6 +6,7 @@ import ViewStream from "@/components/stream/view-stream";
 import { ViewStreamSkeleton } from "@/components/skeletons/ViewStreamSkeleton";
 import AccessGate from "@/components/stream/AccessGate";
 import { toast } from "sonner";
+import { useStellarWallet } from "@/contexts/stellar-wallet-context";
 
 interface PageProps {
   params: Promise<{ username: string }>;
@@ -25,11 +26,15 @@ interface UserData {
   is_following: boolean;
   stellar_address: string | null;
   is_password_protected: boolean;
+  stream_access_type: "public" | "password" | "subscription" | null;
+  subscription_price_usdc: number | null;
   latency_mode: string | null;
 }
 
 const WatchPage = ({ params }: PageProps) => {
   const { username } = use(params);
+  const { publicKey, privyWallet } = useStellarWallet();
+  const viewerPublicKey = publicKey || privyWallet?.wallet || null;
   const [userData, setUserData] = useState<UserData | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound404, setNotFound404] = useState(false);
@@ -213,14 +218,24 @@ const WatchPage = ({ params }: PageProps) => {
 
   // Show access gate if stream is password protected and viewer isn't the owner
   const needsPassword =
-    userData.is_password_protected && !isOwner && !accessGranted;
+    userData.is_password_protected &&
+    userData.stream_access_type !== "subscription" &&
+    !isOwner &&
+    !accessGranted;
+  const needsSubscription =
+    userData.stream_access_type === "subscription" &&
+    !isOwner &&
+    !accessGranted;
 
-  if (needsPassword && userData.mux_playback_id) {
+  if ((needsPassword || needsSubscription) && userData.mux_playback_id) {
     return (
       <AccessGate
         playbackId={userData.mux_playback_id}
         username={username}
         onAccessGranted={handleAccessGranted}
+        accessType={needsSubscription ? "subscription" : "password"}
+        monthlyPrice={userData.subscription_price_usdc}
+        viewerPublicKey={viewerPublicKey}
       />
     );
   }

--- a/app/api/routes-f/domain-validate/_lib/validate.ts
+++ b/app/api/routes-f/domain-validate/_lib/validate.ts
@@ -1,4 +1,4 @@
-import { toASCII } from "punycode/";
+import { toASCII } from "node:punycode";
 import { KNOWN_TLDS } from "./tlds";
 
 export type DomainParts = {
@@ -37,7 +37,12 @@ export function validateDomain(input: string): DomainValidationResult {
     return invalid("");
   }
 
-  if (!ascii || ascii.length > 253 || IP_V4_RE.test(ascii) || ascii.includes(":")) {
+  if (
+    !ascii ||
+    ascii.length > 253 ||
+    IP_V4_RE.test(ascii) ||
+    ascii.includes(":")
+  ) {
     return invalid(ascii);
   }
 
@@ -57,7 +62,8 @@ export function validateDomain(input: string): DomainValidationResult {
 
   const tld = labels[labels.length - 1];
   const sld = labels[labels.length - 2];
-  const subdomain = labels.length > 2 ? labels.slice(0, -2).join(".") : undefined;
+  const subdomain =
+    labels.length > 2 ? labels.slice(0, -2).join(".") : undefined;
   const isIdn = /[^\x00-\x7f]/.test(trimmed) || ascii.includes("xn--");
   const isKnown = KNOWN_TLDS.has(tld);
 

--- a/app/api/routes-f/mac-validate/__tests__/route.test.ts
+++ b/app/api/routes-f/mac-validate/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/mac-validate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/mac-validate", () => {
+  it.each([
+    ["00:11:22:33:44:55", "colon", "00:11:22:33:44:55"],
+    ["00-11-22-33-44-55", "dash", "00-11-22-33-44-55"],
+    ["0011.2233.4455", "dot", "0011.2233.4455"],
+    ["001122334455", "none", "001122334455"],
+  ])("accepts %s and formats as %s", async (mac, format, normalized) => {
+    const res = await POST(makeReq({ mac, format }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.valid).toBe(true);
+    expect(body.normalized).toBe(normalized);
+  });
+
+  it("detects unicast and globally administered addresses", async () => {
+    const res = await POST(makeReq({ mac: "00:11:22:33:44:55" }));
+    const body = await res.json();
+
+    expect(body.is_unicast).toBe(true);
+    expect(body.is_multicast).toBe(false);
+    expect(body.is_locally_administered).toBe(false);
+    expect(body.oui).toBe("Cimsys");
+  });
+
+  it("detects multicast addresses", async () => {
+    const res = await POST(makeReq({ mac: "01:00:5E:00:00:FB" }));
+    const body = await res.json();
+
+    expect(body.is_unicast).toBe(false);
+    expect(body.is_multicast).toBe(true);
+  });
+
+  it("detects locally administered addresses", async () => {
+    const res = await POST(makeReq({ mac: "02:00:00:00:00:01" }));
+    const body = await res.json();
+
+    expect(body.is_locally_administered).toBe(true);
+  });
+
+  it("rejects malformed MAC addresses", async () => {
+    const res = await POST(makeReq({ mac: "00:11:22:33:44" }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/mac-validate/route.ts
+++ b/app/api/routes-f/mac-validate/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type MacFormat = "colon" | "dash" | "dot" | "none";
+
+const OUI_LOOKUP: Record<string, string> = {
+  "00000C": "Cisco Systems",
+  "00005E": "IANA",
+  "0000A2": "Bay Networks",
+  "0001C0": "CompuLab",
+  "0002B3": "Intel",
+  "000347": "Intel",
+  "000393": "Apple",
+  "00044B": "NVIDIA",
+  "000569": "VMware",
+  "0007E9": "Intel",
+  "000A27": "Apple",
+  "000C29": "VMware",
+  "000D3A": "Microsoft",
+  "000E7F": "Hewlett Packard",
+  "001122": "Cimsys",
+  "001320": "Intel",
+  "001451": "Apple",
+  "00155D": "Microsoft",
+  "00163E": "Xensource",
+  "0016CB": "Apple",
+  "0017F2": "Apple",
+  "0019E3": "Apple",
+  "001A11": "Google",
+  "001B63": "Apple",
+  "001C42": "Parallels",
+  "001D25": "Samsung Electronics",
+  "001E52": "Apple",
+  "001F5B": "Apple",
+  "0021E9": "Apple",
+  "00224D": "Mitac International",
+  "0023AE": "Dell",
+  "0024E8": "Dell",
+  "002500": "Apple",
+  "002590": "Super Micro Computer",
+  "0026BB": "Apple",
+  "002713": "Cisco Systems",
+  "00270E": "Intel",
+  "002A10": "Cisco Systems",
+  "005056": "VMware",
+  "0050F2": "Microsoft",
+  "0060DD": "Myricom",
+  "00805F": "Hewlett Packard",
+  "0080C8": "D-Link",
+  "00A0C9": "Intel",
+  "00B0D0": "Dell",
+  "00C04F": "Dell",
+  "00D0B7": "Intel",
+  "00E04C": "Realtek Semiconductor",
+  "00F81C": "Apple",
+  "04D3B0": "Apple",
+  "080020": "Oracle",
+  "0C5415": "Intel",
+  "1002B5": "Intel",
+  "18AF61": "Apple",
+  "1C1B0D": "Giga-byte Technology",
+  "28CFDA": "Apple",
+  "3C5A37": "Samsung Electronics",
+  "44D884": "Apple",
+  "5C514F": "Intel",
+  "60F81D": "Apple",
+  "6C4008": "Apple",
+  "7C0507": "Apple",
+  "8C8590": "Apple",
+  A4C361: "Apple",
+  B827EB: "Raspberry Pi Foundation",
+  BC305B: "Dell",
+  D850E6: "ASUSTek Computer",
+  F0D5BF: "Intel",
+};
+
+function parseMac(mac: unknown): string | null {
+  if (typeof mac !== "string") {
+    return null;
+  }
+
+  const trimmed = mac.trim();
+  const compact = trimmed.replace(/[:-]/g, "").replace(/\./g, "");
+
+  const valid =
+    /^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(trimmed) ||
+    /^([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$/.test(trimmed) ||
+    /^[0-9a-fA-F]{4}(\.[0-9a-fA-F]{4}){2}$/.test(trimmed) ||
+    /^[0-9a-fA-F]{12}$/.test(trimmed);
+
+  if (!valid || compact.length !== 12) {
+    return null;
+  }
+
+  return compact.toUpperCase();
+}
+
+function formatMac(compact: string, format: MacFormat) {
+  const pairs = compact.match(/.{2}/g) ?? [];
+
+  if (format === "dash") {
+    return pairs.join("-");
+  }
+  if (format === "dot") {
+    return compact.match(/.{4}/g)?.join(".") ?? compact;
+  }
+  if (format === "none") {
+    return compact;
+  }
+  return pairs.join(":");
+}
+
+export async function POST(req: NextRequest) {
+  let body: { mac?: unknown; format?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const format = (body.format ?? "colon") as MacFormat;
+  if (!["colon", "dash", "dot", "none"].includes(format)) {
+    return NextResponse.json(
+      { error: "format must be colon, dash, dot, or none" },
+      { status: 400 }
+    );
+  }
+
+  const compact = parseMac(body.mac);
+  if (!compact) {
+    return NextResponse.json(
+      { error: "Malformed MAC address" },
+      { status: 400 }
+    );
+  }
+
+  const firstOctet = Number.parseInt(compact.slice(0, 2), 16);
+  const isMulticast = (firstOctet & 1) === 1;
+  const isLocallyAdministered = (firstOctet & 2) === 2;
+  const oui = OUI_LOOKUP[compact.slice(0, 6)];
+
+  return NextResponse.json({
+    valid: true,
+    normalized: formatMac(compact, format),
+    is_unicast: !isMulticast,
+    is_multicast: isMulticast,
+    is_locally_administered: isLocallyAdministered,
+    ...(oui ? { oui } : {}),
+  });
+}

--- a/app/api/routes-f/shorten/[code]/route.ts
+++ b/app/api/routes-f/shorten/[code]/route.ts
@@ -1,49 +1,46 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { isValidCode } from '../_lib/code-generator';
-import { UrlStorage } from '../_lib/storage';
-import type { LookupResponse } from '../_lib/types';
+import { NextRequest, NextResponse } from "next/server";
+import { isValidCode } from "../_lib/code-generator";
+import { UrlStorage } from "../_lib/storage";
+import type { LookupResponse } from "../_lib/types";
 
-export const runtime = 'nodejs';
-export const dynamic = 'force-dynamic';
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { code: string } }
+  { params }: { params: Promise<{ code: string }> }
 ): Promise<NextResponse<LookupResponse | { message: string }>> {
   try {
-    const { code } = params;
-    
+    const { code } = await params;
+
     // Validate code format
     if (!isValidCode(code)) {
       return NextResponse.json(
-        { message: 'Invalid code format' },
+        { message: "Invalid code format" },
         { status: 400 }
       );
     }
-    
+
     // Look up the URL entry
     const entry = UrlStorage.get(code);
-    
+
     if (!entry) {
-      return NextResponse.json(
-        { message: 'Code not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ message: "Code not found" }, { status: 404 });
     }
-    
+
     // Increment hit counter
     UrlStorage.incrementHits(code);
-    
+
     // Return response with updated hit count
     const response: LookupResponse = {
       url: entry.url,
-      hits: entry.hits + 1 // Return incremented count
+      hits: entry.hits + 1, // Return incremented count
     };
-    
+
     return NextResponse.json(response);
   } catch (error) {
     return NextResponse.json(
-      { message: 'Internal server error' },
+      { message: "Internal server error" },
       { status: 500 }
     );
   }

--- a/app/api/routes-f/shorten/__tests__/route.test.ts
+++ b/app/api/routes-f/shorten/__tests__/route.test.ts
@@ -2,14 +2,14 @@
  * @jest-environment jsdom
  */
 
-import { POST } from '../route';
-import { GET } from '../[code]/route';
-import { NextRequest } from 'next/server';
-import { UrlStorage } from '../_lib/storage';
+import { POST } from "../route";
+import { GET } from "../[code]/route";
+import { NextRequest } from "next/server";
+import { UrlStorage } from "../_lib/storage";
 
 // Mock the storage to reset between tests
-jest.mock('../_lib/storage', () => {
-  const originalModule = jest.requireActual('../_lib/storage');
+jest.mock("../_lib/storage", () => {
+  const originalModule = jest.requireActual("../_lib/storage");
   return {
     ...originalModule,
     UrlStorage: {
@@ -19,211 +19,257 @@ jest.mock('../_lib/storage', () => {
       get: jest.fn(originalModule.UrlStorage.get),
       has: jest.fn(originalModule.UrlStorage.has),
       incrementHits: jest.fn(originalModule.UrlStorage.incrementHits),
-    }
+    },
   };
 });
 
-describe('/api/routes-f/shorten', () => {
+describe("/api/routes-f/shorten", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     UrlStorage.clear();
   });
 
-  describe('POST /api/routes-f/shorten', () => {
-    it('should create a short URL for valid HTTP URL', async () => {
-      const requestBody = { url: 'http://example.com' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+  describe("POST /api/routes-f/shorten", () => {
+    it("should create a short URL for valid HTTP URL", async () => {
+      const requestBody = { url: "http://example.com" };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(201);
-      expect(data).toHaveProperty('code');
-      expect(data).toHaveProperty('short_url');
-      expect(typeof data.code).toBe('string');
+      expect(data).toHaveProperty("code");
+      expect(data).toHaveProperty("short_url");
+      expect(typeof data.code).toBe("string");
       expect(data.code.length).toBe(6);
-      expect(data.short_url).toContain('http://localhost:3000/api/routes-f/shorten/');
-      expect(UrlStorage.set).toHaveBeenCalledWith(data.code, 'http://example.com');
+      expect(data.short_url).toContain(
+        "http://localhost:3000/api/routes-f/shorten/"
+      );
+      expect(UrlStorage.set).toHaveBeenCalledWith(
+        data.code,
+        "http://example.com"
+      );
     });
 
-    it('should create a short URL for valid HTTPS URL', async () => {
-      const requestBody = { url: 'https://secure.example.com/path?query=value' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should create a short URL for valid HTTPS URL", async () => {
+      const requestBody = {
+        url: "https://secure.example.com/path?query=value",
+      };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(201);
-      expect(data).toHaveProperty('code');
-      expect(data).toHaveProperty('short_url');
-      expect(UrlStorage.set).toHaveBeenCalledWith(data.code, 'https://secure.example.com/path?query=value');
+      expect(data).toHaveProperty("code");
+      expect(data).toHaveProperty("short_url");
+      expect(UrlStorage.set).toHaveBeenCalledWith(
+        data.code,
+        "https://secure.example.com/path?query=value"
+      );
     });
 
-    it('should reject empty URL', async () => {
-      const requestBody = { url: '' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should reject empty URL", async () => {
+      const requestBody = { url: "" };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('URL cannot be empty');
-      expect(data.code).toBe('EMPTY_URL');
+      expect(data.message).toBe("URL cannot be empty");
+      expect(data.code).toBe("EMPTY_URL");
     });
 
-    it('should reject whitespace-only URL', async () => {
-      const requestBody = { url: '   ' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should reject whitespace-only URL", async () => {
+      const requestBody = { url: "   " };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('URL cannot be empty');
-      expect(data.code).toBe('EMPTY_URL');
+      expect(data.message).toBe("URL cannot be empty");
+      expect(data.code).toBe("EMPTY_URL");
     });
 
-    it('should reject FTP URL', async () => {
-      const requestBody = { url: 'ftp://example.com' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should reject FTP URL", async () => {
+      const requestBody = { url: "ftp://example.com" };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('Only HTTP and HTTPS URLs are allowed');
-      expect(data.code).toBe('UNSAFE_SCHEME');
+      expect(data.message).toBe("Only HTTP and HTTPS URLs are allowed");
+      expect(data.code).toBe("UNSAFE_SCHEME");
     });
 
-    it('should reject invalid URL format', async () => {
-      const requestBody = { url: 'not-a-valid-url' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should reject invalid URL format", async () => {
+      const requestBody = { url: "not-a-valid-url" };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('Invalid URL format');
-      expect(data.code).toBe('INVALID_URL');
+      expect(data.message).toBe("Invalid URL format");
+      expect(data.code).toBe("INVALID_URL");
     });
 
-    it('should trim whitespace from valid URL', async () => {
-      const requestBody = { url: '  https://example.com  ' };
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten', {
-        method: 'POST',
-        body: JSON.stringify(requestBody),
-        headers: { 'Content-Type': 'application/json' }
-      });
+    it("should trim whitespace from valid URL", async () => {
+      const requestBody = { url: "  https://example.com  " };
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten",
+        {
+          method: "POST",
+          body: JSON.stringify(requestBody),
+          headers: { "Content-Type": "application/json" },
+        }
+      );
 
       const response = await POST(request);
       const data = await response.json();
 
       expect(response.status).toBe(201);
-      expect(UrlStorage.set).toHaveBeenCalledWith(data.code, 'https://example.com');
+      expect(UrlStorage.set).toHaveBeenCalledWith(
+        data.code,
+        "https://example.com"
+      );
     });
   });
 
-  describe('GET /api/routes-f/shorten/[code]', () => {
+  describe("GET /api/routes-f/shorten/[code]", () => {
     beforeEach(() => {
       // Setup test data
-      UrlStorage.set('abc123', 'https://example.com');
-      const entry = UrlStorage.get('abc123');
+      UrlStorage.set("abc123", "https://example.com");
+      const entry = UrlStorage.get("abc123");
       if (entry) {
         entry.hits = 5;
       }
     });
 
-    it('should return URL and hit count for valid code', async () => {
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/abc123');
-      const params = { code: 'abc123' };
+    it("should return URL and hit count for valid code", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/abc123"
+      );
+      const params = { code: "abc123" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.url).toBe('https://example.com');
+      expect(data.url).toBe("https://example.com");
       expect(data.hits).toBe(6); // 5 original + 1 increment
-      expect(UrlStorage.incrementHits).toHaveBeenCalledWith('abc123');
+      expect(UrlStorage.incrementHits).toHaveBeenCalledWith("abc123");
     });
 
-    it('should return 404 for non-existent code', async () => {
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/nonexistent');
-      const params = { code: 'nonexistent' };
+    it("should return 404 for non-existent code", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/nonexistent"
+      );
+      const params = { code: "nonexistent" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data.message).toBe('Code not found');
+      expect(data.message).toBe("Code not found");
     });
 
-    it('should return 400 for invalid code format (too short)', async () => {
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/abc');
-      const params = { code: 'abc' };
+    it("should return 400 for invalid code format (too short)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/abc"
+      );
+      const params = { code: "abc" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('Invalid code format');
+      expect(data.message).toBe("Invalid code format");
     });
 
-    it('should return 400 for invalid code format (too long)', async () => {
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/abcdef123');
-      const params = { code: 'abcdef123' };
+    it("should return 400 for invalid code format (too long)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/abcdef123"
+      );
+      const params = { code: "abcdef123" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('Invalid code format');
+      expect(data.message).toBe("Invalid code format");
     });
 
-    it('should return 400 for invalid code format (invalid characters)', async () => {
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/abc!@#');
-      const params = { code: 'abc!@#' };
+    it("should return 400 for invalid code format (invalid characters)", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/abc!@#"
+      );
+      const params = { code: "abc!@#" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.message).toBe('Invalid code format');
+      expect(data.message).toBe("Invalid code format");
     });
 
-    it('should handle zero hits correctly', async () => {
-      UrlStorage.set('xyz789', 'https://test.com');
-      const request = new NextRequest('http://localhost:3000/api/routes-f/shorten/xyz789');
-      const params = { code: 'xyz789' };
+    it("should handle zero hits correctly", async () => {
+      UrlStorage.set("xyz789", "https://test.com");
+      const request = new NextRequest(
+        "http://localhost:3000/api/routes-f/shorten/xyz789"
+      );
+      const params = { code: "xyz789" };
 
-      const response = await GET(request, { params });
+      const response = await GET(request, { params: Promise.resolve(params) });
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.url).toBe('https://test.com');
+      expect(data.url).toBe("https://test.com");
       expect(data.hits).toBe(1); // 0 original + 1 increment
     });
   });

--- a/app/api/routes-f/status/__tests__/route.test.ts
+++ b/app/api/routes-f/status/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET as getStatus } from "../route";
+import { GET as getHistory } from "../history/route";
+import { POST as createIncident } from "../incidents/route";
+import { PATCH as updateIncident } from "../incidents/[id]/route";
+
+function makeReq(url: string, body?: unknown) {
+  return new NextRequest(url, {
+    method: body ? "POST" : "GET",
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("/api/routes-f/status", () => {
+  it("returns overall and per-service platform status", async () => {
+    const res = await getStatus();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.overall).toBeDefined();
+    expect(body.services.live_streaming).toBeDefined();
+    expect(Array.isArray(body.active_incidents)).toBe(true);
+  });
+
+  it("creates incidents and overlays affected services", async () => {
+    const created = await createIncident(
+      makeReq("http://localhost/api/routes-f/status/incidents", {
+        title: "Chat delivery delays",
+        severity: "minor",
+        affects: ["chat"],
+        update: "We are investigating delayed messages.",
+      })
+    );
+    const incident = await created.json();
+    const status = await getStatus();
+    const body = await status.json();
+
+    expect(created.status).toBe(201);
+    expect(incident.updates[0].body).toContain("investigating");
+    expect(body.services.chat).toBe("degraded");
+  });
+
+  it("updates and resolves incidents", async () => {
+    const created = await createIncident(
+      makeReq("http://localhost/api/routes-f/status/incidents", {
+        title: "Payments outage",
+        severity: "critical",
+        affects: ["payments"],
+      })
+    );
+    const incident = await created.json();
+
+    const patched = await updateIncident(
+      makeReq("http://localhost/api/routes-f/status/incidents/id", {
+        status: "resolved",
+        update: "Payments are healthy again.",
+      }),
+      { params: Promise.resolve({ id: incident.id }) }
+    );
+    const body = await patched.json();
+
+    expect(patched.status).toBe(200);
+    expect(body.status).toBe("resolved");
+    expect(body.resolved_at).toBeTruthy();
+  });
+
+  it("returns incident history and uptime", async () => {
+    const res = await getHistory();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.window_days).toBe(90);
+    expect(body.uptime.payments).toBeLessThanOrEqual(100);
+    expect(Array.isArray(body.incidents)).toBe(true);
+  });
+});

--- a/app/api/routes-f/status/_lib/status.ts
+++ b/app/api/routes-f/status/_lib/status.ts
@@ -1,0 +1,500 @@
+import { sql } from "@vercel/postgres";
+import { buildHealthReport } from "../../health/_lib/service";
+
+export type IncidentSeverity = "minor" | "major" | "critical";
+export type IncidentStatus =
+  | "investigating"
+  | "identified"
+  | "monitoring"
+  | "resolved";
+export type ServiceKey =
+  | "live_streaming"
+  | "payments"
+  | "chat"
+  | "recordings"
+  | "website";
+export type ServiceStatus =
+  | "operational"
+  | "degraded"
+  | "partial_outage"
+  | "major_outage";
+export type OverallStatus = ServiceStatus;
+
+export interface IncidentUpdate {
+  id: string;
+  incident_id: string;
+  body: string;
+  status: IncidentStatus;
+  created_at: string;
+}
+
+export interface Incident {
+  id: string;
+  title: string;
+  severity: IncidentSeverity;
+  status: IncidentStatus;
+  affects: string[];
+  created_at: string;
+  resolved_at: string | null;
+  updates: IncidentUpdate[];
+}
+
+const SERVICES: ServiceKey[] = [
+  "live_streaming",
+  "payments",
+  "chat",
+  "recordings",
+  "website",
+];
+
+const VALID_SEVERITIES: IncidentSeverity[] = ["minor", "major", "critical"];
+const VALID_STATUSES: IncidentStatus[] = [
+  "investigating",
+  "identified",
+  "monitoring",
+  "resolved",
+];
+
+const memoryStore = globalThis as typeof globalThis & {
+  __routesFStatusIncidents?: Incident[];
+};
+
+function shouldUseDatabase() {
+  return Boolean(process.env.POSTGRES_URL || process.env.DATABASE_URL);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createId() {
+  return crypto.randomUUID();
+}
+
+function normalizeAffects(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+
+  const affects = value.map(item => String(item).trim()).filter(Boolean);
+  if (
+    affects.length === 0 ||
+    affects.some(
+      item => item !== "all" && !SERVICES.includes(item as ServiceKey)
+    )
+  ) {
+    return null;
+  }
+
+  return affects;
+}
+
+function getMemoryIncidents() {
+  if (!memoryStore.__routesFStatusIncidents) {
+    memoryStore.__routesFStatusIncidents = [];
+  }
+  return memoryStore.__routesFStatusIncidents;
+}
+
+async function ensureTables() {
+  await sql`DO $$ BEGIN
+    CREATE TYPE incident_severity AS ENUM ('minor', 'major', 'critical');
+  EXCEPTION
+    WHEN duplicate_object THEN null;
+  END $$`;
+
+  await sql`DO $$ BEGIN
+    CREATE TYPE incident_status AS ENUM ('investigating', 'identified', 'monitoring', 'resolved');
+  EXCEPTION
+    WHEN duplicate_object THEN null;
+  END $$`;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS incidents (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      title TEXT NOT NULL,
+      severity incident_severity NOT NULL,
+      status incident_status DEFAULT 'investigating',
+      affects TEXT[],
+      created_at TIMESTAMPTZ DEFAULT now(),
+      resolved_at TIMESTAMPTZ
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS incident_updates (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      incident_id UUID REFERENCES incidents(id) ON DELETE CASCADE,
+      body TEXT NOT NULL,
+      status incident_status NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT now()
+    )
+  `;
+}
+
+function withUpdates(rows: any[], updateRows: any[]): Incident[] {
+  return rows.map(row => ({
+    id: String(row.id),
+    title: String(row.title),
+    severity: row.severity as IncidentSeverity,
+    status: row.status as IncidentStatus,
+    affects: Array.isArray(row.affects) ? row.affects : [],
+    created_at: new Date(row.created_at).toISOString(),
+    resolved_at: row.resolved_at
+      ? new Date(row.resolved_at).toISOString()
+      : null,
+    updates: updateRows
+      .filter(update => String(update.incident_id) === String(row.id))
+      .map(update => ({
+        id: String(update.id),
+        incident_id: String(update.incident_id),
+        body: String(update.body),
+        status: update.status as IncidentStatus,
+        created_at: new Date(update.created_at).toISOString(),
+      })),
+  }));
+}
+
+export function validateIncidentInput(body: any) {
+  const title = typeof body?.title === "string" ? body.title.trim() : "";
+  const severity = body?.severity as IncidentSeverity;
+  const status = (body?.status ?? "investigating") as IncidentStatus;
+  const affects = normalizeAffects(body?.affects);
+  const updateBody = typeof body?.update === "string" ? body.update.trim() : "";
+
+  if (!title) {
+    return { error: "title is required" };
+  }
+  if (!VALID_SEVERITIES.includes(severity)) {
+    return { error: "severity must be minor, major, or critical" };
+  }
+  if (!VALID_STATUSES.includes(status)) {
+    return {
+      error:
+        "status must be investigating, identified, monitoring, or resolved",
+    };
+  }
+  if (!affects) {
+    return { error: "affects must include all or at least one known service" };
+  }
+
+  return { title, severity, status, affects, updateBody };
+}
+
+export function validateIncidentUpdateInput(body: any) {
+  const status = body?.status as IncidentStatus | undefined;
+  const updateBody = typeof body?.update === "string" ? body.update.trim() : "";
+  const title = typeof body?.title === "string" ? body.title.trim() : undefined;
+  const severity = body?.severity as IncidentSeverity | undefined;
+  const affects =
+    body?.affects === undefined ? undefined : normalizeAffects(body.affects);
+
+  if (status !== undefined && !VALID_STATUSES.includes(status)) {
+    return {
+      error:
+        "status must be investigating, identified, monitoring, or resolved",
+    };
+  }
+  if (severity !== undefined && !VALID_SEVERITIES.includes(severity)) {
+    return { error: "severity must be minor, major, or critical" };
+  }
+  if (body?.affects !== undefined && !affects) {
+    return { error: "affects must include all or at least one known service" };
+  }
+  if (!status && !updateBody && !title && !severity && !affects) {
+    return { error: "provide status, update, title, severity, or affects" };
+  }
+
+  return { status, updateBody, title, severity, affects };
+}
+
+export async function createIncident(
+  input: ReturnType<typeof validateIncidentInput>
+) {
+  if ("error" in input) {
+    throw new Error(input.error);
+  }
+
+  const createdAt = nowIso();
+  const resolvedAt = input.status === "resolved" ? createdAt : null;
+
+  if (!shouldUseDatabase()) {
+    const incident: Incident = {
+      id: createId(),
+      title: input.title,
+      severity: input.severity,
+      status: input.status,
+      affects: input.affects,
+      created_at: createdAt,
+      resolved_at: resolvedAt,
+      updates: input.updateBody
+        ? [
+            {
+              id: createId(),
+              incident_id: "",
+              body: input.updateBody,
+              status: input.status,
+              created_at: createdAt,
+            },
+          ]
+        : [],
+    };
+    incident.updates = incident.updates.map(update => ({
+      ...update,
+      incident_id: incident.id,
+    }));
+    getMemoryIncidents().unshift(incident);
+    return incident;
+  }
+
+  await ensureTables();
+  const affectsCsv = input.affects.join(",");
+  const { rows } = await sql`
+    INSERT INTO incidents (title, severity, status, affects, resolved_at)
+    VALUES (${input.title}, ${input.severity}, ${input.status}, string_to_array(${affectsCsv}, ','), ${resolvedAt})
+    RETURNING *
+  `;
+  const incident = withUpdates(rows, [])[0];
+
+  if (input.updateBody) {
+    const { rows: updateRows } = await sql`
+      INSERT INTO incident_updates (incident_id, body, status)
+      VALUES (${incident.id}, ${input.updateBody}, ${input.status})
+      RETURNING *
+    `;
+    incident.updates = withUpdates([rows[0]], updateRows)[0].updates;
+  }
+
+  return incident;
+}
+
+export async function updateIncident(
+  id: string,
+  input: ReturnType<typeof validateIncidentUpdateInput>
+) {
+  if ("error" in input) {
+    throw new Error(input.error);
+  }
+
+  if (!shouldUseDatabase()) {
+    const incident = getMemoryIncidents().find(item => item.id === id);
+    if (!incident) {
+      return null;
+    }
+
+    if (input.title) {
+      incident.title = input.title;
+    }
+    if (input.severity) {
+      incident.severity = input.severity;
+    }
+    if (input.affects) {
+      incident.affects = input.affects;
+    }
+    if (input.status) {
+      incident.status = input.status;
+      incident.resolved_at = input.status === "resolved" ? nowIso() : null;
+    }
+    if (input.updateBody) {
+      incident.updates.unshift({
+        id: createId(),
+        incident_id: incident.id,
+        body: input.updateBody,
+        status: incident.status,
+        created_at: nowIso(),
+      });
+    }
+    return incident;
+  }
+
+  await ensureTables();
+  const current = await sql`SELECT * FROM incidents WHERE id = ${id} LIMIT 1`;
+  if (current.rows.length === 0) {
+    return null;
+  }
+
+  const nextStatus = input.status ?? current.rows[0].status;
+  const resolvedAt =
+    input.status === "resolved"
+      ? new Date().toISOString()
+      : input.status
+        ? null
+        : current.rows[0].resolved_at;
+  const affectsCsv = input.affects?.join(",") ?? null;
+
+  const { rows } = await sql`
+    UPDATE incidents
+    SET
+      title = COALESCE(${input.title ?? null}, title),
+      severity = COALESCE(${input.severity ?? null}, severity),
+      status = ${nextStatus},
+      affects = COALESCE(string_to_array(${affectsCsv}, ','), affects),
+      resolved_at = ${resolvedAt}
+    WHERE id = ${id}
+    RETURNING *
+  `;
+
+  let updateRows: any[] = [];
+  if (input.updateBody) {
+    const inserted = await sql`
+      INSERT INTO incident_updates (incident_id, body, status)
+      VALUES (${id}, ${input.updateBody}, ${nextStatus})
+      RETURNING *
+    `;
+    updateRows = inserted.rows;
+  }
+
+  return withUpdates(rows, updateRows)[0];
+}
+
+export async function listIncidents(includeRecentlyResolved = false) {
+  const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const recentlyResolvedCutoff = new Date(
+    Date.now() - 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  if (!shouldUseDatabase()) {
+    return getMemoryIncidents()
+      .filter(incident => incident.created_at >= cutoff)
+      .filter(
+        incident =>
+          includeRecentlyResolved ||
+          incident.status !== "resolved" ||
+          (incident.resolved_at !== null &&
+            incident.resolved_at >= recentlyResolvedCutoff)
+      )
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  }
+
+  await ensureTables();
+  const { rows } = includeRecentlyResolved
+    ? await sql`
+        SELECT * FROM incidents
+        WHERE created_at >= ${cutoff}
+        ORDER BY created_at DESC
+      `
+    : await sql`
+        SELECT * FROM incidents
+        WHERE created_at >= ${cutoff}
+          AND (status <> 'resolved' OR resolved_at >= ${recentlyResolvedCutoff})
+        ORDER BY created_at DESC
+      `;
+
+  const ids = rows.map(row => String(row.id));
+  const { rows: updateRows } =
+    ids.length === 0
+      ? { rows: [] }
+      : await sql`
+          SELECT * FROM incident_updates
+          WHERE incident_id = ANY(string_to_array(${ids.join(",")}, ',')::uuid[])
+          ORDER BY created_at DESC
+        `;
+
+  return withUpdates(rows, updateRows);
+}
+
+function serviceStatusFromIncident(incident: Incident): ServiceStatus {
+  if (incident.status === "resolved") {
+    return "operational";
+  }
+  if (incident.severity === "critical") {
+    return "major_outage";
+  }
+  if (incident.severity === "major") {
+    return "partial_outage";
+  }
+  return "degraded";
+}
+
+function worstStatus(statuses: ServiceStatus[]): ServiceStatus {
+  const order: ServiceStatus[] = [
+    "operational",
+    "degraded",
+    "partial_outage",
+    "major_outage",
+  ];
+  return statuses.reduce((worst, status) =>
+    order.indexOf(status) > order.indexOf(worst) ? status : worst
+  );
+}
+
+export async function buildStatusResponse() {
+  const [health, incidents] = await Promise.all([
+    buildHealthReport(),
+    listIncidents(false),
+  ]);
+
+  const services = Object.fromEntries(
+    SERVICES.map(service => [service, "operational" as ServiceStatus])
+  ) as Record<ServiceKey, ServiceStatus>;
+
+  if (health.status !== "ok") {
+    services.website = "degraded";
+  }
+
+  for (const incident of incidents) {
+    if (incident.status === "resolved") {
+      continue;
+    }
+    const affectedServices = incident.affects.includes("all")
+      ? SERVICES
+      : (incident.affects as ServiceKey[]);
+    for (const service of affectedServices) {
+      services[service] = worstStatus([
+        services[service],
+        serviceStatusFromIncident(incident),
+      ]);
+    }
+  }
+
+  const overall = worstStatus(Object.values(services));
+
+  return {
+    overall,
+    services,
+    active_incidents: incidents,
+    last_updated: nowIso(),
+  };
+}
+
+export async function buildHistoryResponse() {
+  const incidents = await listIncidents(true);
+  const windowStart = Date.now() - 90 * 24 * 60 * 60 * 1000;
+  const windowEnd = Date.now();
+  const totalWindowMs = windowEnd - windowStart;
+
+  const uptime = Object.fromEntries(
+    SERVICES.map(service => {
+      const downtimeMs = incidents.reduce((total, incident) => {
+        if (
+          incident.status !== "resolved" ||
+          (!incident.affects.includes("all") &&
+            !incident.affects.includes(service))
+        ) {
+          return total;
+        }
+
+        const start = Math.max(
+          new Date(incident.created_at).getTime(),
+          windowStart
+        );
+        const end = Math.min(
+          incident.resolved_at
+            ? new Date(incident.resolved_at).getTime()
+            : windowEnd,
+          windowEnd
+        );
+        return total + Math.max(0, end - start);
+      }, 0);
+
+      const percentage = ((totalWindowMs - downtimeMs) / totalWindowMs) * 100;
+      return [service, Number(percentage.toFixed(3))];
+    })
+  ) as Record<ServiceKey, number>;
+
+  return {
+    window_days: 90,
+    incidents,
+    uptime,
+  };
+}

--- a/app/api/routes-f/status/history/route.ts
+++ b/app/api/routes-f/status/history/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { buildHistoryResponse } from "../_lib/status";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await buildHistoryResponse());
+  } catch (error) {
+    console.error("[routes-f status history GET]", error);
+    return NextResponse.json(
+      { error: "Failed to build incident history" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/status/incidents/[id]/route.ts
+++ b/app/api/routes-f/status/incidents/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateIncident, validateIncidentUpdateInput } from "../../_lib/status";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const input = validateIncidentUpdateInput(body);
+  if ("error" in input) {
+    return NextResponse.json({ error: input.error }, { status: 400 });
+  }
+
+  try {
+    const { id } = await params;
+    const incident = await updateIncident(id, input);
+    if (!incident) {
+      return NextResponse.json(
+        { error: "Incident not found" },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json(incident);
+  } catch (error) {
+    console.error("[routes-f status incidents PATCH]", error);
+    return NextResponse.json(
+      { error: "Failed to update incident" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/status/incidents/route.ts
+++ b/app/api/routes-f/status/incidents/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createIncident, validateIncidentInput } from "../_lib/status";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const input = validateIncidentInput(body);
+  if ("error" in input) {
+    return NextResponse.json({ error: input.error }, { status: 400 });
+  }
+
+  try {
+    return NextResponse.json(await createIncident(input), { status: 201 });
+  } catch (error) {
+    console.error("[routes-f status incidents POST]", error);
+    return NextResponse.json(
+      { error: "Failed to create incident" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/status/route.ts
+++ b/app/api/routes-f/status/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { buildStatusResponse } from "./_lib/status";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await buildStatusResponse());
+  } catch (error) {
+    console.error("[routes-f status GET]", error);
+    return NextResponse.json(
+      { error: "Failed to build platform status" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/sudoku/__tests__/route.test.ts
+++ b/app/api/routes-f/sudoku/__tests__/route.test.ts
@@ -29,7 +29,9 @@ describe("POST /api/routes-f/sudoku", () => {
   });
 
   it("valid partial", async () => {
-    const grid = Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => null));
+    const grid: (number | null)[][] = Array.from({ length: 9 }, () =>
+      Array.from({ length: 9 }, () => null)
+    );
     grid[0][0] = 1;
     const res = await POST(makeRequest(grid));
     const body = await res.json();
@@ -38,29 +40,41 @@ describe("POST /api/routes-f/sudoku", () => {
   });
 
   it("row conflict", async () => {
-    const grid = Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => null));
+    const grid: (number | null)[][] = Array.from({ length: 9 }, () =>
+      Array.from({ length: 9 }, () => null)
+    );
     grid[0][0] = 3;
     grid[0][5] = 3;
     const res = await POST(makeRequest(grid));
     const body = await res.json();
-    expect(body.conflicts.some((c: any) => c.conflict_type === "row")).toBe(true);
+    expect(body.conflicts.some((c: any) => c.conflict_type === "row")).toBe(
+      true
+    );
   });
 
   it("column conflict", async () => {
-    const grid = Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => null));
+    const grid: (number | null)[][] = Array.from({ length: 9 }, () =>
+      Array.from({ length: 9 }, () => null)
+    );
     grid[0][0] = 3;
     grid[5][0] = 3;
     const res = await POST(makeRequest(grid));
     const body = await res.json();
-    expect(body.conflicts.some((c: any) => c.conflict_type === "column")).toBe(true);
+    expect(body.conflicts.some((c: any) => c.conflict_type === "column")).toBe(
+      true
+    );
   });
 
   it("box conflict", async () => {
-    const grid = Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => null));
+    const grid: (number | null)[][] = Array.from({ length: 9 }, () =>
+      Array.from({ length: 9 }, () => null)
+    );
     grid[0][0] = 3;
     grid[2][1] = 3;
     const res = await POST(makeRequest(grid));
     const body = await res.json();
-    expect(body.conflicts.some((c: any) => c.conflict_type === "box")).toBe(true);
+    expect(body.conflicts.some((c: any) => c.conflict_type === "box")).toBe(
+      true
+    );
   });
 });

--- a/app/api/routes-f/sudoku/_lib/validator.ts
+++ b/app/api/routes-f/sudoku/_lib/validator.ts
@@ -4,22 +4,38 @@ const GRID_SIZE = 9;
 const BOX_SIZE = 3;
 
 function isValidCell(value: unknown): value is number | null {
-  return value === null || (Number.isInteger(value) && value >= 1 && value <= 9);
+  return (
+    value === null ||
+    (typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= 1 &&
+      value <= 9)
+  );
 }
 
 export function isValidSudokuGrid(grid: unknown): grid is (number | null)[][] {
   return (
     Array.isArray(grid) &&
     grid.length === GRID_SIZE &&
-    grid.every((row) => Array.isArray(row) && row.length === GRID_SIZE && row.every(isValidCell))
+    grid.every(
+      row =>
+        Array.isArray(row) && row.length === GRID_SIZE && row.every(isValidCell)
+    )
   );
 }
 
-export function validateSudokuGrid(grid: (number | null)[][]): SudokuValidationResult {
+export function validateSudokuGrid(
+  grid: (number | null)[][]
+): SudokuValidationResult {
   const conflicts: SudokuConflict[] = [];
   const seen = new Set<string>();
 
-  const addConflict = (row: number, col: number, value: number, conflict_type: SudokuConflict["conflict_type"]) => {
+  const addConflict = (
+    row: number,
+    col: number,
+    value: number,
+    conflict_type: SudokuConflict["conflict_type"]
+  ) => {
     const key = `${row}:${col}:${value}:${conflict_type}`;
     if (!seen.has(key)) {
       seen.add(key);
@@ -38,7 +54,8 @@ export function validateSudokuGrid(grid: (number | null)[][]): SudokuValidationR
     }
 
     for (const [value, cols] of rowValues.entries()) {
-      if (cols.length > 1) cols.forEach((col) => addConflict(row, col, value, "row"));
+      if (cols.length > 1)
+        cols.forEach(col => addConflict(row, col, value, "row"));
     }
   }
 
@@ -53,7 +70,8 @@ export function validateSudokuGrid(grid: (number | null)[][]): SudokuValidationR
     }
 
     for (const [value, rows] of colValues.entries()) {
-      if (rows.length > 1) rows.forEach((row) => addConflict(row, col, value, "column"));
+      if (rows.length > 1)
+        rows.forEach(row => addConflict(row, col, value, "column"));
     }
   }
 
@@ -72,13 +90,15 @@ export function validateSudokuGrid(grid: (number | null)[][]): SudokuValidationR
       }
 
       for (const [value, cells] of boxValues.entries()) {
-        if (cells.length > 1) cells.forEach((cell) => addConflict(cell.row, cell.col, value, "box"));
+        if (cells.length > 1)
+          cells.forEach(cell => addConflict(cell.row, cell.col, value, "box"));
       }
     }
   }
 
   const valid = conflicts.length === 0;
-  const complete = valid && grid.every((row) => row.every((value) => value !== null));
+  const complete =
+    valid && grid.every(row => row.every(value => value !== null));
 
   return { valid, complete, conflicts };
 }

--- a/app/api/routes-f/wheel/__tests__/route.test.ts
+++ b/app/api/routes-f/wheel/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/wheel", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/wheel", () => {
+  it("keeps the same wheel between spins in keep mode", async () => {
+    const res = await POST(
+      makeReq({ slices: ["A", "B", "C"], spins: 3, seed: "keep", mode: "keep" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results).toHaveLength(3);
+    expect(body.total_slices_remaining).toBe(3);
+    expect(body.results.map((r: any) => r.slices_remaining)).toEqual([3, 3, 3]);
+  });
+
+  it("removes winning slices in eliminate mode", async () => {
+    const res = await POST(
+      makeReq({
+        slices: ["A", "B", "C"],
+        spins: 3,
+        seed: "eliminate",
+        mode: "eliminate",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results).toHaveLength(3);
+    expect(body.total_slices_remaining).toBe(0);
+    expect(new Set(body.results.map((r: any) => r.selected.label)).size).toBe(
+      3
+    );
+  });
+
+  it("uses weights for selection", async () => {
+    const res = await POST(
+      makeReq({
+        slices: [
+          { label: "light", weight: 1 },
+          { label: "heavy", weight: 100 },
+        ],
+        spins: 25,
+        seed: "weighted",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(
+      body.results.filter((r: any) => r.selected.label === "heavy").length
+    ).toBeGreaterThan(20);
+  });
+
+  it("is deterministic when a seed is supplied", async () => {
+    const payload = { slices: ["A", "B", "C"], spins: 10, seed: 668 };
+    const first = await POST(makeReq(payload));
+    const second = await POST(makeReq(payload));
+
+    expect(await first.json()).toEqual(await second.json());
+  });
+});

--- a/app/api/routes-f/wheel/route.ts
+++ b/app/api/routes-f/wheel/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_SLICES = 1000;
+const MAX_SPINS = 100;
+
+type WheelMode = "keep" | "eliminate";
+
+type InputSlice = string | { label?: unknown; weight?: unknown };
+
+interface WheelSlice {
+  label: string;
+  weight: number;
+}
+
+interface SpinResult {
+  spin: number;
+  selected: WheelSlice;
+  slices_remaining: number;
+}
+
+function createSeededRandom(seed: string | number) {
+  let h = 2166136261;
+  const input = String(seed);
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+
+  return () => {
+    h += 0x6d2b79f5;
+    let t = h;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function parseSlices(value: unknown): WheelSlice[] | string {
+  if (!Array.isArray(value)) {
+    return "slices must be an array";
+  }
+
+  if (value.length < 1 || value.length > MAX_SLICES) {
+    return `slices must contain between 1 and ${MAX_SLICES} entries`;
+  }
+
+  return value.map((slice: InputSlice, index): WheelSlice => {
+    if (typeof slice === "string") {
+      return { label: slice.trim(), weight: 1 };
+    }
+
+    if (!slice || typeof slice !== "object") {
+      throw new Error(`slice at index ${index} must be a string or object`);
+    }
+
+    const label = typeof slice.label === "string" ? slice.label.trim() : "";
+    const weight = slice.weight === undefined ? 1 : Number(slice.weight);
+
+    if (!label) {
+      throw new Error(`slice at index ${index} requires a label`);
+    }
+    if (!Number.isFinite(weight) || weight <= 0) {
+      throw new Error(`slice at index ${index} requires weight > 0`);
+    }
+
+    return { label, weight };
+  });
+}
+
+function chooseWeighted(slices: WheelSlice[], random: () => number): number {
+  const totalWeight = slices.reduce((sum, slice) => sum + slice.weight, 0);
+  let cursor = random() * totalWeight;
+
+  for (let i = 0; i < slices.length; i += 1) {
+    cursor -= slices[i].weight;
+    if (cursor < 0) {
+      return i;
+    }
+  }
+
+  return slices.length - 1;
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    slices?: unknown;
+    spins?: unknown;
+    seed?: unknown;
+    mode?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  let slices: WheelSlice[];
+  try {
+    const parsed = parseSlices(body.slices);
+    if (typeof parsed === "string") {
+      return NextResponse.json({ error: parsed }, { status: 400 });
+    }
+    slices = parsed;
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid slices" },
+      { status: 400 }
+    );
+  }
+
+  const spins = body.spins === undefined ? 1 : Number(body.spins);
+  if (!Number.isInteger(spins) || spins < 1 || spins > MAX_SPINS) {
+    return NextResponse.json(
+      { error: `spins must be an integer between 1 and ${MAX_SPINS}` },
+      { status: 400 }
+    );
+  }
+
+  const mode = (body.mode ?? "keep") as WheelMode;
+  if (mode !== "keep" && mode !== "eliminate") {
+    return NextResponse.json(
+      { error: "mode must be keep or eliminate" },
+      { status: 400 }
+    );
+  }
+
+  const random =
+    body.seed === undefined
+      ? Math.random
+      : createSeededRandom(String(body.seed));
+  const wheel = [...slices];
+  const results: SpinResult[] = [];
+  const spinCount =
+    mode === "eliminate" ? Math.min(spins, wheel.length) : spins;
+
+  for (let spin = 1; spin <= spinCount; spin += 1) {
+    const selectedIndex = chooseWeighted(wheel, random);
+    const selected = wheel[selectedIndex];
+
+    if (mode === "eliminate") {
+      wheel.splice(selectedIndex, 1);
+    }
+
+    results.push({
+      spin,
+      selected,
+      slices_remaining: wheel.length,
+    });
+  }
+
+  return NextResponse.json({
+    results,
+    total_slices_remaining: wheel.length,
+  });
+}

--- a/app/api/streams/access/check/route.ts
+++ b/app/api/streams/access/check/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sql } from "@vercel/postgres";
 import { validateStreamAccessToken } from "@/lib/stream-access/token";
+import { checkSubscriptionAccess } from "@/lib/stream/access";
 
 export async function POST(req: NextRequest) {
   try {
-    const { playbackId, token } = await req.json();
+    const { playbackId, token, viewerPublicKey } = await req.json();
 
     if (!playbackId) {
       return NextResponse.json(
@@ -14,7 +15,7 @@ export async function POST(req: NextRequest) {
     }
 
     const { rows } = await sql`
-      SELECT id, stream_password_hash
+      SELECT id, stream_password_hash, stream_access_type
       FROM users
       WHERE mux_playback_id = ${playbackId}
       LIMIT 1
@@ -25,6 +26,14 @@ export async function POST(req: NextRequest) {
     }
 
     const user = rows[0];
+
+    if (user.stream_access_type === "subscription") {
+      const result = await checkSubscriptionAccess(
+        user.id,
+        typeof viewerPublicKey === "string" ? viewerPublicKey : null
+      );
+      return NextResponse.json(result, { status: 200 });
+    }
 
     if (!user.stream_password_hash) {
       return NextResponse.json({ allowed: true }, { status: 200 });

--- a/app/api/streams/key/route.ts
+++ b/app/api/streams/key/route.ts
@@ -30,7 +30,9 @@ export async function GET(req: Request) {
         mux_playback_id,
         is_live,
         enable_recording,
-        latency_mode
+        latency_mode,
+        stream_access_type,
+        creator
       FROM users
       WHERE wallet = ${wallet}
     `;
@@ -49,6 +51,12 @@ export async function GET(req: Request) {
           streamKey: null,
           enableRecording: user.enable_recording === true,
           latencyMode: user.latency_mode || "low",
+          streamAccessType: user.stream_access_type || "public",
+          subscriptionPriceUsdc:
+            Number(
+              user.creator?.subscriptionPrice ??
+                user.creator?.subscription_price_usdc
+            ) || null,
         },
         { status: 200 }
       );
@@ -66,6 +74,12 @@ export async function GET(req: Request) {
           isLive: user.is_live || false,
           enableRecording: user.enable_recording === true,
           latencyMode: user.latency_mode || "low",
+          streamAccessType: user.stream_access_type || "public",
+          subscriptionPriceUsdc:
+            Number(
+              user.creator?.subscriptionPrice ??
+                user.creator?.subscription_price_usdc
+            ) || null,
         },
       },
       { status: 200 }

--- a/app/api/streams/update/route.ts
+++ b/app/api/streams/update/route.ts
@@ -5,8 +5,16 @@ import { hashPassword } from "@/lib/stream-access/password";
 
 export async function PATCH(req: Request) {
   try {
-    const { wallet, title, description, category, tags, thumbnail, password } =
-      await req.json();
+    const {
+      wallet,
+      title,
+      description,
+      category,
+      tags,
+      thumbnail,
+      password,
+      streamAccessType,
+    } = await req.json();
 
     if (!wallet) {
       return NextResponse.json(
@@ -40,6 +48,7 @@ export async function PATCH(req: Request) {
     }
 
     const user = userResult.rows[0];
+    const currentCreator = user.creator || {};
 
     if (!user.mux_stream_id) {
       return NextResponse.json(
@@ -93,7 +102,44 @@ export async function PATCH(req: Request) {
       }
     }
 
-    const currentCreator = user.creator || {};
+    if (streamAccessType !== undefined) {
+      const validAccessTypes = ["public", "password", "subscription"];
+      if (
+        typeof streamAccessType !== "string" ||
+        !validAccessTypes.includes(streamAccessType)
+      ) {
+        return NextResponse.json(
+          {
+            error: "streamAccessType must be public, password, or subscription",
+          },
+          { status: 400 }
+        );
+      }
+
+      const subscriptionPrice = Number(
+        currentCreator.subscriptionPrice ??
+          currentCreator.subscription_price_usdc
+      );
+      if (
+        streamAccessType === "subscription" &&
+        (!Number.isFinite(subscriptionPrice) || subscriptionPrice <= 0)
+      ) {
+        return NextResponse.json(
+          {
+            error: "Set a subscription price before enabling subscriber access",
+          },
+          { status: 400 }
+        );
+      }
+
+      await sql`
+        UPDATE users SET
+          stream_access_type = ${streamAccessType},
+          updated_at = CURRENT_TIMESTAMP
+        WHERE wallet = ${wallet}
+      `;
+    }
+
     const updatedCreator = {
       ...currentCreator,
       ...(title && { streamTitle: title }),
@@ -120,6 +166,7 @@ export async function PATCH(req: Request) {
           category: updatedCreator.category,
           tags: updatedCreator.tags,
           thumbnail: updatedCreator.thumbnail,
+          streamAccessType: streamAccessType ?? "public",
         },
       },
       { status: 200 }

--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -17,6 +17,11 @@ export async function GET(
         u.sociallinks, u.emailverified, u.emailnotifications,
         u.creator, u.auth_type, u.privy_id,
         u.is_live, u.mux_playback_id, u.latency_mode, u.current_viewers,
+        COALESCE(u.stream_access_type, 'public') AS stream_access_type,
+        COALESCE(
+          NULLIF(u.creator->>'subscriptionPrice', '')::numeric,
+          NULLIF(u.creator->>'subscription_price_usdc', '')::numeric
+        ) AS subscription_price_usdc,
         u.stream_started_at, u.total_views,
         u.total_tips_received, u.total_tips_count, u.last_tip_at,
         u.created_at, u.updated_at,

--- a/components/settings/stream-channel-preferences/stream-preference.tsx
+++ b/components/settings/stream-channel-preferences/stream-preference.tsx
@@ -140,6 +140,13 @@ const StreamPreferencesPage: React.FC = () => {
   const [recordingToggleSaving, setRecordingToggleSaving] = useState(false);
   const [latencyMode, setLatencyMode] = useState<"low" | "standard">("low");
   const [latencyToggleSaving, setLatencyToggleSaving] = useState(false);
+  const [streamAccessType, setStreamAccessType] = useState<
+    "public" | "password" | "subscription"
+  >("public");
+  const [subscriptionPriceUsdc, setSubscriptionPriceUsdc] = useState<
+    number | null
+  >(null);
+  const [accessTypeSaving, setAccessTypeSaving] = useState(false);
   const [loading, setLoading] = useState(true);
 
   // State for the modals
@@ -167,6 +174,20 @@ const StreamPreferencesPage: React.FC = () => {
         );
         const mode = data.latencyMode || data.streamData?.latencyMode || "low";
         setLatencyMode(mode === "standard" ? "standard" : "low");
+        const accessType =
+          data.streamAccessType ||
+          data.streamData?.streamAccessType ||
+          "public";
+        setStreamAccessType(
+          accessType === "password" || accessType === "subscription"
+            ? accessType
+            : "public"
+        );
+        setSubscriptionPriceUsdc(
+          data.subscriptionPriceUsdc ??
+            data.streamData?.subscriptionPriceUsdc ??
+            null
+        );
         if (data.hasStream && data.streamData) {
           setStreamData(data.streamData);
         } else {
@@ -332,6 +353,49 @@ const StreamPreferencesPage: React.FC = () => {
       console.error("Failed to update recording preference:", e);
     } finally {
       setRecordingToggleSaving(false);
+    }
+  };
+
+  const handleAccessTypeChange = async (
+    nextValue: "public" | "password" | "subscription"
+  ) => {
+    if (!address || accessTypeSaving) {
+      return;
+    }
+    if (
+      nextValue === "subscription" &&
+      (!subscriptionPriceUsdc || subscriptionPriceUsdc <= 0)
+    ) {
+      toast.error("Set a subscription price before enabling subscriber access");
+      return;
+    }
+
+    const previous = streamAccessType;
+    setStreamAccessType(nextValue);
+    setAccessTypeSaving(true);
+    try {
+      const res = await fetch("/api/streams/update", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          wallet: address,
+          streamAccessType: nextValue,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to update stream access");
+      }
+      toast.success("Stream access updated");
+    } catch (error) {
+      setStreamAccessType(previous);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update stream access"
+      );
+    } finally {
+      setAccessTypeSaving(false);
     }
   };
 
@@ -505,6 +569,51 @@ const StreamPreferencesPage: React.FC = () => {
           </div>
         </SectionCard>
 
+        <SectionCard>
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="flex-1">
+              <h2 className="text-highlight text-xl font-medium mb-2">
+                Stream Access
+              </h2>
+              <p className="text-muted-foreground text-sm italic">
+                Choose who can watch this stream. Subscriber access uses your
+                monthly subscription price.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 md:min-w-64">
+              <select
+                value={streamAccessType}
+                onChange={e =>
+                  handleAccessTypeChange(
+                    e.target.value as "public" | "password" | "subscription"
+                  )
+                }
+                disabled={accessTypeSaving || !streamData}
+                className="w-full bg-input text-foreground rounded-lg p-3 border border-border focus:outline-none focus:ring-2 focus:ring-highlight"
+                title={
+                  !subscriptionPriceUsdc || subscriptionPriceUsdc <= 0
+                    ? "Set a subscription price to enable subscriber-only streams"
+                    : undefined
+                }
+              >
+                <option value="public">Public</option>
+                <option value="password">Password protected</option>
+                <option
+                  value="subscription"
+                  disabled={
+                    !subscriptionPriceUsdc || subscriptionPriceUsdc <= 0
+                  }
+                >
+                  Subscribers only
+                </option>
+              </select>
+              {accessTypeSaving && (
+                <span className="text-sm text-muted-foreground">Saving...</span>
+              )}
+            </div>
+          </div>
+        </SectionCard>
+
         {/* Latency Mode / DVR */}
         <SectionCard>
           <div className="flex justify-between items-start gap-4">
@@ -518,8 +627,8 @@ const StreamPreferencesPage: React.FC = () => {
                   : "Low latency mode is active. Minimal delay (~3–5 seconds), but viewers cannot rewind the stream."}
               </p>
               <p className="text-muted-foreground text-xs mt-2">
-                Changes take effect on your next stream. Existing streams are not
-                affected.
+                Changes take effect on your next stream. Existing streams are
+                not affected.
               </p>
             </div>
             <div className="flex items-center shrink-0">

--- a/components/stream/AccessGate.tsx
+++ b/components/stream/AccessGate.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useState, useEffect, type FormEvent } from "react";
-import { Lock } from "lucide-react";
+import { Crown, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface AccessGateProps {
   playbackId: string;
   username: string;
   onAccessGranted: () => void;
+  accessType?: "password" | "subscription";
+  monthlyPrice?: number | null;
+  viewerPublicKey?: string | null;
 }
 
 function getStorageKey(playbackId: string) {
@@ -18,6 +21,9 @@ export default function AccessGate({
   playbackId,
   username,
   onAccessGranted,
+  accessType = "password",
+  monthlyPrice,
+  viewerPublicKey,
 }: AccessGateProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -25,6 +31,26 @@ export default function AccessGate({
   const [checking, setChecking] = useState(true);
 
   useEffect(() => {
+    if (accessType === "subscription") {
+      fetch("/api/streams/access/check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ playbackId, viewerPublicKey }),
+      })
+        .then(r => r.json())
+        .then(data => {
+          if (data.allowed) {
+            onAccessGranted();
+          } else {
+            setChecking(false);
+          }
+        })
+        .catch(() => {
+          setChecking(false);
+        });
+      return;
+    }
+
     const stored = sessionStorage.getItem(getStorageKey(playbackId));
     if (!stored) {
       setChecking(false);
@@ -48,7 +74,7 @@ export default function AccessGate({
       .catch(() => {
         setChecking(false);
       });
-  }, [playbackId, onAccessGranted]);
+  }, [accessType, playbackId, viewerPublicKey, onAccessGranted]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -87,6 +113,45 @@ export default function AccessGate({
     return (
       <div className="flex items-center justify-center h-full min-h-[400px] bg-background">
         <div className="text-muted-foreground">Checking access...</div>
+      </div>
+    );
+  }
+
+  if (accessType === "subscription") {
+    const priceLabel =
+      typeof monthlyPrice === "number" && Number.isFinite(monthlyPrice)
+        ? `$${monthlyPrice.toFixed(2)}/month`
+        : "monthly";
+
+    return (
+      <div className="flex items-center justify-center h-full min-h-[400px] bg-background">
+        <div className="w-full max-w-sm mx-auto p-6">
+          <div className="flex flex-col items-center text-center mb-6">
+            <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
+              <Crown className="w-6 h-6 text-highlight" />
+            </div>
+            <h2 className="text-lg font-semibold text-foreground">
+              Subscribers only
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Subscribe to @{username} to watch this stream and their subscriber
+              content.
+            </p>
+          </div>
+
+          <Button
+            type="button"
+            onClick={() => {
+              window.location.href = `/subscriptions?creator=${encodeURIComponent(username)}`;
+            }}
+            className="w-full bg-highlight hover:bg-highlight/90 text-white"
+          >
+            Subscribe for {priceLabel}
+          </Button>
+          <p className="text-xs text-muted-foreground text-center mt-3">
+            Paid in USDC on Stellar &middot; Cancel anytime
+          </p>
+        </div>
       </div>
     );
   }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -47,6 +47,21 @@ ADD COLUMN IF NOT EXISTS following UUID[];
 ALTER TABLE users
 ADD COLUMN IF NOT EXISTS stream_password_hash VARCHAR(255);
 
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS stream_access_type TEXT DEFAULT 'public'
+CHECK (stream_access_type IN ('public', 'password', 'subscription'));
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscriber_id UUID REFERENCES users(id),
+  streamer_id UUID REFERENCES users(id),
+  price_usdc NUMERIC(10,2) NOT NULL,
+  status TEXT NOT NULL,
+  current_period_end TIMESTAMPTZ NOT NULL,
+  tx_hash TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
 CREATE TABLE IF NOT EXISTS stream_sessions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID REFERENCES users(id) ON DELETE CASCADE,

--- a/lib/stream/access.ts
+++ b/lib/stream/access.ts
@@ -1,0 +1,31 @@
+import { sql } from "@vercel/postgres";
+
+export type StreamAccessReason = "password" | "subscription";
+
+export type AccessResult =
+  | { allowed: true }
+  | { allowed: false; reason: StreamAccessReason };
+
+export async function checkSubscriptionAccess(
+  streamerId: string,
+  viewerPublicKey: string | null
+): Promise<AccessResult> {
+  if (!viewerPublicKey) {
+    return { allowed: false, reason: "subscription" };
+  }
+
+  const { rows } = await sql`
+    SELECT id FROM subscriptions
+    WHERE streamer_id = ${streamerId}
+      AND subscriber_id = (
+        SELECT id FROM users WHERE LOWER(wallet) = LOWER(${viewerPublicKey})
+      )
+      AND status = 'active'
+      AND current_period_end > now()
+    LIMIT 1
+  `;
+
+  return rows.length > 0
+    ? { allowed: true }
+    : { allowed: false, reason: "subscription" };
+}


### PR DESCRIPTION
## Description
Implements the routes-f wheel spinner, platform status API, MAC validator/formatter, and subscription-gated stream access pieces in one PR so the linked issues can close together.

Closes #668
Closes #403
Closes #676
Closes #377

## Changes proposed

### What were you told to do?
Add three routes-f API features with tests and implement subscription-gated streams, after syncing from upstream, then close all four issues in one PR.

### What did I do?
#### Routes-f utilities
- Added `/api/routes-f/wheel` with seeded deterministic weighted spins, keep mode, elimination mode, caps, and tests.
- Added `/api/routes-f/mac-validate` with common MAC notation parsing, formatting, multicast/unicast/local-admin detection, bundled OUI lookup, and tests.
- Added `/api/routes-f/status`, `/history`, `/incidents`, and `/incidents/[id]` with health overlay, active incident listing, update history, 90-day uptime, DB schema creation, in-memory fallback for local tests, and tests.

#### Subscription-gated streams
- Added `checkSubscriptionAccess()` in `lib/stream/access.ts` using active subscription period checks.
- Extended stream access checking and watch-page gating for `stream_access_type: 'subscription'`.
- Added a subscriber-only AccessGate variant with Subscribe CTA.
- Added stream access selection in stream preferences, disabled subscriber access when no subscription price is available.
- Added schema support for `stream_access_type` and `subscriptions`.

#### Build hook fixes
- Cleared stale generated Next types locally and fixed small existing type blockers in routes-f domain, sudoku, and shorten code so the required commit hook could pass without bypassing hooks.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --runTestsByPath app/api/routes-f/wheel/__tests__/route.test.ts app/api/routes-f/mac-validate/__tests__/route.test.ts app/api/routes-f/status/__tests__/route.test.ts --runInBand` passed: 16 tests.
- `npm test -- --runTestsByPath app/api/routes-f/sudoku/__tests__/route.test.ts --runInBand` passed: 5 tests.
- `npm run type-check` passed.
- Commit hook completed `npm run type-check` and `npm run build` successfully. Build emitted existing environment warnings for missing local Mux/Postgres/Upstash credentials, but completed successfully.