### PR TITLE
feat(routes-f): percentage-change, char-frequency, hex-dump, and cipher utilities

### DIFF
--- a/app/api/routes-f/char-frequency/__tests__/route.test.ts
+++ b/app/api/routes-f/char-frequency/__tests__/route.test.ts
@@ -1,0 +1,34 @@
+import { charFrequency } from "../route";
+
+describe("charFrequency", () => {
+  it("counts characters and sorts by count descending", () => {
+    const { frequencies, total } = charFrequency("aaabb");
+    expect(total).toBe(5);
+    expect(frequencies).toEqual([
+      { char: "a", count: 3 },
+      { char: "b", count: 2 },
+    ]);
+  });
+
+  it("is case-insensitive by default and case-sensitive on request", () => {
+    expect(charFrequency("aA").frequencies).toEqual([{ char: "a", count: 2 }]);
+    expect(charFrequency("aA", { caseSensitive: true }).frequencies).toEqual([
+      { char: "A", count: 1 },
+      { char: "a", count: 1 },
+    ]);
+  });
+
+  it("can ignore whitespace", () => {
+    const { frequencies, total } = charFrequency("a b\tc", {
+      ignoreWhitespace: true,
+    });
+    expect(total).toBe(3);
+    expect(frequencies.find((f) => /\s/.test(f.char))).toBeUndefined();
+  });
+
+  it("limits results with top", () => {
+    const { frequencies } = charFrequency("aaabbc", { top: 2 });
+    expect(frequencies).toHaveLength(2);
+    expect(frequencies[0]).toEqual({ char: "a", count: 3 });
+  });
+});

