### PR TITLE
feat(routes-f): collatz, case-convert, hamming + donations history

### DIFF
--- a/app/api/routes-f/case-convert/__tests__/route.test.ts
+++ b/app/api/routes-f/case-convert/__tests__/route.test.ts
@@ -1,0 +1,32 @@
+import { convertCase, splitWords } from "../route";
+
+describe("splitWords", () => {
+  it("detects each source case", () => {
+    expect(splitWords("foo_bar_baz")).toEqual(["foo", "bar", "baz"]);
+    expect(splitWords("foo-bar-baz")).toEqual(["foo", "bar", "baz"]);
+    expect(splitWords("fooBarBaz")).toEqual(["foo", "bar", "baz"]);
+    expect(splitWords("FooBarBaz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("preserves embedded numbers", () => {
+    expect(splitWords("apiV2Client")).toEqual(["api", "v2", "client"]);
+  });
+});
+
+describe("convertCase", () => {
+  const cases: Array<[string, CaseTargetLike]> = [];
+  type CaseTargetLike = "snake" | "camel" | "pascal" | "kebab";
+
+  it("converts mixed-case input to each target", () => {
+    expect(convertCase("fooBarBaz", "snake")).toBe("foo_bar_baz");
+    expect(convertCase("foo_bar_baz", "camel")).toBe("fooBarBaz");
+    expect(convertCase("foo-bar-baz", "pascal")).toBe("FooBarBaz");
+    expect(convertCase("FooBarBaz", "kebab")).toBe("foo-bar-baz");
+    void cases;
+  });
+
+  it("keeps numbers in the right place", () => {
+    expect(convertCase("apiV2Client", "snake")).toBe("api_v2_client");
+    expect(convertCase("api_v2_client", "pascal")).toBe("ApiV2Client");
+  });
+});

--- a/app/api/routes-f/case-convert/route.ts
+++ b/app/api/routes-f/case-convert/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export type CaseTarget = "snake" | "camel" | "pascal" | "kebab";
+
+/**
+ * Split an identifier into lowercase words, auto-detecting the source case
+ * (snake_case, kebab-case, camelCase, PascalCase). Embedded numbers are kept
+ * attached to their adjacent word.
+ */
+export function splitWords(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // camel/Pascal boundary
+    .replace(/[_-]+/g, " ") // snake / kebab separators
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.toLowerCase());
+}
+
+const cap = (w: string) => (w ? w[0].toUpperCase() + w.slice(1) : w);
+
+/** Convert an identifier between snake / camel / pascal / kebab case. */
+export function convertCase(text: string, target: CaseTarget): string {
+  const words = splitWords(text);
+  switch (target) {
+    case "snake":
+      return words.join("_");
+    case "kebab":
+      return words.join("-");
+    case "camel":
+      return words.map((w, i) => (i === 0 ? w : cap(w))).join("");
+    case "pascal":
+      return words.map(cap).join("");
+  }
+}
+
+const schema = z.object({
+  text: z.string(),
+  target: z.enum(["snake", "camel", "pascal", "kebab"]),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { text, target } = result.data;
+  return NextResponse.json({ result: convertCase(text, target) });
+}

--- a/app/api/routes-f/collatz/__tests__/route.test.ts
+++ b/app/api/routes-f/collatz/__tests__/route.test.ts
@@ -1,0 +1,20 @@
+import { collatz } from "../route";
+
+describe("collatz", () => {
+  it("returns the trivial sequence for n=1", () => {
+    expect(collatz(1)).toEqual({ sequence: [1], steps: 0, max_value: 1 });
+  });
+
+  it("matches the known sequence for n=27 (111 steps, max 9232)", () => {
+    const r = collatz(27);
+    expect(r.steps).toBe(111);
+    expect(r.max_value).toBe(9232);
+    expect(r.sequence[0]).toBe(27);
+    expect(r.sequence[r.sequence.length - 1]).toBe(1);
+    expect(r.sequence.length).toBe(112); // steps + the starting value
+  });
+
+  it("handles a small even start (n=6)", () => {
+    expect(collatz(6).sequence).toEqual([6, 3, 10, 5, 16, 8, 4, 2, 1]);
+  });
+});

--- a/app/api/routes-f/collatz/route.ts
+++ b/app/api/routes-f/collatz/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+const MAX_STEPS = 10000;
+
+export interface CollatzResult {
+  sequence: number[];
+  steps: number;
+  max_value: number;
+}
+
+/**
+ * Generate the Collatz sequence for a positive integer `n`: repeatedly halve
+ * if even, else 3n+1, until reaching 1. Capped at MAX_STEPS to bound output.
+ */
+export function collatz(n: number): CollatzResult {
+  const sequence: number[] = [n];
+  let current = n;
+  let steps = 0;
+  let maxValue = n;
+
+  while (current !== 1 && steps < MAX_STEPS) {
+    current = current % 2 === 0 ? current / 2 : 3 * current + 1;
+    sequence.push(current);
+    if (current > maxValue) maxValue = current;
+    steps += 1;
+  }
+
+  return { sequence, steps, max_value: maxValue };
+}
+
+const schema = z.object({
+  n: z.coerce.number().int().positive(),
+});
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const result = validateQuery(searchParams, schema);
+  if (result instanceof NextResponse) return result;
+  return NextResponse.json(collatz(result.data.n));
+}

--- a/app/api/routes-f/donations/history/__tests__/route.test.ts
+++ b/app/api/routes-f/donations/history/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+jest.mock("@vercel/postgres", () => ({ sql: { query: jest.fn() } }));
+jest.mock("@/lib/auth/verify-session", () => ({ verifySession: jest.fn() }));
+
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { GET } from "../route";
+
+const sqlQuery = (sql as unknown as { query: jest.Mock }).query;
+const verify = verifySession as unknown as jest.Mock;
+
+function req(qs = ""): any {
+  return new Request(`http://localhost/api/routes-f/donations/history${qs}`);
+}
+
+const row = {
+  id: "t1",
+  amount_usdc: "5.00",
+  message: "thanks!",
+  tx_hash: "hash1",
+  created_at: "2026-05-01T00:00:00.000Z",
+  sender_username: "alice",
+  recipient_username: "bob",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  verify.mockResolvedValue({ ok: true, userId: "user-1" });
+});
+
+describe("GET /api/routes-f/donations/history", () => {
+  it("returns the session's 401 response when unauthenticated", async () => {
+    verify.mockResolvedValue({ ok: false, response: new Response("no", { status: 401 }) });
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an invalid direction", async () => {
+    const res = await GET(req("?direction=weird"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-ISO from date", async () => {
+    const res = await GET(req("?from=not-a-date"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the user's donation history", async () => {
+    sqlQuery.mockResolvedValue({ rows: [row] });
+    const res = await GET(req("?direction=all&limit=20"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.donations).toHaveLength(1);
+    expect(json.donations[0]).toMatchObject({
+      amount_usdc: "5.00",
+      sender_username: "alice",
+      recipient_username: "bob",
+    });
+    expect(json.pagination.hasMore).toBe(false);
+  });
+
+  it("sets hasMore + nextCursor when an extra row is returned", async () => {
+    const rows = Array.from({ length: 3 }, (_, k) => ({ ...row, id: `t${k}` }));
+    sqlQuery.mockResolvedValue({ rows });
+    const res = await GET(req("?limit=2"));
+    const json = await res.json();
+    expect(json.donations).toHaveLength(2);
+    expect(json.pagination.hasMore).toBe(true);
+    expect(json.pagination.nextCursor).toBe("2026-05-01T00:00:00.000Z");
+  });
+});

--- a/app/api/routes-f/donations/history/route.ts
+++ b/app/api/routes-f/donations/history/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/routes-f/donations/history (#466)
+ *
+ * Returns the authenticated user's tip/donation history (sent and/or received),
+ * with date-range filtering and keyset (created_at) cursor pagination.
+ *
+ * Query: ?direction=sent|received|all&limit=20&cursor=<ISO>&from=<ISO>&to=<ISO>
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) return session.response;
+  const userId = session.userId;
+
+  const { searchParams } = new URL(req.url);
+
+  const direction = (searchParams.get("direction") ?? "all").toLowerCase();
+  if (!["sent", "received", "all"].includes(direction)) {
+    return NextResponse.json(
+      { error: "direction must be one of sent | received | all" },
+      { status: 400 },
+    );
+  }
+
+  const limit = Math.min(
+    100,
+    Math.max(1, Number.parseInt(searchParams.get("limit") ?? "20", 10) || 20),
+  );
+
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+  const cursor = searchParams.get("cursor");
+  for (const [name, value] of [["from", from], ["to", to], ["cursor", cursor]] as const) {
+    if (value && Number.isNaN(Date.parse(value))) {
+      return NextResponse.json({ error: `${name} must be an ISO timestamp` }, { status: 400 });
+    }
+  }
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let i = 1;
+
+  if (direction === "sent") {
+    conditions.push(`t.sender_id = $${i++}`);
+    params.push(userId);
+  } else if (direction === "received") {
+    conditions.push(`t.recipient_id = $${i++}`);
+    params.push(userId);
+  } else {
+    conditions.push(`(t.sender_id = $${i} OR t.recipient_id = $${i})`);
+    i += 1;
+    params.push(userId);
+  }
+  if (from) {
+    conditions.push(`t.created_at >= $${i++}`);
+    params.push(from);
+  }
+  if (to) {
+    conditions.push(`t.created_at <= $${i++}`);
+    params.push(to);
+  }
+  if (cursor) {
+    conditions.push(`t.created_at < $${i++}`);
+    params.push(cursor);
+  }
+
+  // Fetch one extra row to determine the next cursor.
+  const queryText = `
+    SELECT t.id,
+           t.amount_usdc,
+           t.message,
+           t.tx_hash,
+           t.created_at,
+           s.username AS sender_username,
+           r.username AS recipient_username
+    FROM tips t
+    LEFT JOIN users s ON s.id = t.sender_id
+    LEFT JOIN users r ON r.id = t.recipient_id
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY t.created_at DESC
+    LIMIT $${i}`;
+  params.push(limit + 1);
+
+  try {
+    const { rows } = await sql.query(queryText, params);
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor =
+      hasMore && items.length > 0
+        ? new Date(items[items.length - 1].created_at).toISOString()
+        : null;
+
+    return NextResponse.json({
+      donations: items.map((row) => ({
+        id: row.id,
+        amount_usdc: row.amount_usdc,
+        sender_username: row.sender_username,
+        recipient_username: row.recipient_username,
+        message: row.message ?? null,
+        tx_hash: row.tx_hash ?? null,
+        created_at: row.created_at,
+      })),
+      pagination: { limit, nextCursor, hasMore },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to load donation history" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/routes-f/hamming/__tests__/route.test.ts
+++ b/app/api/routes-f/hamming/__tests__/route.test.ts
@@ -1,0 +1,18 @@
+import { hammingDistance } from "../route";
+
+describe("hammingDistance", () => {
+  it("computes distance for equal-length strings", () => {
+    expect(hammingDistance("karolin", "kathrin")).toBe(3);
+    expect(hammingDistance("karolin", "kerstin")).toBe(3);
+    expect(hammingDistance("abc", "abc")).toBe(0);
+  });
+
+  it("computes distance for binary inputs", () => {
+    expect(hammingDistance("1011101", "1001001")).toBe(2);
+    expect(hammingDistance("0000", "1111")).toBe(4);
+  });
+
+  it("throws on unequal lengths", () => {
+    expect(() => hammingDistance("abc", "ab")).toThrow(RangeError);
+  });
+});

--- a/app/api/routes-f/hamming/route.ts
+++ b/app/api/routes-f/hamming/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+/**
+ * Hamming distance: the number of positions at which two equal-length strings
+ * differ. Throws if the inputs are not the same length.
+ */
+export function hammingDistance(a: string, b: string): number {
+  if (a.length !== b.length) {
+    throw new RangeError("inputs must be of equal length");
+  }
+  let distance = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) distance += 1;
+  }
+  return distance;
+}
+
+const schema = z.object({
+  a: z.string(),
+  b: z.string(),
+  mode: z.enum(["string", "binary"]).optional().default("string"),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { a, b, mode } = result.data;
+
+  if (mode === "binary" && (!/^[01]+$/.test(a) || !/^[01]+$/.test(b))) {
+    return NextResponse.json(
+      { error: "binary mode requires inputs containing only 0 and 1" },
+      { status: 400 },
+    );
+  }
+
+  if (a.length !== b.length) {
+    return NextResponse.json(
+      { error: "inputs must be of equal length" },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({ distance: hammingDistance(a, b) });
+}


### PR DESCRIPTION
## Summary
Four `routes-f` endpoints.

closes #817
closes #824
closes #861
closes #466

- **#817 collatz** `GET ?n` — `{ sequence, steps, max_value }`, validated positive int, capped at 10k steps (tested incl. n=27 → 111 steps / max 9232).
- **#824 case-convert** `POST { text, target }` — snake/camel/pascal/kebab with source auto-detection and embedded-number preservation.
- **#861 hamming** `POST { a, b, mode? }` — distance for equal-length string/binary inputs; 400 on unequal length or non-binary chars in binary mode.
- **#466 donations/history** `GET` — authenticated user's sent/received tips (`direction`, `from`/`to`, keyset `cursor` pagination), each record with `amount_usdc`, `sender_username`, `recipient_username`, `message`, `tx_hash`, `created_at`. Uses the existing `verifySession` + `@vercel/postgres` pattern.

The three pure utilities export their logic with unit tests; donations/history has a mocked-DB test.
