### PR TITLE
feat(routes-f): continent, base64-validate, rounding, team-name

### DIFF
--- a/app/api/routes-f/base64-validate/__tests__/route.test.ts
+++ b/app/api/routes-f/base64-validate/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { validateBase64 } from "../route";
+
+describe("validateBase64", () => {
+  it("accepts well-formed standard base64", () => {
+    expect(validateBase64("Zm9vYmFy")).toEqual({
+      valid: true,
+      variant_detected: "standard",
+      decoded_length: 6,
+    });
+  });
+
+  it("accounts for padding in decoded_length", () => {
+    expect(validateBase64("Zm9vYg==")).toEqual({
+      valid: true,
+      variant_detected: "standard",
+      decoded_length: 4,
+    });
+  });
+
+  it("detects the url-safe alphabet", () => {
+    const r = validateBase64("a-b_");
+    expect(r.valid).toBe(true);
+    expect(r.variant_detected).toBe("urlsafe");
+  });
+
+  it("rejects misplaced padding", () => {
+    expect(validateBase64("Zm=9").valid).toBe(false);
+  });
+
+  it("rejects the wrong charset", () => {
+    expect(validateBase64("Zm9v$bcd").valid).toBe(false);
+  });
+
+  it("rejects an impossible length (len % 4 == 1)", () => {
+    expect(validateBase64("Zm9vY").valid).toBe(false);
+  });
+
+  it("rejects mixed alphabets", () => {
+    expect(validateBase64("ab+c-d").valid).toBe(false);
+  });
+});

--- a/app/api/routes-f/base64-validate/route.ts
+++ b/app/api/routes-f/base64-validate/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export type Base64Variant = "standard" | "urlsafe" | "auto";
+
+export interface Base64Result {
+  valid: boolean;
+  variant_detected: "standard" | "urlsafe" | null;
+  decoded_length: number;
+}
+
+const INVALID: Base64Result = { valid: false, variant_detected: null, decoded_length: 0 };
+
+/**
+ * Validate whether `input` is well-formed base64 (standard or URL-safe):
+ * charset, padding placement, and length divisibility.
+ */
+export function validateBase64(input: string, variant: Base64Variant = "auto"): Base64Result {
+  if (input.length === 0) {
+    return { valid: true, variant_detected: variant === "auto" ? "standard" : variant, decoded_length: 0 };
+  }
+
+  const hasStd = /[+/]/.test(input);
+  const hasUrl = /[-_]/.test(input);
+  if (hasStd && hasUrl) return INVALID; // mixed alphabets
+
+  let detected: "standard" | "urlsafe" = hasUrl ? "urlsafe" : "standard";
+  if (variant !== "auto") {
+    if ((hasStd || hasUrl) && variant !== detected) return INVALID;
+    detected = variant;
+  }
+
+  const charset = detected === "urlsafe" ? /^[A-Za-z0-9_-]+={0,2}$/ : /^[A-Za-z0-9+/]+={0,2}$/;
+  if (!charset.test(input)) return INVALID;
+
+  const padIdx = input.indexOf("=");
+  const padding = padIdx === -1 ? 0 : input.length - padIdx;
+  // padding, if present, must be 1–2 '=' all at the very end
+  if (padIdx !== -1 && !/^={1,2}$/.test(input.slice(padIdx))) return INVALID;
+
+  if (input.length % 4 === 1) return INVALID; // impossible base64 length
+  if (input.length % 4 !== 0) {
+    // only tolerate unpadded length for url-safe (padding is optional there)
+    if (padding > 0 || detected === "standard") return INVALID;
+  } else if (padding > 0 && input.length % 4 !== 0) {
+    return INVALID;
+  }
+
+  const decoded_length = Math.floor((input.length - padding) * 3 / 4);
+  return { valid: true, variant_detected: detected, decoded_length };
+}
+
+const schema = z.object({
+  input: z.string(),
+  variant: z.enum(["standard", "urlsafe", "auto"]).optional().default("auto"),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { input, variant } = result.data;
+  return NextResponse.json(validateBase64(input, variant));
+}

--- a/app/api/routes-f/continent/__tests__/route.test.ts
+++ b/app/api/routes-f/continent/__tests__/route.test.ts
@@ -1,0 +1,24 @@
+import { lookupContinent } from "../route";
+
+describe("lookupContinent", () => {
+  it("maps countries across several continents", () => {
+    expect(lookupContinent("NG")).toEqual({
+      country: "Nigeria",
+      continent: "Africa",
+      region: "Western Africa",
+    });
+    expect(lookupContinent("JP")?.continent).toBe("Asia");
+    expect(lookupContinent("BR")?.continent).toBe("South America");
+    expect(lookupContinent("DE")?.continent).toBe("Europe");
+    expect(lookupContinent("AU")?.continent).toBe("Oceania");
+    expect(lookupContinent("US")?.continent).toBe("North America");
+  });
+
+  it("is case-insensitive", () => {
+    expect(lookupContinent("ng")?.country).toBe("Nigeria");
+  });
+
+  it("returns null for an unknown code", () => {
+    expect(lookupContinent("ZZ")).toBeNull();
+  });
+});

--- a/app/api/routes-f/continent/route.ts
+++ b/app/api/routes-f/continent/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export interface CountryInfo {
+  country: string;
+  continent: string;
+  region: string;
+}
+
+// ISO 3166-1 alpha-2 -> continent/region. Bundled in-folder (representative
+// subset across all continents; extend as needed).
+const COUNTRIES: Record<string, CountryInfo> = {
+  NG: { country: "Nigeria", continent: "Africa", region: "Western Africa" },
+  ZA: { country: "South Africa", continent: "Africa", region: "Southern Africa" },
+  EG: { country: "Egypt", continent: "Africa", region: "Northern Africa" },
+  KE: { country: "Kenya", continent: "Africa", region: "Eastern Africa" },
+  US: { country: "United States", continent: "North America", region: "Northern America" },
+  CA: { country: "Canada", continent: "North America", region: "Northern America" },
+  MX: { country: "Mexico", continent: "North America", region: "Central America" },
+  BR: { country: "Brazil", continent: "South America", region: "South America" },
+  AR: { country: "Argentina", continent: "South America", region: "South America" },
+  GB: { country: "United Kingdom", continent: "Europe", region: "Northern Europe" },
+  DE: { country: "Germany", continent: "Europe", region: "Western Europe" },
+  FR: { country: "France", continent: "Europe", region: "Western Europe" },
+  ES: { country: "Spain", continent: "Europe", region: "Southern Europe" },
+  IT: { country: "Italy", continent: "Europe", region: "Southern Europe" },
+  RU: { country: "Russia", continent: "Europe", region: "Eastern Europe" },
+  CN: { country: "China", continent: "Asia", region: "Eastern Asia" },
+  JP: { country: "Japan", continent: "Asia", region: "Eastern Asia" },
+  IN: { country: "India", continent: "Asia", region: "Southern Asia" },
+  SG: { country: "Singapore", continent: "Asia", region: "South-Eastern Asia" },
+  AE: { country: "United Arab Emirates", continent: "Asia", region: "Western Asia" },
+  SA: { country: "Saudi Arabia", continent: "Asia", region: "Western Asia" },
+  AU: { country: "Australia", continent: "Oceania", region: "Australia and New Zealand" },
+  NZ: { country: "New Zealand", continent: "Oceania", region: "Australia and New Zealand" },
+  FJ: { country: "Fiji", continent: "Oceania", region: "Melanesia" },
+  AQ: { country: "Antarctica", continent: "Antarctica", region: "Antarctica" },
+};
+
+/** Look up continent/region for an ISO alpha-2 country code (case-insensitive). */
+export function lookupContinent(code: string): CountryInfo | null {
+  return COUNTRIES[code.trim().toUpperCase()] ?? null;
+}
+
+const schema = z.object({ code: z.string() });
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const info = lookupContinent(result.data.code);
+  if (!info) {
+    return NextResponse.json(
+      { error: `unknown country code: ${result.data.code}` },
+      { status: 404 },
+    );
+  }
+  return NextResponse.json(info);
+}

