### PR TITLE
feat(routes-f): implement apikey, macro, hashtag, and text reverse APIs

### DIFF
--- a/app/api/routes-f/apikey-gen/route.test.ts
+++ b/app/api/routes-f/apikey-gen/route.test.ts
@@ -1,0 +1,52 @@
+import { POST } from './route';
+
+describe('apikey-gen route', () => {
+  it('generates a key with default parameters', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({})
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.keys).toBeDefined();
+    expect(data.keys.length).toBe(1);
+    expect(data.keys[0].key.length).toBe(32);
+    expect(data.keys[0].fingerprint.length).toBe(16);
+  });
+
+  it('generates multiple keys and ensures uniqueness', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ count: 50 })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.keys.length).toBe(50);
+    const keys = data.keys.map((k: any) => k.key);
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(50); // Uniqueness check
+  });
+
+  it('adds prefix', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ prefix: 'test' })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.keys[0].key.startsWith('test_')).toBe(true);
+  });
+
+  it('adds checksum', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ with_checksum: true })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    const keyParts = data.keys[0].key.split('-');
+    expect(keyParts.length).toBeGreaterThan(1);
+    const checksum = keyParts.pop();
+    expect(checksum?.length).toBe(8); // CRC32 is 8 hex chars
+  });
+});

--- a/app/api/routes-f/apikey-gen/route.ts
+++ b/app/api/routes-f/apikey-gen/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+function generateChecksum(key: string): string {
+  // basic CRC32 style checksum logic
+  let crc = 0xFFFFFFFF;
+  for (let i = 0; i < key.length; i++) {
+    crc ^= key.charCodeAt(i);
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ ((crc & 1) ? 0xEDB88320 : 0);
+    }
+  }
+  return (crc ^ 0xFFFFFFFF).toString(16).padStart(8, '0');
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    let { count = 1, prefix = '', length = 32, with_checksum = false } = body;
+
+    count = Math.max(1, Math.min(100, Number(count) || 1));
+    length = Math.max(8, Math.min(128, Number(length) || 32));
+
+    const keys = [];
+
+    for (let i = 0; i < count; i++) {
+      const entropyBytes = Math.ceil(length / 2);
+      let randomPart = crypto.randomBytes(entropyBytes).toString('hex').slice(0, length);
+      
+      let key = prefix ? `${prefix}_${randomPart}` : randomPart;
+
+      if (with_checksum) {
+        const checksum = generateChecksum(key);
+        key = `${key}-${checksum}`;
+      }
+
+      const fingerprint = crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
+
+      keys.push({ key, fingerprint });
+    }
+
+    return NextResponse.json({ keys });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/hashtag-extract/route.test.ts
+++ b/app/api/routes-f/hashtag-extract/route.test.ts
@@ -1,0 +1,30 @@
+import { POST } from './route';
+
+describe('hashtag-extract route', () => {
+  it('extracts hashtags, mentions, urls and handles dedup/urls correctly', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'Hello @world! Check this out https://example.com/#notahashtag #cool #cool'
+      })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.urls).toContain('https://example.com/#notahashtag');
+    expect(data.hashtags).toContain('#cool');
+    expect(data.hashtags.length).toBe(1); // deduplication
+    expect(data.hashtags).not.toContain('#notahashtag'); // excludes hashtag in url
+    expect(data.mentions).toContain('@world');
+  });
+
+  it('rejects input over 100KB', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'a'.repeat(100 * 1024 + 1)
+      })
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+});

