### PR TITLE
feat(routesF): add numeric utility endpoints

### DIFF
--- a/app/api/routesF/__tests__/clamp-normalize.test.ts
+++ b/app/api/routesF/__tests__/clamp-normalize.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../clamp-normalize/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/clamp-normalize", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/clamp-normalize", () => {
+  it("clamps values below the range", async () => {
+    const res = await POST(makeReq({ value: -5, min: 0, max: 10 }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ clamped: 0 });
+  });
+
+  it("keeps values within the range", async () => {
+    const res = await POST(makeReq({ value: 6, min: 0, max: 10 }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ clamped: 6 });
+  });
+
+  it("clamps values above the range", async () => {
+    const res = await POST(makeReq({ value: 15, min: 0, max: 10, normalize: true }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ clamped: 10, normalized: 1 });
+  });
+
+  it("normalizes clamped values to the 0-1 range", async () => {
+    const res = await POST(makeReq({ value: 5, min: 0, max: 10, normalize: true }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ clamped: 5, normalized: 0.5 });
+  });
+
+  it("rejects ranges where min is greater than max", async () => {
+    const res = await POST(makeReq({ value: 5, min: 10, max: 0 }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/__tests__/interpolation.test.ts
+++ b/app/api/routesF/__tests__/interpolation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../interpolation/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/interpolation", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/interpolation", () => {
+  it("returns the midpoint between two values in lerp mode", async () => {
+    const res = await POST(makeReq({ mode: "lerp", a: 10, b: 20, t: 0.5 }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ result: 15 });
+  });
+
+  it("maps a value from one range to another", async () => {
+    const res = await POST(
+      makeReq({ mode: "map", value: 5, in_min: 0, in_max: 10, out_min: 0, out_max: 100 })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ result: 50 });
+  });
+
+  it("maps reversed output ranges", async () => {
+    const res = await POST(
+      makeReq({ mode: "map", value: 25, in_min: 0, in_max: 100, out_min: 1, out_max: 0 })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ result: 0.75 });
+  });
+
+  it("rejects unknown modes", async () => {
+    const res = await POST(makeReq({ mode: "scale", value: 5 }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects zero-width input ranges in map mode", async () => {
+    const res = await POST(
+      makeReq({ mode: "map", value: 5, in_min: 1, in_max: 1, out_min: 0, out_max: 10 })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/clamp-normalize/route.ts
+++ b/app/api/routesF/clamp-normalize/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type ClampBody = {
+  value?: unknown;
+  min?: unknown;
+  max?: unknown;
+  normalize?: unknown;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: ClampBody;
+
+  try {
+    body = (await req.json()) as ClampBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { value, min, max, normalize } = body;
+
+  if (!isFiniteNumber(value) || !isFiniteNumber(min) || !isFiniteNumber(max)) {
+    return badRequest("value, min, and max must be finite numbers.");
+  }
+
+  if (min > max) {
+    return badRequest("min must be less than or equal to max.");
+  }
+
+  const clamped = Math.min(Math.max(value, min), max);
+
+  if (normalize === true) {
+    const normalized = min === max ? 0 : (clamped - min) / (max - min);
+    return NextResponse.json({ clamped, normalized });
+  }
+
+  return NextResponse.json({ clamped });
+}

--- a/app/api/routesF/interpolation/route.ts
+++ b/app/api/routesF/interpolation/route.ts
@@ -1,0 +1,64 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type InterpolationBody = {
+  mode?: unknown;
+  a?: unknown;
+  b?: unknown;
+  t?: unknown;
+  value?: unknown;
+  in_min?: unknown;
+  in_max?: unknown;
+  out_min?: unknown;
+  out_max?: unknown;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: InterpolationBody;
+
+  try {
+    body = (await req.json()) as InterpolationBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  if (body.mode === "lerp") {
+    const { a, b, t } = body;
+
+    if (!isFiniteNumber(a) || !isFiniteNumber(b) || !isFiniteNumber(t)) {
+      return badRequest("a, b, and t must be finite numbers.");
+    }
+
+    return NextResponse.json({ result: a + (b - a) * t });
+  }
+
+  if (body.mode === "map") {
+    const { value, in_min, in_max, out_min, out_max } = body;
+
+    if (
+      !isFiniteNumber(value) ||
+      !isFiniteNumber(in_min) ||
+      !isFiniteNumber(in_max) ||
+      !isFiniteNumber(out_min) ||
+      !isFiniteNumber(out_max)
+    ) {
+      return badRequest("value, in_min, in_max, out_min, and out_max must be finite numbers.");
+    }
+
+    if (in_min === in_max) {
+      return badRequest("in_min and in_max must be different values.");
+    }
+
+    const ratio = (value - in_min) / (in_max - in_min);
+    return NextResponse.json({ result: out_min + ratio * (out_max - out_min) });
+  }
+
+  return badRequest("mode must be either lerp or map.");
+}


### PR DESCRIPTION
Closes #814
Closes #815
Closes #801
Closes #812

## Changes
- Add POST `/api/routesF/clamp-normalize` for clamping values and optional 0-1 normalization.
- Add POST `/api/routesF/interpolation` for `lerp` and range `map` modes.
- Add scoped Jest tests under `app/api/routesF/__tests__` for both endpoints.

## Testing
- Not run locally because this checkout did not contain the full repository files or installed dependencies.