--- a/app/api/routes-f/rounding/__tests__/route.test.ts
+++ b/app/api/routes-f/rounding/__tests__/route.test.ts
@@ -1,0 +1,29 @@
+import { roundValue } from "../route";
+
+describe("roundValue", () => {
+  it("half_up rounds .5 away from zero", () => {
+    expect(roundValue(2.5, "half_up")).toBe(3);
+    expect(roundValue(3.5, "half_up")).toBe(4);
+    expect(roundValue(-2.5, "half_up")).toBe(-3);
+  });
+
+  it("half_even uses banker's rounding on .5", () => {
+    expect(roundValue(2.5, "half_even")).toBe(2);
+    expect(roundValue(3.5, "half_even")).toBe(4);
+    expect(roundValue(0.5, "half_even")).toBe(0);
+    expect(roundValue(1.5, "half_even")).toBe(2);
+    expect(roundValue(-2.5, "half_even")).toBe(-2);
+  });
+
+  it("ceil / floor / trunc", () => {
+    expect(roundValue(2.1, "ceil")).toBe(3);
+    expect(roundValue(2.9, "floor")).toBe(2);
+    expect(roundValue(-2.9, "trunc")).toBe(-2);
+    expect(roundValue(2.9, "trunc")).toBe(2);
+  });
+
+  it("respects decimals", () => {
+    expect(roundValue(2.345, "floor", 2)).toBe(2.34);
+    expect(roundValue(2.5, "ceil", 0)).toBe(3);
+  });
+});

