### PR TITLE
feat(routes-f): hex-color, checksums, fiscal-quarter, address-generator

### DIFF
--- a/app/api/routes-f/address-generator/__tests__/route.test.ts
+++ b/app/api/routes-f/address-generator/__tests__/route.test.ts
@@ -1,0 +1,34 @@
+import { generateAddresses } from "../route";
+
+describe("generateAddresses", () => {
+  it("returns the requested count", () => {
+    expect(generateAddresses(5, "US", 42)).toHaveLength(5);
+    expect(generateAddresses(1, "NG", 7)).toHaveLength(1);
+  });
+
+  it("is deterministic for a given seed", () => {
+    expect(generateAddresses(3, "US", 42)).toEqual(
+      generateAddresses(3, "US", 42),
+    );
+  });
+
+  it("produces different output for different seeds", () => {
+    expect(generateAddresses(3, "US", 42)).not.toEqual(
+      generateAddresses(3, "US", 43),
+    );
+  });
+
+  it("uses the correct postal format per country", () => {
+    expect(generateAddresses(10, "US", 1).every((a) => /^\d{5}$/.test(a.postal_code))).toBe(true);
+    expect(generateAddresses(10, "NG", 1).every((a) => /^\d{6}$/.test(a.postal_code))).toBe(true);
+    expect(
+      generateAddresses(10, "UK", 1).every((a) =>
+        /^[A-Z]{2}\d \d[A-Z]{2}$/.test(a.postal_code),
+      ),
+    ).toBe(true);
+  });
+
+  it("tags addresses with the country name", () => {
+    expect(generateAddresses(1, "US", 1)[0].country).toBe("United States");
+  });
+});

--- a/app/api/routes-f/address-generator/route.ts
+++ b/app/api/routes-f/address-generator/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+export type CountryCode = "US" | "UK" | "NG";
+
+export interface SyntheticAddress {
+  street: string;
+  city: string;
+  region: string;
+  postal_code: string;
+  country: string;
+}
+
+// Pools and postal formats bundled inside this folder (no external data deps).
+interface CountryPool {
+  country: string;
+  streets: string[];
+  cities: { city: string; region: string }[];
+  postal: (rng: () => number) => string;
+}
+
+const digits = (rng: () => number, n: number): string =>
+  Array.from({ length: n }, () => Math.floor(rng() * 10)).join("");
+
+const letter = (rng: () => number): string =>
+  String.fromCharCode(65 + Math.floor(rng() * 26));
+
+const POOLS: Record<CountryCode, CountryPool> = {
+  US: {
+    country: "United States",
+    streets: ["Main St", "Oak Ave", "Maple Dr", "Cedar Ln", "Pine Rd", "Elm St"],
+    cities: [
+      { city: "Springfield", region: "IL" },
+      { city: "Austin", region: "TX" },
+      { city: "Denver", region: "CO" },
+      { city: "Portland", region: "OR" },
+    ],
+    postal: (rng) => digits(rng, 5),
+  },
+  UK: {
+    country: "United Kingdom",
+    streets: ["High St", "Station Rd", "Church Ln", "Victoria Rd", "Kings Way"],
+    cities: [
+      { city: "London", region: "England" },
+      { city: "Manchester", region: "England" },
+      { city: "Glasgow", region: "Scotland" },
+      { city: "Cardiff", region: "Wales" },
+    ],
+    // e.g. "AB1 2CD"
+    postal: (rng) =>
+      `${letter(rng)}${letter(rng)}${digits(rng, 1)} ${digits(rng, 1)}${letter(rng)}${letter(rng)}`,
+  },
+  NG: {
+    country: "Nigeria",
+    streets: ["Awolowo Rd", "Adeola Odeku St", "Broad St", "Ahmadu Bello Way"],
+    cities: [
+      { city: "Lagos", region: "Lagos" },
+      { city: "Abuja", region: "FCT" },
+      { city: "Kano", region: "Kano" },
+      { city: "Enugu", region: "Enugu" },
+    ],
+    postal: (rng) => digits(rng, 6),
+  },
+};
+
+/** Deterministic PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const pick = <T>(arr: T[], rng: () => number): T =>
+  arr[Math.floor(rng() * arr.length)];
+
+/** Generate `count` deterministic synthetic addresses for `country` from `seed`. */
+export function generateAddresses(
+  count: number,
+  country: CountryCode,
+  seed: number,
+): SyntheticAddress[] {
+  const rng = mulberry32(seed);
+  const pool = POOLS[country];
+  return Array.from({ length: count }, () => {
+    const number = 1 + Math.floor(rng() * 9998);
+    const { city, region } = pick(pool.cities, rng);
+    return {
+      street: `${number} ${pick(pool.streets, rng)}`,
+      city,
+      region,
+      postal_code: pool.postal(rng),
+      country: pool.country,
+    };
+  });
+}
+
+const schema = z.object({
+  count: z.coerce.number().int().min(1).max(100).optional().default(5),
+  country: z.enum(["US", "UK", "NG"]).optional().default("US"),
+  seed: z.coerce.number().int().optional().default(0),
+});
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const result = validateQuery(searchParams, schema);
+  if (result instanceof NextResponse) return result;
+  const { count, country, seed } = result.data;
+  return NextResponse.json({ addresses: generateAddresses(count, country, seed) });
+}

