### PR TITLE
feat(routes-f): base32, country-flag, json-schema validator, initials

### DIFF
--- a/app/api/routes-f/base32/__tests__/route.test.ts
+++ b/app/api/routes-f/base32/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import { base32Encode, base32Decode } from "../route";
+
+describe("base32Encode", () => {
+  it("matches RFC 4648 test vectors", () => {
+    expect(base32Encode("")).toBe("");
+    expect(base32Encode("f")).toBe("MY======");
+    expect(base32Encode("fo")).toBe("MZXQ====");
+    expect(base32Encode("foo")).toBe("MZXW6===");
+    expect(base32Encode("foobar")).toBe("MZXW6YTBOI======");
+  });
+
+  it("omits padding when padding=false", () => {
+    expect(base32Encode("foobar", false)).toBe("MZXW6YTBOI");
+  });
+});
+
+describe("base32Decode", () => {
+  it("decodes RFC 4648 vectors (with or without padding)", () => {
+    expect(base32Decode("MZXW6YTBOI======")).toBe("foobar");
+    expect(base32Decode("MZXW6YTBOI")).toBe("foobar");
+    expect(base32Decode("MY======")).toBe("f");
+  });
+
+  it("round-trips arbitrary input", () => {
+    for (const s of ["hello world", "Stellar ⭐", "a", "12345"]) {
+      expect(base32Decode(base32Encode(s))).toBe(s);
+    }
+  });
+
+  it("throws on invalid base32 characters", () => {
+    expect(() => base32Decode("0189")).toThrow(RangeError); // 0,1,8,9 not in alphabet
+  });
+});

