### PR TITLE
feat(routesF): ROI calculator, MIME magic, word wrap, dedupe-by-key

### DIFF
--- a/app/api/routesF/dedupe-by-key/route.test.ts
+++ b/app/api/routesF/dedupe-by-key/route.test.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/dedupe-by-key", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Dedupe By Key API", () => {
+  it("keeps first occurrence by default", async () => {
+    const items = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 1, name: "c" },
+    ];
+    const res = await POST(makeReq({ items, key: "id" }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.items).toEqual([
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ]);
+    expect(data.removed_count).toBe(1);
+  });
+
+  it("keeps last occurrence when keep=last", async () => {
+    const items = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 1, name: "c" },
+    ];
+    const res = await POST(makeReq({ items, key: "id", keep: "last" }));
+    const data = await res.json();
+    expect(data.items).toEqual([
+      { id: 2, name: "b" },
+      { id: 1, name: "c" },
+    ]);
+    expect(data.removed_count).toBe(1);
+  });
+
+  it("supports dot-path keys", async () => {
+    const items = [
+      { user: { id: 1 }, name: "a" },
+      { user: { id: 2 }, name: "b" },
+      { user: { id: 1 }, name: "c" },
+    ];
+    const res = await POST(makeReq({ items, key: "user.id" }));
+    const data = await res.json();
+    expect(data.items).toHaveLength(2);
+    expect(data.removed_count).toBe(1);
+  });
+
+  it("returns 400 for missing items", async () => {
+    const res = await POST(makeReq({ key: "id" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing key", async () => {
+    const res = await POST(makeReq({ items: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for items exceeding 10000", async () => {
+    const items = Array.from({ length: 10001 }, (_, i) => ({ id: i }));
+    const res = await POST(makeReq({ items, key: "id" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("handles empty array", async () => {
+    const res = await POST(makeReq({ items: [], key: "id" }));
+    const data = await res.json();
+    expect(data.items).toEqual([]);
+    expect(data.removed_count).toBe(0);
+  });
+});

--- a/app/api/routesF/dedupe-by-key/route.ts
+++ b/app/api/routesF/dedupe-by-key/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type DedupeBody = {
+  items?: unknown;
+  key?: unknown;
+  keep?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  let current: unknown = obj;
+  for (const segment of path.split(".")) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export async function POST(req: NextRequest) {
+  let body: DedupeBody;
+
+  try {
+    body = (await req.json()) as DedupeBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { items, key, keep } = body;
+
+  if (!Array.isArray(items)) {
+    return badRequest("items must be an array.");
+  }
+
+  if (items.length > 10000) {
+    return badRequest("items must not exceed 10000 elements.");
+  }
+
+  if (typeof key !== "string" || key.length === 0) {
+    return badRequest("key must be a non-empty string.");
+  }
+
+  const keepMode = keep === "last" ? "last" : "first";
+
+  const seen = new Map<unknown, number>();
+
+  for (let i = 0; i < items.length; i++) {
+    const value = getByPath(items[i], key);
+    seen.set(value, i);
+  }
+
+  const result: unknown[] = [];
+  const seenKeys = new Set<unknown>();
+
+  if (keepMode === "last") {
+    for (let i = items.length - 1; i >= 0; i--) {
+      const value = getByPath(items[i], key);
+      if (!seenKeys.has(value)) {
+        seenKeys.add(value);
+        result.unshift(items[i]);
+      }
+    }
+  } else {
+    for (let i = 0; i < items.length; i++) {
+      const value = getByPath(items[i], key);
+      if (!seenKeys.has(value)) {
+        seenKeys.add(value);
+        result.push(items[i]);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    items: result,
+    removed_count: items.length - result.length,
+  });
+}

--- a/app/api/routesF/mime-magic/route.test.ts
+++ b/app/api/routesF/mime-magic/route.test.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(hex: string) {
+  return new NextRequest("http://localhost/api/routesF/mime-magic", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ hex }),
+  });
+}
+
+describe("MIME Magic API", () => {
+  it("detects PNG", async () => {
+    const res = await POST(makeReq("89504e470d0a1a0a"));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.mime).toBe("image/png");
+    expect(data.extension).toBe("png");
+  });
+
+  it("detects JPEG", async () => {
+    const res = await POST(makeReq("ffd8ffe000104a46"));
+    const data = await res.json();
+    expect(data.mime).toBe("image/jpeg");
+    expect(data.extension).toBe("jpg");
+  });
+
+  it("detects GIF", async () => {
+    const res = await POST(makeReq("474946383961"));
+    const data = await res.json();
+    expect(data.mime).toBe("image/gif");
+  });
+
+  it("detects PDF", async () => {
+    const res = await POST(makeReq("255044462d312e34"));
+    const data = await res.json();
+    expect(data.mime).toBe("application/pdf");
+  });
+
+  it("detects ZIP", async () => {
+    const res = await POST(makeReq("504b030414000000"));
+    const data = await res.json();
+    expect(data.mime).toBe("application/zip");
+  });
+
+  it("detects GZIP", async () => {
+    const res = await POST(makeReq("1f8b0800"));
+    const data = await res.json();
+    expect(data.mime).toBe("application/gzip");
+  });
+
+  it("detects WebP", async () => {
+    const res = await POST(makeReq("52494646e0730c00"));
+    const data = await res.json();
+    expect(data.mime).toBe("image/webp");
+  });
+
+  it("returns null for unknown bytes", async () => {
+    const res = await POST(makeReq("deadbeef"));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.mime).toBeNull();
+    expect(data.extension).toBeNull();
+    expect(data.matched).toBeNull();
+  });
+
+  it("returns 400 for empty hex", async () => {
+    const res = await POST(makeReq(""));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid hex", async () => {
+    const res = await POST(makeReq("zzzz"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for odd-length hex", async () => {
+    const res = await POST(makeReq("abc"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/mime-magic/route.ts
+++ b/app/api/routesF/mime-magic/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { SIGNATURES } from "./signatures";
+
+type MimeBody = {
+  hex?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: MimeBody;
+
+  try {
+    body = (await req.json()) as MimeBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { hex } = body;
+
+  if (typeof hex !== "string" || hex.length === 0) {
+    return badRequest("hex must be a non-empty hex string.");
+  }
+
+  const cleanHex = hex.replace(/\s+/g, "");
+  if (!/^[0-9a-fA-F]*$/.test(cleanHex) || cleanHex.length % 2 !== 0) {
+    return badRequest("hex must contain an even number of valid hex characters.");
+  }
+
+  const bytes: number[] = [];
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
+  }
+
+  for (const sig of SIGNATURES) {
+    if (bytes.length >= sig.bytes.length) {
+      let match = true;
+      for (let i = 0; i < sig.bytes.length; i++) {
+        if (bytes[i] !== sig.bytes[i]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        return NextResponse.json({
+          mime: sig.mime,
+          extension: sig.extension,
+          matched: sig.bytes.map((b) => b.toString(16).padStart(2, "0")).join(""),
+        });
+      }
+    }
+  }
+
+  return NextResponse.json({ mime: null, extension: null, matched: null });
+}

--- a/app/api/routesF/mime-magic/signatures.ts
+++ b/app/api/routesF/mime-magic/signatures.ts
@@ -1,0 +1,10 @@
+export const SIGNATURES: { mime: string; extension: string; bytes: number[] }[] = [
+  { mime: "image/png", extension: "png", bytes: [0x89, 0x50, 0x4e, 0x47] },
+  { mime: "image/jpeg", extension: "jpg", bytes: [0xff, 0xd8, 0xff] },
+  { mime: "image/gif", extension: "gif", bytes: [0x47, 0x49, 0x46, 0x38] },
+  { mime: "application/pdf", extension: "pdf", bytes: [0x25, 0x50, 0x44, 0x46] },
+  { mime: "application/zip", extension: "zip", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/gzip", extension: "gz", bytes: [0x1f, 0x8b] },
+  { mime: "video/mp4", extension: "mp4", bytes: [0x00, 0x00, 0x00] }, // ftyp box prefix
+  { mime: "image/webp", extension: "webp", bytes: [0x52, 0x49, 0x46, 0x46] }, // RIFF header
+];

--- a/app/api/routesF/roi-calculator/route.test.ts
+++ b/app/api/routesF/roi-calculator/route.test.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/roi-calculator", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("ROI Calculator API", () => {
+  it("computes a simple gain", async () => {
+    const res = await POST(makeReq({ initial: 100, final: 150 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.roi_percent).toBeCloseTo(50);
+    expect(data.gain).toBe(50);
+  });
+
+  it("computes a loss", async () => {
+    const res = await POST(makeReq({ initial: 200, final: 100 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.roi_percent).toBeCloseTo(-50);
+    expect(data.gain).toBe(-100);
+  });
+
+  it("computes annualized ROI when years provided", async () => {
+    const res = await POST(makeReq({ initial: 100, final: 200, years: 3 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.roi_percent).toBeCloseTo(100);
+    expect(data.annualized_percent).toBeCloseTo(25.992, 1);
+  });
+
+  it("returns 400 for missing initial", async () => {
+    const res = await POST(makeReq({ final: 100 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for zero initial", async () => {
+    const res = await POST(makeReq({ initial: 0, final: 100 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-positive years", async () => {
+    const res = await POST(makeReq({ initial: 100, final: 200, years: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routesF/roi-calculator", {
+      method: "POST",
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/roi-calculator/route.ts
+++ b/app/api/routesF/roi-calculator/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type ROIBody = {
+  initial?: unknown;
+  final?: unknown;
+  years?: unknown;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: ROIBody;
+
+  try {
+    body = (await req.json()) as ROIBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { initial, final, years } = body;
+
+  if (!isFiniteNumber(initial) || !isFiniteNumber(final)) {
+    return badRequest("initial and final must be finite numbers.");
+  }
+
+  if (initial === 0) {
+    return badRequest("initial must not be zero.");
+  }
+
+  const gain = final - initial;
+  const roi_percent = (gain / Math.abs(initial)) * 100;
+
+  const result: Record<string, number> = { roi_percent, gain };
+
+  if (years !== undefined) {
+    if (!isFiniteNumber(years) || years <= 0) {
+      return badRequest("years must be a positive number.");
+    }
+    result.annualized_percent =
+      (Math.pow(final / initial, 1 / years) - 1) * 100;
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/api/routesF/word-wrap/route.test.ts
+++ b/app/api/routesF/word-wrap/route.test.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/word-wrap", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Word Wrap API", () => {
+  it("wraps text at word boundaries", async () => {
+    const res = await POST(makeReq({ text: "hello world foo bar", width: 11 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.wrapped).toBe("hello world\nfoo bar");
+    expect(data.line_count).toBe(2);
+  });
+
+  it("preserves existing newlines as paragraph breaks", async () => {
+    const res = await POST(makeReq({ text: "first line\nsecond line", width: 100 }));
+    const data = await res.json();
+    expect(data.line_count).toBe(2);
+    expect(data.wrapped).toBe("first line\nsecond line");
+  });
+
+  it("hard breaks long words", async () => {
+    const res = await POST(makeReq({ text: "abcdefghijklmnop", width: 5, hard_break: true }));
+    const data = await res.json();
+    expect(data.wrapped).toBe("abcde\nfghij\nklmno\np");
+    expect(data.line_count).toBe(4);
+  });
+
+  it("returns 400 for missing text", async () => {
+    const res = await POST(makeReq({ width: 10 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid width", async () => {
+    const res = await POST(makeReq({ text: "hello", width: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("handles empty text", async () => {
+    const res = await POST(makeReq({ text: "", width: 10 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.line_count).toBe(1);
+  });
+});

--- a/app/api/routesF/word-wrap/route.ts
+++ b/app/api/routesF/word-wrap/route.ts
@@ -1,0 +1,74 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type WrapBody = {
+  text?: unknown;
+  width?: unknown;
+  hard_break?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function wrapLine(line: string, width: number, hardBreak: boolean): string[] {
+  if (line.length <= width) return [line];
+
+  const result: string[] = [];
+  let remaining = line;
+
+  while (remaining.length > width) {
+    if (hardBreak) {
+      result.push(remaining.substring(0, width));
+      remaining = remaining.substring(width);
+    } else {
+      let breakPoint = remaining.lastIndexOf(" ", width);
+      if (breakPoint <= 0) breakPoint = width;
+      result.push(remaining.substring(0, breakPoint));
+      remaining = remaining.substring(breakPoint).replace(/^ /, "");
+    }
+  }
+
+  if (remaining.length > 0) result.push(remaining);
+  return result;
+}
+
+export async function POST(req: NextRequest) {
+  let body: WrapBody;
+
+  try {
+    body = (await req.json()) as WrapBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { text, width, hard_break } = body;
+
+  if (typeof text !== "string") {
+    return badRequest("text must be a string.");
+  }
+
+  if (!isFiniteNumber(width) || width < 1) {
+    return badRequest("width must be a positive number.");
+  }
+
+  const hardBreak = hard_break === true;
+  const paragraphs = text.split("\n");
+  const wrappedLines: string[] = [];
+
+  for (const para of paragraphs) {
+    if (para.length === 0) {
+      wrappedLines.push("");
+    } else {
+      wrappedLines.push(...wrapLine(para, width, hardBreak));
+    }
+  }
+
+  return NextResponse.json({
+    wrapped: wrappedLines.join("\n"),
+    line_count: wrappedLines.length,
+  });
+}


### PR DESCRIPTION
Fixes #831, #832, #834, #835

## What changed
- **ROI calculator** (`roi-calculator/`): POST { initial, final, years? } → { roi_percent, gain, annualized_percent? }
- **MIME magic** (`mime-magic/`): POST { hex } → { mime, extension, matched } — detects png, jpg, gif, pdf, zip, gzip, mp4, webp
- **Word wrap** (`word-wrap/`): POST { text, width, hard_break? } → { wrapped, line_count }
- **Dedupe by key** (`dedupe-by-key/`): POST { items, key, keep? } → { items, removed_count } with dot-path key support

## Why
Implements the 4 requested utility endpoints scoped to `app/api/routesF/`.

## How to test
Run: `npx jest app/api/routesF/roi-calculator app/api/routesF/mime-magic app/api/routesF/word-wrap app/api/routesF/dedupe-by-key --no-coverage`
All 31 tests pass.

Closes #831
Closes #832
Closes #834
Closes #835