### PR TITLE
feat(routes-f): add robots.txt and notation utilities

### DIFF
--- a/app/api/routes-f/__tests__/robots-txt.test.ts
+++ b/app/api/routes-f/__tests__/robots-txt.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../robots-txt/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/robots-txt", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/robots-txt", () => {
+  it("generates robots.txt for multiple agents", async () => {
+    const res = await POST(
+      makeReq({
+        rules: [
+          { user_agent: "*", allow: ["/"], disallow: ["/private"] },
+          { user_agent: "Googlebot", disallow: ["/no-google"] },
+        ],
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.robots_txt).toBe(
+      "User-agent: *\nAllow: /\nDisallow: /private\n\nUser-agent: Googlebot\nDisallow: /no-google\n"
+    );
+  });
+
+  it("includes a sitemap line when provided", async () => {
+    const res = await POST(
+      makeReq({
+        rules: [{ user_agent: "*", disallow: ["/drafts"] }],
+        sitemap: "https://example.com/sitemap.xml",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.robots_txt).toContain("Sitemap: https://example.com/sitemap.xml");
+  });
+
+  it("rejects requests without at least one rule", async () => {
+    const res = await POST(makeReq({ rules: [] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/__tests__/scientific-notation.test.ts
+++ b/app/api/routes-f/__tests__/scientific-notation.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../scientific-notation/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/scientific-notation", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/scientific-notation", () => {
+  it("formats large numbers in scientific notation", async () => {
+    const res = await POST(makeReq({ mode: "format", value: 1230000, sig_figs: 3 }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.result).toBe("1.23e6");
+  });
+
+  it("parses scientific notation back to a number", async () => {
+    const res = await POST(makeReq({ mode: "parse", value: "1.23e6" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.result).toBe(1230000);
+  });
+
+  it("formats small magnitudes", async () => {
+    const res = await POST(makeReq({ mode: "format", value: 0.0000012, sig_figs: 2 }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.result).toBe("1.2e-6");
+  });
+
+  it("formats and parses negative engineering notation", async () => {
+    const formatRes = await POST(
+      makeReq({ mode: "format", value: -4560, sig_figs: 3, style: "engineering" })
+    );
+    expect(formatRes.status).toBe(200);
+    const formatted = await formatRes.json();
+    expect(formatted.result).toBe("-4.56 k");
+
+    const parseRes = await POST(makeReq({ mode: "parse", value: "-4.56 k", style: "engineering" }));
+    expect(parseRes.status).toBe(200);
+    const parsed = await parseRes.json();
+    expect(parsed.result).toBeCloseTo(-4560);
+  });
+
+  it("rejects invalid modes", async () => {
+    const res = await POST(makeReq({ mode: "convert", value: 42 }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/robots-txt/_lib/helpers.ts
+++ b/app/api/routes-f/robots-txt/_lib/helpers.ts
@@ -1,0 +1,73 @@
+import type { RobotsRule } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} must not be empty.`);
+  }
+
+  return trimmed;
+}
+
+function normalizePathList(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`${field} must be an array of strings.`);
+  }
+
+  return value.map((item, index) => normalizeString(item, `${field}[${index}]`));
+}
+
+function normalizeRule(value: unknown, index: number): RobotsRule {
+  if (!isRecord(value)) {
+    throw new Error(`rules[${index}] must be an object.`);
+  }
+
+  return {
+    user_agent: normalizeString(value.user_agent, `rules[${index}].user_agent`),
+    allow: normalizePathList(value.allow, `rules[${index}].allow`),
+    disallow: normalizePathList(value.disallow, `rules[${index}].disallow`),
+  };
+}
+
+export function buildRobotsTxt(input: unknown): string {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  if (!Array.isArray(input.rules) || input.rules.length === 0) {
+    throw new Error("rules must contain at least one rule.");
+  }
+
+  const rules = input.rules.map(normalizeRule);
+  const sections = rules.map((rule) => {
+    const lines = [`User-agent: ${rule.user_agent}`];
+
+    for (const path of rule.allow ?? []) {
+      lines.push(`Allow: ${path}`);
+    }
+
+    for (const path of rule.disallow ?? []) {
+      lines.push(`Disallow: ${path}`);
+    }
+
+    return lines.join("\n");
+  });
+
+  if (input.sitemap !== undefined) {
+    sections.push(`Sitemap: ${normalizeString(input.sitemap, "sitemap")}`);
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}

--- a/app/api/routes-f/robots-txt/_lib/types.ts
+++ b/app/api/routes-f/robots-txt/_lib/types.ts
@@ -1,0 +1,9 @@
+export interface RobotsRule {
+  user_agent: string;
+  allow?: string[];
+  disallow?: string[];
+}
+
+export interface RobotsResponse {
+  robots_txt: string;
+}

--- a/app/api/routes-f/robots-txt/route.ts
+++ b/app/api/routes-f/robots-txt/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { buildRobotsTxt } from "./_lib/helpers";
+import type { RobotsResponse } from "./_lib/types";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    const robotsTxt = buildRobotsTxt(body);
+    return NextResponse.json({ robots_txt: robotsTxt } satisfies RobotsResponse);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to build robots.txt.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/scientific-notation/_lib/helpers.ts
+++ b/app/api/routes-f/scientific-notation/_lib/helpers.ts
@@ -1,0 +1,190 @@
+import type { NotationResponse, NotationStyle } from "./types";
+
+const SI_PREFIXES = new Map<number, string>([
+  [-24, "y"],
+  [-21, "z"],
+  [-18, "a"],
+  [-15, "f"],
+  [-12, "p"],
+  [-9, "n"],
+  [-6, "u"],
+  [-3, "m"],
+  [0, ""],
+  [3, "k"],
+  [6, "M"],
+  [9, "G"],
+  [12, "T"],
+  [15, "P"],
+  [18, "E"],
+  [21, "Z"],
+  [24, "Y"],
+]);
+
+const SI_EXPONENTS = new Map<string, number>([
+  ["", 0],
+  ["y", -24],
+  ["z", -21],
+  ["a", -18],
+  ["f", -15],
+  ["p", -12],
+  ["n", -9],
+  ["u", -6],
+  ["\u00b5", -6],
+  ["\u03bc", -6],
+  ["m", -3],
+  ["k", 3],
+  ["K", 3],
+  ["M", 6],
+  ["G", 9],
+  ["T", 12],
+  ["P", 15],
+  ["E", 18],
+  ["Z", 21],
+  ["Y", 24],
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStyle(value: unknown): NotationStyle {
+  if (value === undefined) {
+    return "scientific";
+  }
+
+  if (value === "scientific" || value === "engineering") {
+    return value;
+  }
+
+  throw new Error("style must be scientific or engineering.");
+}
+
+function normalizeSigFigs(value: unknown): number {
+  if (value === undefined) {
+    return 3;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 15) {
+    throw new Error("sig_figs must be an integer from 1 to 15.");
+  }
+
+  return value;
+}
+
+function finiteNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function normalizeExponent(exponentPart: string): number {
+  return Number.parseInt(exponentPart.replace("+", ""), 10);
+}
+
+export function formatScientific(value: number, sigFigs = 3): string {
+  if (Object.is(value, 0) || value === 0) {
+    return "0e0";
+  }
+
+  const [coefficient, exponentPart] = value.toExponential(sigFigs - 1).split("e");
+  return `${coefficient}e${normalizeExponent(exponentPart)}`;
+}
+
+export function formatEngineering(value: number, sigFigs = 3): string {
+  if (Object.is(value, 0) || value === 0) {
+    return "0";
+  }
+
+  let exponent = Math.floor(Math.log10(Math.abs(value)) / 3) * 3;
+  let coefficient = value / 10 ** exponent;
+  let coefficientText = coefficient.toPrecision(sigFigs);
+
+  if (Math.abs(Number(coefficientText)) >= 1000) {
+    exponent += 3;
+    coefficient = value / 10 ** exponent;
+    coefficientText = coefficient.toPrecision(sigFigs);
+  }
+
+  const suffix = SI_PREFIXES.get(exponent);
+  if (suffix === undefined) {
+    return `${coefficientText}e${exponent}`;
+  }
+
+  return suffix ? `${coefficientText} ${suffix}` : coefficientText;
+}
+
+export function parseScientific(value: unknown): number {
+  if (typeof value === "number") {
+    return finiteNumber(value, "value");
+  }
+
+  if (typeof value !== "string") {
+    throw new Error("value must be a string or finite number.");
+  }
+
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed)) {
+    throw new Error("value must be valid scientific notation.");
+  }
+
+  return parsed;
+}
+
+export function parseEngineering(value: unknown): number {
+  if (typeof value === "number") {
+    return finiteNumber(value, "value");
+  }
+
+  if (typeof value !== "string") {
+    throw new Error("value must be a string or finite number.");
+  }
+
+  const match = value
+    .trim()
+    .match(
+      /^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)\s*([A-Za-z]|\u00b5|\u03bc)?$/
+    );
+
+  if (!match) {
+    throw new Error("value must be valid engineering notation.");
+  }
+
+  const numberPart = Number(match[1]);
+  const suffix = match[2] ?? "";
+  const exponent = SI_EXPONENTS.get(suffix);
+
+  if (!Number.isFinite(numberPart) || exponent === undefined) {
+    throw new Error("value must be valid engineering notation.");
+  }
+
+  return numberPart * 10 ** exponent;
+}
+
+export function processNotation(input: unknown): NotationResponse {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  const style = normalizeStyle(input.style);
+
+  if (input.mode === "format") {
+    const value = finiteNumber(input.value, "value");
+    const sigFigs = normalizeSigFigs(input.sig_figs);
+    const result =
+      style === "engineering"
+        ? formatEngineering(value, sigFigs)
+        : formatScientific(value, sigFigs);
+
+    return { result };
+  }
+
+  if (input.mode === "parse") {
+    const result =
+      style === "engineering" ? parseEngineering(input.value) : parseScientific(input.value);
+    return { result };
+  }
+
+  throw new Error("mode must be format or parse.");
+}

--- a/app/api/routes-f/scientific-notation/_lib/types.ts
+++ b/app/api/routes-f/scientific-notation/_lib/types.ts
@@ -1,0 +1,6 @@
+export type NotationMode = "format" | "parse";
+export type NotationStyle = "scientific" | "engineering";
+
+export interface NotationResponse {
+  result: number | string;
+}

--- a/app/api/routes-f/scientific-notation/route.ts
+++ b/app/api/routes-f/scientific-notation/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { processNotation } from "./_lib/helpers";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    return NextResponse.json(processNotation(body));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to process notation.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}


### PR DESCRIPTION
Closes #798
Closes #802
Closes #797
Closes #800

## Changes
- Add `POST /api/routes-f/robots-txt` to generate robots.txt content from structured rules and optional sitemap input.
- Add `POST /api/routes-f/scientific-notation` to format and parse scientific or engineering notation.
- Add focused Jest coverage for multiple robots agents, sitemap inclusion, large/small notation values, and negative engineering values.

## Testing
- `npx.cmd --yes -p typescript@5.9.3 tsc --noEmit --target ES2017 --module ESNext --moduleResolution Bundler --strict app/api/routes-f/robots-txt/_lib/helpers.ts app/api/routes-f/robots-txt/_lib/types.ts app/api/routes-f/scientific-notation/_lib/helpers.ts app/api/routes-f/scientific-notation/_lib/types.ts`
- Full Jest suite not run; pushed as requested without waiting on CI.