--- a/app/api/routes-f/hashtag-extract/route.ts
+++ b/app/api/routes-f/hashtag-extract/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { text } = body;
+
+    if (typeof text !== 'string') {
+      return NextResponse.json({ error: 'Invalid text' }, { status: 400 });
+    }
+
+    if (text.length > 100 * 1024) {
+      return NextResponse.json({ error: 'Input too large' }, { status: 413 });
+    }
+
+    const urlRegex = /https?:\/\/[^\s]+/gi;
+    const urlsMatches = text.match(urlRegex) || [];
+    
+    // Remove URLs from text to avoid hashtag/mention extraction from them
+    let cleanText = text;
+    for (const url of urlsMatches) {
+        cleanText = cleanText.replace(url, ' ');
+    }
+
+    const hashtagRegex = /#\w+/g;
+    const mentionRegex = /@\w+/g;
+
+    const hashtagsMatches = cleanText.match(hashtagRegex) || [];
+    const mentionsMatches = cleanText.match(mentionRegex) || [];
+
+    const urls = Array.from(new Set(urlsMatches));
+    const hashtags = Array.from(new Set(hashtagsMatches));
+    const mentions = Array.from(new Set(mentionsMatches));
+
+    return NextResponse.json({ hashtags, mentions, urls });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/macro-nutrients/route.test.ts
+++ b/app/api/routes-f/macro-nutrients/route.test.ts
@@ -1,0 +1,57 @@
+import { POST } from './route';
+
+describe('macro-nutrients route', () => {
+  it('calculates macros for male sedentary maintain', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        weight_kg: 70,
+        height_cm: 175,
+        age: 30,
+        sex: 'male',
+        activity_level: 'sedentary',
+        goal: 'maintain'
+      })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.bmr).toBeDefined();
+    expect(data.tdee).toBeDefined();
+    expect(data.target_calories).toBeDefined();
+    expect(data.macros).toBeDefined();
+  });
+
+  it('calculates macros for female active lose', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        weight_kg: 60,
+        height_cm: 160,
+        age: 25,
+        sex: 'female',
+        activity_level: 'active',
+        goal: 'lose'
+      })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.target_calories).toBeLessThan(data.tdee); // because goal is lose
+  });
+
+  it('calculates macros for male very_active gain', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({
+        weight_kg: 80,
+        height_cm: 180,
+        age: 22,
+        sex: 'male',
+        activity_level: 'very_active',
+        goal: 'gain'
+      })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.target_calories).toBeGreaterThan(data.tdee); // because goal is gain
+  });
+});

--- a/app/api/routes-f/macro-nutrients/route.ts
+++ b/app/api/routes-f/macro-nutrients/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { weight_kg, height_cm, age, sex, activity_level, goal } = body;
+
+    if (!weight_kg || !height_cm || !age || !sex || !activity_level || !goal) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    // BMR Mifflin-St Jeor
+    let bmr = 10 * weight_kg + 6.25 * height_cm - 5 * age;
+    if (sex === 'male') {
+      bmr += 5;
+    } else if (sex === 'female') {
+      bmr -= 161;
+    } else {
+      return NextResponse.json({ error: 'Invalid sex' }, { status: 400 });
+    }
+
+    const activityMultipliers: Record<string, number> = {
+      sedentary: 1.2,
+      light: 1.375,
+      moderate: 1.55,
+      active: 1.725,
+      very_active: 1.9
+    };
+
+    const multiplier = activityMultipliers[activity_level];
+    if (!multiplier) {
+      return NextResponse.json({ error: 'Invalid activity_level' }, { status: 400 });
+    }
+
+    let tdee = bmr * multiplier;
+    let target_calories = tdee;
+
+    if (goal === 'lose') {
+      target_calories -= 500;
+    } else if (goal === 'gain') {
+      target_calories += 500;
+    } else if (goal !== 'maintain') {
+      return NextResponse.json({ error: 'Invalid goal' }, { status: 400 });
+    }
+
+    const protein_cals = target_calories * 0.3;
+    const carbs_cals = target_calories * 0.4;
+    const fat_cals = target_calories * 0.3;
+
+    const protein_g = Math.round(protein_cals / 4);
+    const carbs_g = Math.round(carbs_cals / 4);
+    const fat_g = Math.round(fat_cals / 9);
+
+    const water_ml = weight_kg * 35; // simple heuristic
+
+    return NextResponse.json({
+      bmr: Math.round(bmr),
+      tdee: Math.round(tdee),
+      target_calories: Math.round(target_calories),
+      macros: {
+        protein_g,
+        carbs_g,
+        fat_g
+      },
+      water_ml: Math.round(water_ml),
+      disclaimer: "This provides general guidance and is not medical advice."
+    });
+
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/reverse-text/route.test.ts
+++ b/app/api/routes-f/reverse-text/route.test.ts
@@ -1,0 +1,52 @@
+import { POST } from './route';
+
+describe('reverse-text route', () => {
+  it('reverses by char with emojis', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'abc 🚀', mode: 'char' })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('🚀 cba');
+  });
+
+  it('reverses by word preserving whitespace', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'hello   world \n test', mode: 'word' })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('test   world \n hello');
+  });
+
+  it('reverses by sentence', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'Hello. How are you? I am fine.', mode: 'sentence' })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('I am fine. How are you? Hello.');
+  });
+
+  it('reverses by line', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'line1\nline2\nline3', mode: 'line' })
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('line3\nline2\nline1');
+  });
+  
+  it('rejects input over 1MB', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'a'.repeat(1024 * 1024 + 1), mode: 'char' })
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+});