--- a/app/api/routes-f/char-frequency/route.ts
+++ b/app/api/routes-f/char-frequency/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const MAX_INPUT_BYTES = 1_000_000;
+
+export interface CharCount {
+  char: string;
+  count: number;
+}
+
+export interface CharFrequencyResult {
+  frequencies: CharCount[];
+  total: number;
+}
+
+export interface CharFrequencyOptions {
+  caseSensitive?: boolean;
+  ignoreWhitespace?: boolean;
+  top?: number;
+}
+
+/**
+ * Count character frequency in `text`, sorted by count descending (ties broken
+ * by character for stable output). `total` is the number of counted characters.
+ */
+export function charFrequency(
+  text: string,
+  { caseSensitive = false, ignoreWhitespace = false, top }: CharFrequencyOptions = {},
+): CharFrequencyResult {
+  const normalized = caseSensitive ? text : text.toLowerCase();
+  const counts = new Map<string, number>();
+  let total = 0;
+
+  for (const char of normalized) {
+    if (ignoreWhitespace && /\s/.test(char)) continue;
+    counts.set(char, (counts.get(char) ?? 0) + 1);
+    total += 1;
+  }
+
+  let frequencies: CharCount[] = Array.from(counts, ([char, count]) => ({
+    char,
+    count,
+  })).sort((a, b) => b.count - a.count || a.char.localeCompare(b.char));
+
+  if (top !== undefined) {
+    frequencies = frequencies.slice(0, top);
+  }
+
+  return { frequencies, total };
+}
+
+const schema = z.object({
+  text: z.string().max(MAX_INPUT_BYTES, "text exceeds 1MB limit"),
+  case_sensitive: z.boolean().optional(),
+  ignore_whitespace: z.boolean().optional(),
+  top: z.number().int().positive().optional(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { text, case_sensitive, ignore_whitespace, top } = result.data;
+  return NextResponse.json(
+    charFrequency(text, {
+      caseSensitive: case_sensitive,
+      ignoreWhitespace: ignore_whitespace,
+      top,
+    }),
+  );
+}

--- a/app/api/routes-f/ciphers/__tests__/route.test.ts
+++ b/app/api/routes-f/ciphers/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import {
+  atbash,
+  railFenceEncode,
+  railFenceDecode,
+} from "../route";
+
+describe("atbash", () => {
+  it("mirrors letters and is its own inverse", () => {
+    expect(atbash("abc")).toBe("zyx");
+    expect(atbash("Hello")).toBe("Svool");
+    expect(atbash(atbash("Round Trip!"))).toBe("Round Trip!");
+  });
+
+  it("leaves non-letters untouched", () => {
+    expect(atbash("a1 b2")).toBe("z1 y2");
+  });
+});
+
+describe("rail fence", () => {
+  it("encodes with the classic zig-zag", () => {
+    // "WEAREDISCOVEREDFLEEATONCE" with 3 rails -> known result
+    expect(railFenceEncode("WEAREDISCOVEREDFLEEATONCE", 3)).toBe(
+      "WECRLTEERDSOEEFEAOCAIVDEN",
+    );
+  });
+
+  it("round-trips encode -> decode for several rail counts", () => {
+    const text = "the quick brown fox";
+    for (const rails of [2, 3, 4, 5]) {
+      expect(railFenceDecode(railFenceEncode(text, rails), rails)).toBe(text);
+    }
+  });
+});

--- a/app/api/routes-f/ciphers/route.ts
+++ b/app/api/routes-f/ciphers/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+/**
+ * Atbash cipher: maps each Latin letter to its mirror (a<->z, A<->Z). It is its
+ * own inverse, so encoding and decoding are identical.
+ */
+export function atbash(text: string): string {
+  return text
+    .replace(/[a-z]/g, (c) => String.fromCharCode(219 - c.charCodeAt(0)))
+    .replace(/[A-Z]/g, (c) => String.fromCharCode(155 - c.charCodeAt(0)));
+}
+
+/** Index of the zig-zag rail each character lands on, for a given length. */
+function railPattern(length: number, rails: number): number[] {
+  const pattern: number[] = [];
+  let row = 0;
+  let dir = 1;
+  for (let i = 0; i < length; i += 1) {
+    pattern.push(row);
+    if (row === 0) dir = 1;
+    else if (row === rails - 1) dir = -1;
+    row += dir;
+  }
+  return pattern;
+}
+
+export function railFenceEncode(text: string, rails: number): string {
+  const rows: string[] = Array.from({ length: rails }, () => "");
+  const pattern = railPattern(text.length, rails);
+  for (let i = 0; i < text.length; i += 1) {
+    rows[pattern[i]] += text[i];
+  }
+  return rows.join("");
+}
+
+export function railFenceDecode(cipher: string, rails: number): string {
+  const pattern = railPattern(cipher.length, rails);
+
+  const perRail = Array.from({ length: rails }, (_, r) =>
+    pattern.filter((p) => p === r).length,
+  );
+  const railStrings: string[] = [];
+  let idx = 0;
+  for (let r = 0; r < rails; r += 1) {
+    railStrings.push(cipher.slice(idx, idx + perRail[r]));
+    idx += perRail[r];
+  }
+
+  const railCursor = new Array(rails).fill(0);
+  let out = "";
+  for (let i = 0; i < cipher.length; i += 1) {
+    const r = pattern[i];
+    out += railStrings[r][railCursor[r]];
+    railCursor[r] += 1;
+  }
+  return out;
+}
+
+const schema = z
+  .object({
+    text: z.string(),
+    cipher: z.enum(["atbash", "railfence"]),
+    rails: z.number().int().min(2).optional(),
+    mode: z.enum(["encode", "decode"]),
+  })
+  .refine((v) => v.cipher !== "railfence" || v.rails !== undefined, {
+    message: "rails (>= 2) is required for the railfence cipher",
+    path: ["rails"],
+  });
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { text, cipher, rails, mode } = result.data;
+
+  let output: string;
+  if (cipher === "atbash") {
+    // Symmetric — mode does not change the result.
+    output = atbash(text);
+  } else {
+    output =
+      mode === "encode"
+        ? railFenceEncode(text, rails as number)
+        : railFenceDecode(text, rails as number);
+  }
+
+  return NextResponse.json({ result: output });
+}

--- a/app/api/routes-f/hex-dump/__tests__/route.test.ts
+++ b/app/api/routes-f/hex-dump/__tests__/route.test.ts
@@ -1,0 +1,28 @@
+import { hexDump } from "../route";
+
+describe("hexDump", () => {
+  it("formats offset, hex bytes, and an ASCII gutter", () => {
+    const dump = hexDump("Hello");
+    expect(dump.startsWith("00000000  48 65 6c 6c 6f")).toBe(true);
+    expect(dump).toContain("|Hello|");
+  });
+
+  it("expands UTF-8 multibyte characters into their bytes", () => {
+    const dump = hexDump("é"); // U+00E9 -> 0xC3 0xA9
+    expect(dump).toContain("c3 a9");
+    expect(dump).toContain("|..|"); // non-printable bytes render as dots
+  });
+
+  it("wraps lines with incrementing offsets", () => {
+    const lines = hexDump("ABCDE", 4).split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].startsWith("00000000  41 42 43 44")).toBe(true);
+    expect(lines[0]).toContain("|ABCD|");
+    expect(lines[1].startsWith("00000004  45")).toBe(true);
+    expect(lines[1]).toContain("|E|");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(hexDump("")).toBe("");
+  });
+});

