### PR TITLE
Fix: api, algorithms, testing, routes-f

### DIFF
--- a/app/api/routes-f/__tests__/duration.test.ts
+++ b/app/api/routes-f/__tests__/duration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../duration/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/duration", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/duration", () => {
+  it("parses a time-only ISO 8601 duration", async () => {
+    const res = await POST(makeReq({ mode: "parse", text: "PT1H30M5S" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.components).toEqual({
+      years: 0,
+      months: 0,
+      weeks: 0,
+      days: 0,
+      hours: 1,
+      minutes: 30,
+      seconds: 5,
+    });
+    expect(data.total_seconds).toBe(5405);
+  });
+
+  it("round-trips a combined date and time duration", async () => {
+    const parseRes = await POST(
+      makeReq({ mode: "parse", text: "P1Y2M3W4DT5H6M7S" })
+    );
+    expect(parseRes.status).toBe(200);
+    const parsed = await parseRes.json();
+
+    expect(parsed.components).toEqual({
+      years: 1,
+      months: 2,
+      weeks: 3,
+      days: 4,
+      hours: 5,
+      minutes: 6,
+      seconds: 7,
+    });
+
+    const formatRes = await POST(
+      makeReq({ mode: "format", components: parsed.components })
+    );
+    expect(formatRes.status).toBe(200);
+    const formatted = await formatRes.json();
+
+    expect(formatted.text).toBe("P1Y2M3W4DT5H6M7S");
+    expect(formatted.total_seconds).toBe(1 * 31536000 + 2 * 2592000 + 3 * 604800 + 4 * 86400 + 5 * 3600 + 6 * 60 + 7);
+
+    const roundTripRes = await POST(makeReq({ mode: "parse", text: formatted.text }));
+    expect(roundTripRes.status).toBe(200);
+    const roundTrip = await roundTripRes.json();
+    expect(roundTrip.components).toEqual(parsed.components);
+  });
+
+  it("formats zero duration as PT0S", async () => {
+    const res = await POST(makeReq({ mode: "format", components: {} }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.text).toBe("PT0S");
+    expect(data.total_seconds).toBe(0);
+  });
+});

--- a/app/api/routes-f/__tests__/nth-prime.test.ts
+++ b/app/api/routes-f/__tests__/nth-prime.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../nth-prime/route";
+
+test("/api/routes-f/nth-prime returns the tenth prime", async () => {
+  const req = new NextRequest("http://localhost/api/routes-f/nth-prime?n=10");
+  const res = await GET(req);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ n: 10, prime: 29 });
+});
+
+test("/api/routes-f/nth-prime returns the 100000th prime", async () => {
+  const req = new NextRequest("http://localhost/api/routes-f/nth-prime?n=100000");
+  const res = await GET(req);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ n: 100000, prime: 1299709 });
+});
+
+test("/api/routes-f/nth-prime rejects out-of-range values", async () => {
+  const req = new NextRequest("http://localhost/api/routes-f/nth-prime?n=0");
+  const res = await GET(req);
+
+  expect(res.status).toBe(400);
+  const data = await res.json();
+  expect(data.error).toMatch(/integer between 1 and 100000/i);
+});