--- a/app/api/routes-f/reverse-text/route.ts
+++ b/app/api/routes-f/reverse-text/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { text, mode } = body;
+
+    if (typeof text !== 'string' || !mode) {
+      return NextResponse.json({ error: 'Missing text or mode' }, { status: 400 });
+    }
+
+    if (text.length > 1024 * 1024) {
+      return NextResponse.json({ error: 'Input too large' }, { status: 413 });
+    }
+
+    let result = '';
+
+    if (mode === 'char') {
+      result = Array.from(text).reverse().join('');
+    } else if (mode === 'word') {
+      // preserve whitespace structure
+      const wordsAndSpaces = text.match(/(\s+|\S+)/g) || [];
+      const words = wordsAndSpaces.filter(w => /\S/.test(w)).reverse();
+      let wordIndex = 0;
+      result = wordsAndSpaces.map(part => {
+        if (/\S/.test(part)) {
+          return words[wordIndex++];
+        }
+        return part; // keep spaces
+      }).join('');
+    } else if (mode === 'sentence') {
+      const sentencesAndSpaces = text.match(/([^.!?]+[.!?]+|\s+)/g) || [text];
+      const sentences = sentencesAndSpaces.filter(s => /\S/.test(s)).reverse();
+      let sentenceIndex = 0;
+      result = sentencesAndSpaces.map(part => {
+        if (/\S/.test(part)) {
+          return sentences[sentenceIndex++];
+        }
+        return part;
+      }).join('');
+    } else if (mode === 'line') {
+      result = text.split(/\r?\n/).reverse().join('\n');
+    } else {
+      return NextResponse.json({ error: 'Invalid mode' }, { status: 400 });
+    }
+
+    return NextResponse.json({ result, mode });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}


### PR DESCRIPTION
# Pull Request

## Summary
This pull request implements four independent API route handlers within the `app/api/routes-f/` directory. These isolated utilities provide functionality for API key generation, macro nutrient calculation, hashtag and mention extraction, and text string reversal with multiple modes. All functionalities are accompanied by their respective tests and are fully scoped to their designated directories to ensure they remain independent and mergeable.

## Changes Included
- Added `apikey-gen` endpoint for secure, customizable key generation with prefix and checksum support.
- Added `macro-nutrients` endpoint utilizing the Mifflin-St Jeor equation to compute BMR, TDEE, and macro splits based on user goals.
- Added `hashtag-extract` endpoint using regex to extract deduplicated hashtags and mentions, while safely filtering out URLs.
- Added `reverse-text` endpoint handling word, sentence, line, and character-level reversals while preserving surrogate pairs and whitespace structures.

## Related Issues
Closes #739
Closes #733
Closes #740
Closes #742