--- a/app/api/routes-f/checksums/__tests__/route.test.ts
+++ b/app/api/routes-f/checksums/__tests__/route.test.ts
@@ -1,0 +1,28 @@
+import { crc32, adler32, checksums } from "../route";
+
+describe("crc32", () => {
+  it("matches known vectors", () => {
+    expect(crc32("")).toBe("00000000");
+    expect(crc32("123456789")).toBe("cbf43926");
+    expect(crc32("The quick brown fox jumps over the lazy dog")).toBe("414fa339");
+  });
+});
+
+describe("adler32", () => {
+  it("matches known vectors", () => {
+    expect(adler32("")).toBe("00000001");
+    expect(adler32("Wikipedia")).toBe("11e60398");
+  });
+});
+
+describe("checksums", () => {
+  it("returns both by default", () => {
+    const out = checksums("123456789");
+    expect(out).toEqual({ crc32: "cbf43926", adler32: adler32("123456789") });
+  });
+
+  it("returns only the requested algorithm", () => {
+    expect(checksums("abc", "crc32")).toEqual({ crc32: crc32("abc") });
+    expect(checksums("abc", "adler32")).toEqual({ adler32: adler32("abc") });
+  });
+});

--- a/app/api/routes-f/checksums/route.ts
+++ b/app/api/routes-f/checksums/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const toHex8 = (n: number) => (n >>> 0).toString(16).padStart(8, "0");
+
+/** CRC32 (IEEE 802.3) of UTF-8 encoded input, returned as 8-digit hex. */
+export function crc32(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return toHex8(crc ^ 0xffffffff);
+}
+
+/** Adler-32 of UTF-8 encoded input, returned as 8-digit hex. */
+export function adler32(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const MOD = 65521;
+  let a = 1;
+  let b = 0;
+  for (const byte of bytes) {
+    a = (a + byte) % MOD;
+    b = (b + a) % MOD;
+  }
+  return toHex8((b << 16) | a);
+}
+
+export type ChecksumAlgorithm = "crc32" | "adler32" | "both";
+
+export function checksums(
+  input: string,
+  algorithm: ChecksumAlgorithm = "both",
+): { crc32?: string; adler32?: string } {
+  const out: { crc32?: string; adler32?: string } = {};
+  if (algorithm === "crc32" || algorithm === "both") out.crc32 = crc32(input);
+  if (algorithm === "adler32" || algorithm === "both") out.adler32 = adler32(input);
+  return out;
+}
+
+const schema = z.object({
+  input: z.string(),
+  algorithm: z.enum(["crc32", "adler32", "both"]).optional(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { input, algorithm } = result.data;
+  return NextResponse.json(checksums(input, algorithm));
+}

--- a/app/api/routes-f/fiscal-quarter/__tests__/route.test.ts
+++ b/app/api/routes-f/fiscal-quarter/__tests__/route.test.ts
@@ -1,0 +1,35 @@
+import { fiscalQuarter } from "../route";
+
+describe("fiscalQuarter", () => {
+  it("uses the calendar year by default (Jan start)", () => {
+    expect(fiscalQuarter("2026-02-15")).toEqual({
+      quarter: 1,
+      fiscal_year: 2026,
+      quarter_start: "2026-01-01",
+      quarter_end: "2026-03-31",
+    });
+    expect(fiscalQuarter("2026-08-10")).toEqual({
+      quarter: 3,
+      fiscal_year: 2026,
+      quarter_start: "2026-07-01",
+      quarter_end: "2026-09-30",
+    });
+  });
+
+  it("handles an offset fiscal year (April start)", () => {
+    // May is the first month of an April-start fiscal year -> Q1 of FY2026
+    expect(fiscalQuarter("2026-05-15", 4)).toEqual({
+      quarter: 1,
+      fiscal_year: 2026,
+      quarter_start: "2026-04-01",
+      quarter_end: "2026-06-30",
+    });
+    // February falls in Q4 of the April-start fiscal year that began in 2025
+    expect(fiscalQuarter("2026-02-15", 4)).toEqual({
+      quarter: 4,
+      fiscal_year: 2025,
+      quarter_start: "2026-01-01",
+      quarter_end: "2026-03-31",
+    });
+  });
+});

--- a/app/api/routes-f/fiscal-quarter/route.ts
+++ b/app/api/routes-f/fiscal-quarter/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+export interface FiscalQuarterResult {
+  quarter: number;
+  fiscal_year: number;
+  quarter_start: string;
+  quarter_end: string;
+}
+
+/**
+ * Return the fiscal quarter for a date given a configurable fiscal-year start
+ * month (1 = January = calendar year). `fiscal_year` is the calendar year in
+ * which the containing fiscal year begins.
+ */
+export function fiscalQuarter(dateStr: string, fiscalStartMonth = 1): FiscalQuarterResult {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  const month = d.getUTCMonth() + 1;
+  const year = d.getUTCFullYear();
+
+  const offset = (month - fiscalStartMonth + 12) % 12; // months into the fiscal year
+  const quarter = Math.floor(offset / 3) + 1;
+  const fyStartYear = month >= fiscalStartMonth ? year : year - 1;
+
+  const quarterStartMonthAbs = fiscalStartMonth - 1 + (quarter - 1) * 3;
+  const start = new Date(Date.UTC(fyStartYear, quarterStartMonthAbs, 1));
+  const end = new Date(Date.UTC(fyStartYear, quarterStartMonthAbs + 3, 0)); // last day of quarter
+
+  const fmt = (x: Date) => x.toISOString().slice(0, 10);
+  return {
+    quarter,
+    fiscal_year: fyStartYear,
+    quarter_start: fmt(start),
+    quarter_end: fmt(end),
+  };
+}
+
+const schema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
+  fiscal_start_month: z.coerce.number().int().min(1).max(12).optional().default(1),
+});
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const result = validateQuery(searchParams, schema);
+  if (result instanceof NextResponse) return result;
+  const { date, fiscal_start_month } = result.data;
+  return NextResponse.json(fiscalQuarter(date, fiscal_start_month));
+}