--- a/app/api/routes-f/__tests__/template-interpolation.test.ts
+++ b/app/api/routes-f/__tests__/template-interpolation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../template-interpolation/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/template-interpolation", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/template-interpolation", () => {
+  it("interpolates nested values using dot paths", async () => {
+    const res = await POST(
+      makeReq({
+        template: "Hello {{user.name}}, your city is {{user.location.city}}.",
+        values: { user: { name: "Alice", location: { city: "Seattle" } } },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      output: "Hello Alice, your city is Seattle.",
+      missing_keys: [],
+    });
+  });
+
+  it("replaces missing values with empty strings when on_missing is empty", async () => {
+    const res = await POST(
+      makeReq({
+        template: "Hi {{user.name}}, {{user.age}} years old.",
+        values: { user: { name: "Bob" } },
+        on_missing: "empty",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      output: "Hi Bob,  years old.",
+      missing_keys: ["user.age"],
+    });
+  });
+
+  it("keeps placeholders when on_missing is keep", async () => {
+    const res = await POST(
+      makeReq({
+        template: "Hello {{user.name}} and {{user.nickname}}.",
+        values: { user: { name: "Sam" } },
+        on_missing: "keep",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      output: "Hello Sam and {{user.nickname}}.",
+      missing_keys: ["user.nickname"],
+    });
+  });
+
+  it("returns error when on_missing is error and values are missing", async () => {
+    const res = await POST(
+      makeReq({
+        template: "{{a}} {{b}}",
+        values: { a: "1" },
+        on_missing: "error",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Missing values for template placeholders.",
+      missing_keys: ["b"],
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/text-similarity.test.ts
+++ b/app/api/routes-f/__tests__/text-similarity.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../text-similarity/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/text-similarity", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/text-similarity", () => {
+  it("returns 1 for identical text on both Jaccard and cosine", async () => {
+    const res = await POST(makeReq({ a: "The quick brown fox", b: "The quick brown fox" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.jaccard).toBe(1);
+    expect(data.cosine).toBe(1);
+  });
+
+  it("returns 0 for completely disjoint text", async () => {
+    const res = await POST(makeReq({ a: "apple orange", b: "cat dog" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.jaccard).toBe(0);
+    expect(data.cosine).toBe(0);
+  });
+
+  it("computes partial overlap using both algorithms", async () => {
+    const res = await POST(
+      makeReq({ a: "quick brown fox", b: "brown fox jumps", algorithm: "both" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.jaccard).toBe(0.5);
+    expect(data.cosine).toBeCloseTo(0.6667, 3);
+  });
+
+  it("supports single-algorithm selection", async () => {
+    const res = await POST(makeReq({ a: "a b c", b: "a b", algorithm: "jaccard" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data).toEqual({ jaccard: 0.6666666666666666 });
+  });
+});

--- a/app/api/routes-f/_lib/duration.ts
+++ b/app/api/routes-f/_lib/duration.ts
@@ -1,0 +1,103 @@
+export type DurationComponents = {
+  years?: number;
+  months?: number;
+  weeks?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+};
+
+const DURATION_PATTERN = /^P(?:(\d+(?:\.\d+)?)Y)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)W)?(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+
+export function parseDuration(text: string): DurationComponents {
+  if (typeof text !== "string") {
+    throw new Error("Duration text must be a string.");
+  }
+
+  const match = DURATION_PATTERN.exec(text);
+  if (!match) {
+    throw new Error("Invalid ISO 8601 duration format.");
+  }
+
+  const [
+    ,
+    years = "0",
+    months = "0",
+    weeks = "0",
+    days = "0",
+    hours = "0",
+    minutes = "0",
+    seconds = "0",
+  ] = match;
+
+  return {
+    years: Number(years),
+    months: Number(months),
+    weeks: Number(weeks),
+    days: Number(days),
+    hours: Number(hours),
+    minutes: Number(minutes),
+    seconds: Number(seconds),
+  };
+}
+
+export function formatDuration(components: DurationComponents): string {
+  const normalized = normalizeComponents(components);
+  const { years, months, weeks, days, hours, minutes, seconds } = normalized;
+
+  if (!years && !months && !weeks && !days && !hours && !minutes && !seconds) {
+    return "PT0S";
+  }
+
+  let text = "P";
+
+  if (years) text += `${years}Y`;
+  if (months) text += `${months}M`;
+  if (weeks) text += `${weeks}W`;
+  if (days) text += `${days}D`;
+
+  if (hours || minutes || seconds) {
+    text += "T";
+    if (hours) text += `${hours}H`;
+    if (minutes) text += `${minutes}M`;
+    if (seconds) text += `${seconds}S`;
+  }
+
+  return text;
+}
+
+export function durationToSeconds(components: DurationComponents): number {
+  const { years, months, weeks, days, hours, minutes, seconds } = normalizeComponents(components);
+
+  return (
+    years * 31536000 +
+    months * 2592000 +
+    weeks * 604800 +
+    days * 86400 +
+    hours * 3600 +
+    minutes * 60 +
+    seconds
+  );
+}
+
+export function normalizeComponents(components: DurationComponents): Required<DurationComponents> {
+  const normalized = {
+    years: 0,
+    months: 0,
+    weeks: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    ...components,
+  };
+
+  for (const [key, value] of Object.entries(normalized)) {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new Error("Duration components must be non-negative finite numbers.");
+    }
+  }
+
+  return normalized;
+}

--- a/app/api/routes-f/_lib/prime.ts
+++ b/app/api/routes-f/_lib/prime.ts
@@ -1,0 +1,52 @@
+function getSieveLimit(n: number): number {
+  if (n < 6) {
+    return 15;
+  }
+
+  return Math.ceil(n * (Math.log(n) + Math.log(Math.log(n)))) + 10;
+}
+
+function sieveNthPrime(n: number, limit: number): number | null {
+  const sieve = new Uint8Array(limit + 1);
+  sieve.fill(1);
+  sieve[0] = 0;
+  sieve[1] = 0;
+
+  let count = 0;
+
+  for (let i = 2; i <= limit; i += 1) {
+    if (!sieve[i]) {
+      continue;
+    }
+
+    count += 1;
+    if (count === n) {
+      return i;
+    }
+
+    const step = i * i;
+    if (step <= limit) {
+      for (let j = step; j <= limit; j += i) {
+        sieve[j] = 0;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function findNthPrime(n: number): number {
+  if (!Number.isInteger(n) || n < 1 || n > 100000) {
+    throw new Error("n must be an integer between 1 and 100000.");
+  }
+
+  let limit = getSieveLimit(n);
+  let prime = sieveNthPrime(n, limit);
+
+  while (prime === null) {
+    limit = Math.ceil(limit * 1.2) + 10;
+    prime = sieveNthPrime(n, limit);
+  }
+
+  return prime;
+}

--- a/app/api/routes-f/_lib/templateInterpolation.ts
+++ b/app/api/routes-f/_lib/templateInterpolation.ts
@@ -1,0 +1,58 @@
+export type MissingMode = "empty" | "keep" | "error";
+
+export type InterpolationResult = {
+  output: string;
+  missing_keys: string[];
+};
+
+function resolveValue(values: unknown, path: string): unknown {
+  const segments = path.split(".").filter(Boolean);
+  let current = values;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+
+    if (Array.isArray(current)) {
+      current = (current as any)[segment];
+    } else {
+      current = (current as Record<string, unknown>)[segment];
+    }
+  }
+
+  return current;
+}
+
+export function interpolateTemplate(
+  template: string,
+  values: unknown,
+  onMissing: MissingMode = "empty"
+): InterpolationResult {
+  const missingKeys = new Set<string>();
+
+  const output = template.replace(/{{\s*([^}]+?)\s*}}/g, (match, path) => {
+    const key = String(path).trim();
+    const resolved = resolveValue(values, key);
+
+    if (resolved === undefined || resolved === null) {
+      missingKeys.add(key);
+      return onMissing === "keep" ? match : "";
+    }
+
+    if (typeof resolved === "string") {
+      return resolved;
+    }
+
+    if (typeof resolved === "number" || typeof resolved === "boolean") {
+      return String(resolved);
+    }
+
+    return JSON.stringify(resolved);
+  });
+
+  return {
+    output,
+    missing_keys: Array.from(missingKeys),
+  };
+}

--- a/app/api/routes-f/_lib/textSimilarity.ts
+++ b/app/api/routes-f/_lib/textSimilarity.ts
@@ -1,0 +1,75 @@
+export type SimilarityAlgorithm = "jaccard" | "cosine" | "both";
+
+export function tokenize(text: string): string[] {
+  return Array.from(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+}
+
+export function jaccardSimilarity(a: string, b: string): number {
+  const aTokens = new Set(tokenize(a));
+  const bTokens = new Set(tokenize(b));
+
+  if (aTokens.size === 0 && bTokens.size === 0) {
+    return 1;
+  }
+
+  const intersectionSize = Array.from(aTokens).reduce((count, token) => {
+    return bTokens.has(token) ? count + 1 : count;
+  }, 0);
+
+  const unionSize = new Set([...aTokens, ...bTokens]).size;
+  return unionSize === 0 ? 0 : intersectionSize / unionSize;
+}
+
+export function cosineSimilarity(a: string, b: string): number {
+  const aTokens = tokenize(a);
+  const bTokens = tokenize(b);
+
+  if (aTokens.length === 0 && bTokens.length === 0) {
+    return 1;
+  }
+
+  const aFreq = new Map<string, number>();
+  const bFreq = new Map<string, number>();
+
+  for (const token of aTokens) {
+    aFreq.set(token, (aFreq.get(token) ?? 0) + 1);
+  }
+  for (const token of bTokens) {
+    bFreq.set(token, (bFreq.get(token) ?? 0) + 1);
+  }
+
+  let dotProduct = 0;
+  let aSum = 0;
+  let bSum = 0;
+
+  for (const [token, aCount] of aFreq.entries()) {
+    aSum += aCount * aCount;
+    const bCount = bFreq.get(token) ?? 0;
+    dotProduct += aCount * bCount;
+  }
+
+  for (const bCount of bFreq.values()) {
+    bSum += bCount * bCount;
+  }
+
+  const denominator = Math.sqrt(aSum) * Math.sqrt(bSum);
+  return denominator === 0 ? 0 : dotProduct / denominator;
+}
+
+export function computeSimilarity(
+  a: string,
+  b: string,
+  algorithm: SimilarityAlgorithm = "both"
+): { jaccard?: number; cosine?: number } {
+  const result: { jaccard?: number; cosine?: number } = {};
+
+  if (algorithm === "jaccard" || algorithm === "both") {
+    result.jaccard = jaccardSimilarity(a, b);
+  }
+
+  if (algorithm === "cosine" || algorithm === "both") {
+    result.cosine = cosineSimilarity(a, b);
+  }
+
+  return result;
+}

--- a/app/api/routes-f/duration/route.ts
+++ b/app/api/routes-f/duration/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import {
+  DurationComponents,
+  durationToSeconds,
+  formatDuration,
+  parseDuration,
+} from "@/app/api/routes-f/_lib/duration";
+
+const durationComponentsSchema = z.object({
+  years: z.number().min(0).optional(),
+  months: z.number().min(0).optional(),
+  weeks: z.number().min(0).optional(),
+  days: z.number().min(0).optional(),
+  hours: z.number().min(0).optional(),
+  minutes: z.number().min(0).optional(),
+  seconds: z.number().min(0).optional(),
+});
+
+const durationBodySchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("parse"), text: z.string() }),
+  z.object({ mode: z.literal("format"), components: durationComponentsSchema }),
+]);
+
+export async function POST(req: NextRequest) {
+  const validated = await validateBody(req, durationBodySchema);
+  if (validated instanceof NextResponse) {
+    return validated;
+  }
+
+  const { mode } = validated.data;
+
+  if (mode === "parse") {
+    const { text } = validated.data;
+    try {
+      const parsed = parseDuration(text);
+      return NextResponse.json({
+        text,
+        components: parsed,
+        total_seconds: durationToSeconds(parsed),
+      });
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : "Invalid ISO duration." },
+        { status: 400 }
+      );
+    }
+  }
+
+  try {
+    const formatted = formatDuration(components as DurationComponents);
+    const normalized = parseDuration(formatted);
+    return NextResponse.json({
+      text: formatted,
+      components: normalized,
+      total_seconds: durationToSeconds(normalized),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to format duration." },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routes-f/nth-prime/route.ts
+++ b/app/api/routes-f/nth-prime/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { findNthPrime } from "@/app/api/routes-f/_lib/prime";
+
+const querySchema = z.object({
+  n: z.string(),
+});
+
+export async function GET(req: NextRequest) {
+  const validated = validateQuery(req.nextUrl.searchParams, querySchema);
+  if (validated instanceof NextResponse) {
+    return validated;
+  }
+
+  const n = Number(validated.data.n);
+  if (!Number.isInteger(n) || n < 1 || n > 100000) {
+    return NextResponse.json(
+      { error: "n must be an integer between 1 and 100000." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const prime = findNthPrime(n);
+    return NextResponse.json({ n, prime });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to compute nth prime." },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routes-f/template-interpolation/route.ts
+++ b/app/api/routes-f/template-interpolation/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import {
+  interpolateTemplate,
+  type MissingMode,
+} from "@/app/api/routes-f/_lib/templateInterpolation";
+
+const interpolationBodySchema = z.object({
+  template: z.string(),
+  values: z.any(),
+  on_missing: z.enum(["empty", "keep", "error"]).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const validated = await validateBody(req, interpolationBodySchema);
+  if (validated instanceof NextResponse) {
+    return validated;
+  }
+
+  const { template, values, on_missing } = validated.data;
+  const mode = (on_missing as MissingMode) ?? "empty";
+
+  const result = interpolateTemplate(template, values, mode);
+  if (mode === "error" && result.missing_keys.length > 0) {
+    return NextResponse.json(
+      {
+        error: "Missing values for template placeholders.",
+        missing_keys: result.missing_keys,
+      },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/api/routes-f/text-similarity/route.ts
+++ b/app/api/routes-f/text-similarity/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { computeSimilarity, type SimilarityAlgorithm } from "@/app/api/routes-f/_lib/textSimilarity";
+
+const similarityBodySchema = z.object({
+  a: z.string(),
+  b: z.string(),
+  algorithm: z.enum(["jaccard", "cosine", "both"]).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const validated = await validateBody(req, similarityBodySchema);
+  if (validated instanceof NextResponse) {
+    return validated;
+  }
+
+  const { a, b, algorithm } = validated.data;
+  const normalizedAlgorithm = algorithm ?? "both";
+  return NextResponse.json(computeSimilarity(a, b, normalizedAlgorithm as SimilarityAlgorithm));
+}


### PR DESCRIPTION
# Pull Request Summary

Close #845,
Close #857,
Close #865,
Close #879

## Description

This PR adds a scoped set of independent API utilities entirely inside `app/api/routes-f/`, without importing from or modifying shared folders outside those directories.

The following endpoints were implemented:

- `POST /api/routes-f/duration`
  - Supports `mode: parse|format`
  - Parses ISO 8601 durations and returns normalized `components` plus `total_seconds`
  - Formats duration component objects back into ISO 8601 strings
- `GET /api/routes-f/nth-prime?n=...`
  - Validates `n` within `[1, 100000]`
  - Computes the nth prime efficiently using a sieve-based algorithm
- `POST /api/routes-f/text-similarity`
  - Supports `jaccard`, `cosine`, and `both`
  - Tokenizes lowercase words and returns normalized similarity scores in `[0,1]`
- `POST /api/routes-f/template-interpolation`
  - Resolves dot-path placeholders like `{{user.name}}`
  - Supports `on_missing` modes: `empty`, `keep`, and `error`
  - Returns interpolated output and `missing_keys`

## Files added

- `app/api/routes-f/_lib/duration.ts`
- `app/api/routes-f/_lib/prime.ts`
- `app/api/routes-f/_lib/textSimilarity.ts`
- `app/api/routes-f/_lib/templateInterpolation.ts`
- `app/api/routes-f/duration/route.ts`
- `app/api/routes-f/nth-prime/route.ts`
- `app/api/routes-f/text-similarity/route.ts`
- `app/api/routes-f/template-interpolation/route.ts`
- `app/api/routes-f/__tests__/duration.test.ts`
- `app/api/routes-f/__tests__/nth-prime.test.ts`
- `app/api/routes-f/__tests__/text-similarity.test.ts`
- `app/api/routes-f/__tests__/template-interpolation.test.ts`

## Test coverage

New tests cover:

- Duration parsing and round-trip formatting, including date/time durations
- nth-prime small and large values, plus validation errors
- Text similarity for identical, disjoint, and partial-overlap text pairs
- Template interpolation nested values and all `on_missing` modes

## Notes

- All route logic is self-contained under `app/api/routes-f/`
- No shared directories outside of `routes-f` were imported or modified
- The implementation is intentionally isolated for testability and clarity