--- a/app/api/routes-f/hex-dump/route.ts
+++ b/app/api/routes-f/hex-dump/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const MAX_INPUT_BYTES = 1_000_000;
+const DEFAULT_BYTES_PER_LINE = 16;
+
+/**
+ * Produce a classic hex dump (8-digit hex offset, space-separated hex bytes, and
+ * an ASCII gutter) of UTF-8 encoded `input`. Non-printable bytes render as `.`.
+ */
+export function hexDump(input: string, bytesPerLine = DEFAULT_BYTES_PER_LINE): string {
+  const bytes = new TextEncoder().encode(input);
+  const lines: string[] = [];
+
+  for (let offset = 0; offset < bytes.length; offset += bytesPerLine) {
+    const slice = bytes.subarray(offset, offset + bytesPerLine);
+
+    const hex = Array.from(slice, (b) => b.toString(16).padStart(2, "0"))
+      .join(" ")
+      .padEnd(bytesPerLine * 3 - 1, " ");
+
+    const ascii = Array.from(slice, (b) =>
+      b >= 0x20 && b <= 0x7e ? String.fromCharCode(b) : ".",
+    ).join("");
+
+    lines.push(`${offset.toString(16).padStart(8, "0")}  ${hex}  |${ascii}|`);
+  }
+
+  return lines.join("\n");
+}
+
+const schema = z.object({
+  input: z.string().max(MAX_INPUT_BYTES, "input exceeds 1MB limit"),
+  bytes_per_line: z.number().int().min(1).max(64).optional(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { input, bytes_per_line } = result.data;
+  return NextResponse.json({
+    dump: hexDump(input, bytes_per_line ?? DEFAULT_BYTES_PER_LINE),
+  });
+}

--- a/app/api/routes-f/percentage-change/__tests__/route.test.ts
+++ b/app/api/routes-f/percentage-change/__tests__/route.test.ts
@@ -1,0 +1,43 @@
+import { computePercentageChange } from "../route";
+
+describe("computePercentageChange", () => {
+  it("reports an increase", () => {
+    expect(computePercentageChange(100, 150)).toEqual({
+      percent_change: 50,
+      absolute_change: 50,
+      direction: "up",
+    });
+  });
+
+  it("reports a decrease", () => {
+    expect(computePercentageChange(200, 150)).toEqual({
+      percent_change: -25,
+      absolute_change: -50,
+      direction: "down",
+    });
+  });
+
+  it("reports no change", () => {
+    expect(computePercentageChange(42, 42)).toEqual({
+      percent_change: 0,
+      absolute_change: 0,
+      direction: "none",
+    });
+  });
+
+  it("handles a zero base explicitly (null percent, still directional)", () => {
+    expect(computePercentageChange(0, 10)).toEqual({
+      percent_change: null,
+      absolute_change: 10,
+      direction: "up",
+    });
+  });
+
+  it("treats 0 -> 0 as no change", () => {
+    expect(computePercentageChange(0, 0)).toEqual({
+      percent_change: 0,
+      absolute_change: 0,
+      direction: "none",
+    });
+  });
+});

--- a/app/api/routes-f/percentage-change/route.ts
+++ b/app/api/routes-f/percentage-change/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export type ChangeDirection = "up" | "down" | "none";
+
+export interface PercentageChangeResult {
+  percent_change: number | null;
+  absolute_change: number;
+  direction: ChangeDirection;
+}
+
+/**
+ * Compute percentage change, absolute change, and direction between two numbers.
+ * When `from` is 0 the percentage is undefined (returned as null), except when
+ * `to` is also 0 (no change → 0%).
+ */
+export function computePercentageChange(
+  from: number,
+  to: number,
+): PercentageChangeResult {
+  const absolute_change = to - from;
+  const direction: ChangeDirection =
+    absolute_change > 0 ? "up" : absolute_change < 0 ? "down" : "none";
+
+  let percent_change: number | null;
+  if (from === 0) {
+    percent_change = to === 0 ? 0 : null;
+  } else {
+    percent_change = (absolute_change / Math.abs(from)) * 100;
+  }
+
+  return { percent_change, absolute_change, direction };
+}
+
+const schema = z.object({
+  from: z.number().finite(),
+  to: z.number().finite(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { from, to } = result.data;
+  return NextResponse.json(computePercentageChange(from, to));
+}


### PR DESCRIPTION
## Summary
Four self-contained `routes-f` utility endpoints, all confined to `app/api/routes-f/` (no imports from `lib/`, `utils/`, `types/`, etc.), each exporting pure logic with unit tests.

- **closes #803** — `percentage-change`: `{ from, to }` → `{ percent_change, absolute_change, direction }`; explicit zero-base handling (null percent when `from=0`).
- **closes #844** — `char-frequency`: histogram with `case_sensitive` / `ignore_whitespace` / `top`, sorted by count desc, 1MB cap.
- **closes #821** — `hex-dump`: classic offset / hex / ASCII gutter, UTF-8 byte expansion, configurable `bytes_per_line`, 1MB cap.
- **closes #820** — `ciphers`: Atbash (self-inverse) and Rail Fence (`rails >= 2`) encode/decode.

Each endpoint uses the in-`routes-f` `validateBody` + zod for input validation. Tests target the exported pure functions (round-trips for ciphers, edge cases for the others).