--- a/app/api/routes-f/rounding/route.ts
+++ b/app/api/routes-f/rounding/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export type RoundingMode = "half_up" | "half_even" | "ceil" | "floor" | "trunc";
+
+/** Banker's rounding (round half to even). */
+function roundHalfEven(x: number): number {
+  const floor = Math.floor(x);
+  const diff = x - floor;
+  if (diff < 0.5) return floor;
+  if (diff > 0.5) return floor + 1;
+  // exactly .5 → round to the even neighbour
+  return floor % 2 === 0 ? floor : floor + 1;
+}
+
+/** Round `value` to `decimals` places using the given strategy. */
+export function roundValue(value: number, mode: RoundingMode, decimals = 0): number {
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  let r: number;
+  switch (mode) {
+    case "ceil":
+      r = Math.ceil(scaled);
+      break;
+    case "floor":
+      r = Math.floor(scaled);
+      break;
+    case "trunc":
+      r = Math.trunc(scaled);
+      break;
+    case "half_up":
+      // round half away from zero
+      r = Math.sign(scaled) * Math.round(Math.abs(scaled));
+      break;
+    case "half_even":
+      r = roundHalfEven(scaled);
+      break;
+  }
+  return r / factor;
+}
+
+const schema = z.object({
+  value: z.number().finite(),
+  mode: z.enum(["half_up", "half_even", "ceil", "floor", "trunc"]),
+  decimals: z.number().int().min(0).max(15).optional().default(0),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) return result;
+  const { value, mode, decimals } = result.data;
+  return NextResponse.json({ result: roundValue(value, mode, decimals), mode });
+}

--- a/app/api/routes-f/team-name/__tests__/route.test.ts
+++ b/app/api/routes-f/team-name/__tests__/route.test.ts
@@ -1,0 +1,28 @@
+import { generateTeamNames } from "../route";
+
+describe("generateTeamNames", () => {
+  it("returns the requested count", () => {
+    expect(generateTeamNames(5, 42, "fierce")).toHaveLength(5);
+    expect(generateTeamNames(1, 7, "funny")).toHaveLength(1);
+  });
+
+  it("is deterministic for a given seed", () => {
+    expect(generateTeamNames(4, 42, "classic")).toEqual(
+      generateTeamNames(4, 42, "classic"),
+    );
+  });
+
+  it("differs across seeds", () => {
+    expect(generateTeamNames(4, 1, "classic")).not.toEqual(
+      generateTeamNames(4, 2, "classic"),
+    );
+  });
+
+  it("uses the requested style's adjective pool", () => {
+    const funnyAdjectives = ["Wobbly", "Sneaky", "Spicy", "Clumsy", "Hangry", "Derpy", "Sleepy", "Cheeky"];
+    for (const name of generateTeamNames(10, 99, "funny")) {
+      const adjective = name.split(" ")[0];
+      expect(funnyAdjectives).toContain(adjective);
+    }
+  });
+});

--- a/app/api/routes-f/team-name/route.ts
+++ b/app/api/routes-f/team-name/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+export type TeamStyle = "fierce" | "funny" | "classic";
+
+// Pools bundled in-folder (no external data deps).
+const ADJECTIVES: Record<TeamStyle, string[]> = {
+  fierce: ["Savage", "Iron", "Brutal", "Raging", "Venomous", "Storm", "Shadow", "Apex"],
+  funny: ["Wobbly", "Sneaky", "Spicy", "Clumsy", "Hangry", "Derpy", "Sleepy", "Cheeky"],
+  classic: ["Royal", "Golden", "United", "Athletic", "Imperial", "Grand", "Premier", "Legacy"],
+};
+
+const MASCOTS = [
+  "Tigers", "Wolves", "Falcons", "Dragons", "Vipers", "Titans",
+  "Sharks", "Ravens", "Bulls", "Phoenix", "Cobras", "Hawks",
+];
+
+/** Deterministic PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const pick = <T>(arr: T[], rng: () => number): T => arr[Math.floor(rng() * arr.length)];
+
+/** Generate `count` deterministic team names in the given style from `seed`. */
+export function generateTeamNames(count: number, seed: number, style: TeamStyle): string[] {
+  const rng = mulberry32(seed);
+  const adjectives = ADJECTIVES[style];
+  return Array.from({ length: count }, () => `${pick(adjectives, rng)} ${pick(MASCOTS, rng)}`);
+}
+
+const schema = z.object({
+  count: z.coerce.number().int().min(1).max(50).optional().default(5),
+  seed: z.coerce.number().int().optional().default(0),
+  style: z.enum(["fierce", "funny", "classic"]).optional().default("classic"),
+});
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const result = validateQuery(searchParams, schema);
+  if (result instanceof NextResponse) return result;
+  const { count, seed, style } = result.data;
+  return NextResponse.json({ names: generateTeamNames(count, seed, style) });
+}


### PR DESCRIPTION
## Summary
Four self-contained `routes-f` utilities, each exporting pure logic with unit tests.

closes #830
closes #842
closes #843
closes #851

- **#830 continent** `POST { code }` — ISO alpha-2 → `{ country, continent, region }` from an in-folder table spanning all continents; 404 on unknown.
- **#842 base64-validate** `POST { input, variant? }` — standard/url-safe/auto charset, padding placement, and length-divisibility checks → `{ valid, variant_detected, decoded_length }`.
- **#843 rounding** `POST { value, mode, decimals? }` — `half_up` / `half_even` (banker's) / `ceil` / `floor` / `trunc`, with .5-case tests per mode.
- **#851 team-name** `GET ?count&seed&style` — seeded-deterministic names from in-folder adjective (per-style) + mascot pools.