--- a/app/api/routes-f/base32/route.ts
+++ b/app/api/routes-f/base32/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/** RFC 4648 base32 encode of a UTF-8 string. */
+export function base32Encode(input: string, padding = true): string {
+  const bytes = new TextEncoder().encode(input);
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const b of bytes) {
+    value = ((value << 8) | b) >>> 0;
+    bits += 8;
+    while (bits >= 5) {
+      out += ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+    value &= (1 << bits) - 1;
+  }
+  if (bits > 0) {
+    out += ALPHABET[(value << (5 - bits)) & 31];
+  }
+  if (padding) {
+    while (out.length % 8 !== 0) out += "=";
+  }
+  return out;
+}
+
+/** RFC 4648 base32 decode back to a UTF-8 string. Throws on invalid input. */
+export function base32Decode(input: string): string {
+  const clean = input.toUpperCase().replace(/=+$/, "");
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  for (const ch of clean) {
+    const idx = ALPHABET.indexOf(ch);
+    if (idx === -1) {
+      throw new RangeError(`invalid base32 character: ${ch}`);
+    }
+    value = ((value << 5) | idx) >>> 0;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+    value &= (1 << bits) - 1;
+  }
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+const schema = z.object({
+  input: z.string(),
+  mode: z.enum(["encode", "decode"]),
+  padding: z.boolean().optional().default(true),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { input, mode, padding } = result.data;
+
+  if (mode === "encode") {
+    return NextResponse.json({ output: base32Encode(input, padding) });
+  }
+  try {
+    return NextResponse.json({ output: base32Decode(input) });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "invalid base32 input" },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/routes-f/country-flag/__tests__/route.test.ts
+++ b/app/api/routes-f/country-flag/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { codeToFlag, flagToCode } from "../route";
+
+describe("codeToFlag", () => {
+  it("converts codes to flag emoji", () => {
+    expect(codeToFlag("NG")).toBe("🇳🇬");
+    expect(codeToFlag("us")).toBe("🇺🇸");
+    expect(codeToFlag("GB")).toBe("🇬🇧");
+  });
+  it("rejects invalid codes", () => {
+    expect(() => codeToFlag("N")).toThrow();
+    expect(() => codeToFlag("N1")).toThrow();
+  });
+});
+
+describe("flagToCode", () => {
+  it("converts flag emoji back to codes", () => {
+    expect(flagToCode("🇳🇬")).toBe("NG");
+    expect(flagToCode("🇺🇸")).toBe("US");
+  });
+  it("round-trips", () => {
+    for (const c of ["NG", "US", "GB", "JP", "DE"]) {
+      expect(flagToCode(codeToFlag(c))).toBe(c);
+    }
+  });
+  it("rejects non-flag input", () => {
+    expect(() => flagToCode("AB")).toThrow();
+    expect(() => flagToCode("🇳")).toThrow();
+  });
+});

--- a/app/api/routes-f/country-flag/route.ts
+++ b/app/api/routes-f/country-flag/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+const A = 0x1f1e6; // regional indicator 'A'
+
+/** Convert an ISO 3166-1 alpha-2 code (e.g. "NG") to its flag emoji. */
+export function codeToFlag(code: string): string {
+  const cc = code.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(cc)) {
+    throw new RangeError("code must be two ASCII letters");
+  }
+  return String.fromCodePoint(
+    A + (cc.charCodeAt(0) - 65),
+    A + (cc.charCodeAt(1) - 65),
+  );
+}
+
+/** Convert a flag emoji (two regional indicators) back to its alpha-2 code. */
+export function flagToCode(flag: string): string {
+  const cps = Array.from(flag, (ch) => ch.codePointAt(0) ?? 0);
+  if (cps.length !== 2 || cps.some((cp) => cp < A || cp > A + 25)) {
+    throw new RangeError("flag must be two regional-indicator symbols");
+  }
+  return cps.map((cp) => String.fromCharCode(cp - A + 65)).join("");
+}
+
+const schema = z.object({
+  mode: z.enum(["to_flag", "to_code"]),
+  code: z.string().optional(),
+  flag: z.string().optional(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { mode, code, flag } = result.data;
+
+  try {
+    if (mode === "to_flag") {
+      if (!code) return NextResponse.json({ error: "code is required for to_flag" }, { status: 400 });
+      return NextResponse.json({ flag: codeToFlag(code) });
+    }
+    if (!flag) return NextResponse.json({ error: "flag is required for to_code" }, { status: 400 });
+    return NextResponse.json({ code: flagToCode(flag) });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "invalid input" },
+      { status: 400 },
+    );
+  }
+}

--- a/app/api/routes-f/initials/__tests__/route.test.ts
+++ b/app/api/routes-f/initials/__tests__/route.test.ts
@@ -1,0 +1,20 @@
+import { extractInitials } from "../route";
+
+describe("extractInitials", () => {
+  it("handles a single name", () => {
+    expect(extractInitials("John")).toBe("J");
+  });
+  it("handles two words", () => {
+    expect(extractInitials("John Smith")).toBe("JS");
+  });
+  it("caps at max for three words", () => {
+    expect(extractInitials("John Michael Smith")).toBe("JM");
+    expect(extractInitials("John Michael Smith", 3)).toBe("JMS");
+  });
+  it("treats hyphenated names as separate parts", () => {
+    expect(extractInitials("Mary-Jane Watson")).toBe("MJ");
+  });
+  it("uppercases and ignores extra whitespace", () => {
+    expect(extractInitials("  ada   lovelace  ")).toBe("AL");
+  });
+});

--- a/app/api/routes-f/initials/route.ts
+++ b/app/api/routes-f/initials/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+/**
+ * Extract uppercased initials from a full name. Whitespace and hyphens both
+ * separate name parts (so "Mary-Jane" contributes M and J), capped at `max`.
+ */
+export function extractInitials(name: string, max = 2): string {
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .flatMap((w) => w.split("-"))
+    .filter(Boolean);
+  return parts
+    .map((p) => p[0].toUpperCase())
+    .slice(0, max)
+    .join("");
+}
+
+const schema = z.object({
+  name: z.string(),
+  max: z.number().int().positive().optional().default(2),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { name, max } = result.data;
+  return NextResponse.json({ initials: extractInitials(name, max) });
+}

--- a/app/api/routes-f/json-schema-validate/__tests__/route.test.ts
+++ b/app/api/routes-f/json-schema-validate/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+import { validateAgainstSchema } from "../route";
+
+describe("validateAgainstSchema", () => {
+  it("passes a valid object", () => {
+    const schema = {
+      type: "object",
+      required: ["name", "age"],
+      properties: {
+        name: { type: "string", minLength: 1, maxLength: 50 },
+        age: { type: "integer", minimum: 0, maximum: 130 },
+        role: { type: "string", enum: ["admin", "user"] },
+      },
+    };
+    const r = validateAgainstSchema(schema, { name: "Ada", age: 36, role: "admin" });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("flags a type mismatch", () => {
+    const r = validateAgainstSchema({ type: "number" }, "nope");
+    expect(r.valid).toBe(false);
+    expect(r.errors[0].message).toMatch(/expected type number/);
+  });
+
+  it("flags missing required properties", () => {
+    const r = validateAgainstSchema(
+      { type: "object", required: ["id"], properties: {} },
+      {},
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors[0]).toEqual({ path: "id", message: "required property is missing" });
+  });
+
+  it("enforces minimum/maximum", () => {
+    expect(validateAgainstSchema({ type: "number", minimum: 10 }, 5).valid).toBe(false);
+    expect(validateAgainstSchema({ type: "number", maximum: 10 }, 20).valid).toBe(false);
+    expect(validateAgainstSchema({ type: "number", minimum: 0, maximum: 10 }, 5).valid).toBe(true);
+  });
+
+  it("enforces minLength/maxLength", () => {
+    expect(validateAgainstSchema({ type: "string", minLength: 3 }, "ab").valid).toBe(false);
+    expect(validateAgainstSchema({ type: "string", maxLength: 3 }, "abcd").valid).toBe(false);
+  });
+
+  it("enforces enum", () => {
+    expect(validateAgainstSchema({ enum: ["a", "b"] }, "c").valid).toBe(false);
+    expect(validateAgainstSchema({ enum: ["a", "b"] }, "a").valid).toBe(true);
+  });
+
+  it("reports nested property paths", () => {
+    const schema = {
+      type: "object",
+      properties: { user: { type: "object", properties: { age: { type: "integer", minimum: 0 } } } },
+    };
+    const r = validateAgainstSchema(schema, { user: { age: -1 } });
+    expect(r.valid).toBe(false);
+    expect(r.errors[0].path).toBe("user.age");
+  });
+});

--- a/app/api/routes-f/json-schema-validate/route.ts
+++ b/app/api/routes-f/json-schema-validate/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+// Minimal JSON-schema subset validator (no ajv): supports type, required,
+// properties, minimum/maximum, minLength/maxLength, enum.
+
+export interface SchemaError {
+  path: string;
+  message: string;
+}
+
+type JsonSchema = Record<string, unknown>;
+
+function typeOf(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+const join = (path: string, key: string) => (path ? `${path}.${key}` : key);
+
+function walk(schema: JsonSchema, data: unknown, path: string, errors: SchemaError[]): void {
+  if (typeof schema !== "object" || schema === null) return;
+
+  if (schema.type !== undefined) {
+    const expected = Array.isArray(schema.type) ? (schema.type as string[]) : [schema.type as string];
+    const actual = typeOf(data);
+    const ok = expected.some((t) =>
+      t === "integer" ? actual === "number" && Number.isInteger(data) : t === actual,
+    );
+    if (!ok) {
+      errors.push({ path, message: `expected type ${expected.join(" | ")}, got ${actual}` });
+      return; // further keyword checks are meaningless on a type mismatch
+    }
+  }
+
+  if (Array.isArray(schema.enum)) {
+    const match = (schema.enum as unknown[]).some(
+      (e) => JSON.stringify(e) === JSON.stringify(data),
+    );
+    if (!match) errors.push({ path, message: "value is not one of the allowed enum values" });
+  }
+
+  if (typeof data === "number") {
+    if (typeof schema.minimum === "number" && data < schema.minimum) {
+      errors.push({ path, message: `must be >= ${schema.minimum}` });
+    }
+    if (typeof schema.maximum === "number" && data > schema.maximum) {
+      errors.push({ path, message: `must be <= ${schema.maximum}` });
+    }
+  }
+
+  if (typeof data === "string") {
+    if (typeof schema.minLength === "number" && data.length < schema.minLength) {
+      errors.push({ path, message: `length must be >= ${schema.minLength}` });
+    }
+    if (typeof schema.maxLength === "number" && data.length > schema.maxLength) {
+      errors.push({ path, message: `length must be <= ${schema.maxLength}` });
+    }
+  }
+
+  if (typeOf(data) === "object") {
+    const obj = data as Record<string, unknown>;
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required as string[]) {
+        if (!(key in obj)) errors.push({ path: join(path, key), message: "required property is missing" });
+      }
+    }
+    if (schema.properties && typeof schema.properties === "object") {
+      for (const [key, sub] of Object.entries(schema.properties as Record<string, JsonSchema>)) {
+        if (key in obj) walk(sub, obj[key], join(path, key), errors);
+      }
+    }
+  }
+}
+
+export function validateAgainstSchema(
+  schema: JsonSchema,
+  data: unknown,
+): { valid: boolean; errors: SchemaError[] } {
+  const errors: SchemaError[] = [];
+  walk(schema, data, "", errors);
+  return { valid: errors.length === 0, errors };
+}
+
+const schema = z.object({
+  schema: z.record(z.any()),
+  data: z.any(),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { schema: jsonSchema, data } = result.data;
+  return NextResponse.json(validateAgainstSchema(jsonSchema as JsonSchema, data));
+}


### PR DESCRIPTION
## Summary
Four self-contained `routes-f` utilities, each exporting pure logic with unit tests.

closes #799
closes #805
closes #806
closes #810

- **#799 base32** `POST { input, mode, padding? }` — RFC 4648 encode/decode (tested against the spec vectors, e.g. `foobar` → `MZXW6YTBOI======`), 400 on invalid decode input.
- **#805 country-flag** `POST { mode, code?, flag? }` — alpha-2 ↔ regional-indicator flag emoji, with round-trip + invalid-input tests.
- **#806 json-schema-validate** `POST { schema, data }` — inline (no ajv) validator for `type` (incl. `integer`), `required`, `properties` (recursive, path-aware), `minimum`/`maximum`, `minLength`/`maxLength`, `enum`; returns `{ valid, errors: [{ path, message }] }`.
- **#810 initials** `POST { name, max? }` — uppercased initials handling middle/hyphenated/single names.