--- a/app/api/routes-f/hex-color/__tests__/route.test.ts
+++ b/app/api/routes-f/hex-color/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { normalizeHexColor } from "../route";
+
+describe("normalizeHexColor", () => {
+  it("normalizes 3-digit to 6-digit", () => {
+    expect(normalizeHexColor("#abc")).toEqual({
+      valid: true,
+      normalized: "#aabbcc",
+      has_alpha: false,
+    });
+  });
+
+  it("normalizes 4-digit to 8-digit with alpha", () => {
+    expect(normalizeHexColor("#abcd")).toEqual({
+      valid: true,
+      normalized: "#aabbccdd",
+      has_alpha: true,
+    });
+  });
+
+  it("accepts 6-digit (no #) and lowercases", () => {
+    expect(normalizeHexColor("FF8800")).toEqual({
+      valid: true,
+      normalized: "#ff8800",
+      has_alpha: false,
+    });
+  });
+
+  it("accepts 8-digit with alpha", () => {
+    expect(normalizeHexColor("#ff8800cc")).toEqual({
+      valid: true,
+      normalized: "#ff8800cc",
+      has_alpha: true,
+    });
+  });
+
+  it("rejects invalid input", () => {
+    for (const bad of ["#12", "#xyz", "12345", "#1234567", "nope"]) {
+      expect(normalizeHexColor(bad)).toEqual({
+        valid: false,
+        normalized: null,
+        has_alpha: false,
+      });
+    }
+  });
+});

--- a/app/api/routes-f/hex-color/route.ts
+++ b/app/api/routes-f/hex-color/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export interface HexColorResult {
+  valid: boolean;
+  normalized: string | null;
+  has_alpha: boolean;
+}
+
+/**
+ * Validate a hex color (#rgb, #rgba, #rrggbb, #rrggbbaa, with or without the
+ * leading #) and normalize it to 6-digit (#rrggbb) or 8-digit (#rrggbbaa) form.
+ */
+export function normalizeHexColor(input: string): HexColorResult {
+  const invalid: HexColorResult = { valid: false, normalized: null, has_alpha: false };
+  const hex = input.trim().replace(/^#/, "").toLowerCase();
+
+  if (!/^[0-9a-f]+$/.test(hex)) return invalid;
+
+  const expand = (s: string) => [...s].map((ch) => ch + ch).join("");
+
+  switch (hex.length) {
+    case 3:
+      return { valid: true, normalized: `#${expand(hex)}`, has_alpha: false };
+    case 4:
+      return { valid: true, normalized: `#${expand(hex)}`, has_alpha: true };
+    case 6:
+      return { valid: true, normalized: `#${hex}`, has_alpha: false };
+    case 8:
+      return { valid: true, normalized: `#${hex}`, has_alpha: true };
+    default:
+      return invalid;
+  }
+}
+
+const schema = z.object({ color: z.string() });
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  return NextResponse.json(normalizeHexColor(result.data.color));
+}


### PR DESCRIPTION
## Summary
Four self-contained `routes-f` utility endpoints (all files inside `app/api/routes-f/`, no imports from `lib/`/`utils/`/etc.), each exporting pure logic with unit tests.

closes #841
closes #822
closes #827
closes #819

- **#841 hex-color** — validate `#rgb|#rgba|#rrggbb|#rrggbbaa` (with/without `#`) → `{ valid, normalized, has_alpha }`, normalized to 6/8 digit.
- **#822 checksums** — inline CRC32 + Adler32 (no zlib), returned as hex; `algorithm: crc32|adler32|both`. Tested against known vectors.
- **#827 address-generator** — seeded deterministic synthetic addresses; per-country (US/UK/NG) postal formats; street/city pools bundled in-folder.
- **#819 fiscal-quarter** — `{ quarter, fiscal_year, quarter_start, quarter_end }` with configurable fiscal-year start month.
