### PR TITLE
feat: implement 4 routesF API endpoints

### DIFF
--- a/app/api/routesF/__tests__/company-name-generator.test.ts
+++ b/app/api/routesF/__tests__/company-name-generator.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../company-name-generator/route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/company-name-generator");
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
+describe("/api/routesF/company-name-generator", () => {
+  it("generates default 5 company names", async () => {
+    const res = await GET(makeReq());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.names).toHaveLength(5);
+    expect(data.count).toBe(5);
+    expect(data.industry).toBe("any");
+    expect(typeof data.seed).toBe("string");
+  });
+
+  it("respects count parameter", async () => {
+    const res = await GET(makeReq({ count: "3" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.names).toHaveLength(3);
+    expect(data.count).toBe(3);
+  });
+
+  it("filters by tech industry", async () => {
+    const res = await GET(makeReq({ industry: "tech", count: "10" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.industry).toBe("tech");
+    expect(data.names).toHaveLength(10);
+    
+    // Check that names contain tech-related words
+    const allNames = data.names.join(" ");
+    const techWords = ["Tech", "Digital", "Cyber", "Smart", "Data", "Cloud", "System", "Network", "Labs", "Solutions"];
+    const containsTechWords = techWords.some(word => allNames.includes(word));
+    expect(containsTechWords).toBe(true);
+  });
+
+  it("produces deterministic results with seed", async () => {
+    const res1 = await GET(makeReq({ seed: "42", count: "3" }));
+    const data1 = await res1.json();
+
+    const res2 = await GET(makeReq({ seed: "42", count: "3" }));
+    const data2 = await res2.json();
+
+    expect(data1.names).toEqual(data2.names);
+    expect(data1.seed).toBe(42);
+    expect(data2.seed).toBe(42);
+  });
+
+  it("produces different results with different seeds", async () => {
+    const res1 = await GET(makeReq({ seed: "42", count: "5" }));
+    const data1 = await res1.json();
+
+    const res2 = await GET(makeReq({ seed: "123", count: "5" }));
+    const data2 = await res2.json();
+
+    expect(data1.names).not.toEqual(data2.names);
+  });
+
+  it("handles finance industry filter", async () => {
+    const res = await GET(makeReq({ industry: "finance", count: "5" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.industry).toBe("finance");
+    
+    const allNames = data.names.join(" ");
+    const financeWords = ["Capital", "Bank", "Fund", "Investment", "Trust", "Partners", "Holdings"];
+    const containsFinanceWords = financeWords.some(word => allNames.includes(word));
+    expect(containsFinanceWords).toBe(true);
+  });
+
+  it("handles food industry filter", async () => {
+    const res = await GET(makeReq({ industry: "food", count: "5" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.industry).toBe("food");
+    
+    const allNames = data.names.join(" ");
+    const foodWords = ["Fresh", "Organic", "Kitchen", "Bistro", "Cafe", "Foods", "Grill"];
+    const containsFoodWords = foodWords.some(word => allNames.includes(word));
+    expect(containsFoodWords).toBe(true);
+  });
+
+  it("clamps count to reasonable limits", async () => {
+    const res = await GET(makeReq({ count: "100" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.count).toBe(50); // Should be clamped to max 50
+  });
+
+  it("handles invalid industry gracefully", async () => {
+    const res = await GET(makeReq({ industry: "invalid" }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/__tests__/pascal-triangle.test.ts
+++ b/app/api/routesF/__tests__/pascal-triangle.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../pascal-triangle/route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/pascal-triangle");
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
+describe("/api/routesF/pascal-triangle", () => {
+  it("generates default 5 rows of Pascal's triangle", async () => {
+    const res = await GET(makeReq());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.triangle).toHaveLength(5);
+    expect(data.rows).toBe(5);
+    
+    // Verify the structure of first 5 rows
+    expect(data.triangle[0]).toEqual([1]);
+    expect(data.triangle[1]).toEqual([1, 1]);
+    expect(data.triangle[2]).toEqual([1, 2, 1]);
+    expect(data.triangle[3]).toEqual([1, 3, 3, 1]);
+    expect(data.triangle[4]).toEqual([1, 4, 6, 4, 1]);
+  });
+
+  it("generates single row", async () => {
+    const res = await GET(makeReq({ rows: "1" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.triangle).toEqual([[1]]);
+    expect(data.rows).toBe(1);
+  });
+
+  it("generates 10 rows correctly", async () => {
+    const res = await GET(makeReq({ rows: "10" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.triangle).toHaveLength(10);
+    
+    // Verify row 9 (10th row, 0-indexed)
+    expect(data.triangle[9]).toEqual([1, 9, 36, 84, 126, 126, 84, 36, 9, 1]);
+  });
+
+  it("verifies row sums are powers of 2", async () => {
+    const res = await GET(makeReq({ rows: "8" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    
+    data.triangle.forEach((row: number[], index: number) => {
+      const sum = row.reduce((acc, val) => acc + val, 0);
+      expect(sum).toBe(Math.pow(2, index));
+    });
+  });
+
+  it("verifies symmetry of rows", async () => {
+    const res = await GET(makeReq({ rows: "7" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    
+    data.triangle.forEach((row: number[]) => {
+      const reversed = [...row].reverse();
+      expect(row).toEqual(reversed);
+    });
+  });
+
+  it("handles large row counts with BigInt", async () => {
+    const res = await GET(makeReq({ rows: "20" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.triangle).toHaveLength(20);
+    
+    // Row 19 should have large numbers but still be accurate
+    const row19 = data.triangle[19];
+    expect(row19[0]).toBe(1);
+    expect(row19[1]).toBe(19);
+    expect(row19[10]).toBe(92378); // C(19,10)
+  });
+
+  it("rejects rows less than 1", async () => {
+    const res = await GET(makeReq({ rows: "0" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects rows greater than 50", async () => {
+    const res = await GET(makeReq({ rows: "51" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid row parameter", async () => {
+    const res = await GET(makeReq({ rows: "invalid" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("verifies binomial coefficient properties", async () => {
+    const res = await GET(makeReq({ rows: "6" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    
+    // Row 5 (6th row): [1, 5, 10, 10, 5, 1]
+    const row5 = data.triangle[5];
+    expect(row5).toEqual([1, 5, 10, 10, 5, 1]);
+    
+    // Verify C(5,2) = C(5,3) = 10 (symmetry)
+    expect(row5[2]).toBe(row5[3]);
+    expect(row5[2]).toBe(10);
+  });
+});

--- a/app/api/routesF/__tests__/text-excerpt.test.ts
+++ b/app/api/routesF/__tests__/text-excerpt.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../text-excerpt/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/text-excerpt", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/text-excerpt", () => {
+  const sampleText = "The quick brown fox jumps over the lazy dog. This is a sample text for testing purposes.";
+
+  it("extracts excerpt around keyword in middle of text", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "fox",
+      radius: 10
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("brown fox jumps ov");
+    expect(data.match_index).toBe(16);
+    expect(data.highlighted).toBeUndefined();
+  });
+
+  it("extracts excerpt with highlighting", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "fox",
+      radius: 10,
+      highlight: true
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("brown fox jumps ov");
+    expect(data.highlighted).toBe("brown <mark>fox</mark> jumps ov");
+    expect(data.match_index).toBe(16);
+  });
+
+  it("handles keyword at start of text", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "The",
+      radius: 15
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("The quick brown f");
+    expect(data.match_index).toBe(0);
+  });
+
+  it("handles keyword at end of text", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "purposes",
+      radius: 20
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("for testing purposes.");
+    expect(data.match_index).toBe(75);
+  });
+
+  it("uses default radius of 50", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "fox"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("The quick brown fox jumps over the lazy dog. This is a sample text for testing purposes.");
+    expect(data.match_index).toBe(16);
+  });
+
+  it("handles case-insensitive matching", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "QUICK",
+      radius: 10
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("The quick brown f");
+    expect(data.match_index).toBe(4);
+  });
+
+  it("preserves original case in excerpt", async () => {
+    const res = await POST(makeReq({
+      text: "Hello WORLD this is a Test",
+      keyword: "world",
+      radius: 10,
+      highlight: true
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("Hello WORLD this i");
+    expect(data.highlighted).toBe("Hello <mark>WORLD</mark> this i");
+  });
+
+  it("returns 404 when keyword not found", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "elephant"
+    }));
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Keyword not found in text");
+  });
+
+  it("handles empty keyword", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: ""
+    }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("handles missing text field", async () => {
+    const res = await POST(makeReq({
+      keyword: "test"
+    }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("handles invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routesF/text-excerpt", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("handles radius of 0", async () => {
+    const res = await POST(makeReq({
+      text: sampleText,
+      keyword: "fox",
+      radius: 0
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("fox");
+    expect(data.match_index).toBe(16);
+  });
+
+  it("handles very large radius", async () => {
+    const res = await POST(makeReq({
+      text: "Short text with keyword here",
+      keyword: "keyword",
+      radius: 1000
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.excerpt).toBe("Short text with keyword here");
+    expect(data.match_index).toBe(16);
+  });
+
+  it("finds first occurrence when keyword appears multiple times", async () => {
+    const text = "The cat and the dog and the cat again";
+    const res = await POST(makeReq({
+      text,
+      keyword: "cat",
+      radius: 5
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.match_index).toBe(4); // First occurrence
+    expect(data.excerpt).toBe("The cat and t");
+  });
+});

--- a/app/api/routesF/__tests__/uuid-validator.test.ts
+++ b/app/api/routesF/__tests__/uuid-validator.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../uuid-validator/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/uuid-validator", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/uuid-validator", () => {
+  it("validates a version 4 UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400-e29b-41d4-a716-446655440000"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(4);
+    expect(data.variant).toBe("rfc4122");
+    expect(data.normalized).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("validates a version 1 UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(1);
+    expect(data.variant).toBe("rfc4122");
+  });
+
+  it("validates a version 3 UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(1);
+    expect(data.variant).toBe("rfc4122");
+  });
+
+  it("validates a version 5 UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "6ba7b815-9dad-11d1-80b4-00c04fd430c8"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(5);
+    expect(data.variant).toBe("rfc4122");
+  });
+
+  it("validates a version 7 UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "6ba7b817-9dad-11d1-80b4-00c04fd430c8"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(7);
+    expect(data.variant).toBe("rfc4122");
+  });
+
+  it("handles nil UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "00000000-0000-0000-0000-000000000000"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(0);
+    expect(data.variant).toBe("nil");
+    expect(data.normalized).toBe("00000000-0000-0000-0000-000000000000");
+  });
+
+  it("normalizes UUID without hyphens", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400e29b41d4a716446655440000"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.normalized).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("normalizes uppercase UUID", async () => {
+    const res = await POST(makeReq({
+      uuid: "550E8400-E29B-41D4-A716-446655440000"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.normalized).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("rejects malformed UUID - too short", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400-e29b-41d4-a716-44665544000"
+    }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+  });
+
+  it("rejects malformed UUID - invalid characters", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400-e29b-41d4-a716-44665544000g"
+    }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+  });
+
+  it("rejects malformed UUID - wrong format", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400e29b41d4a716446655440000123"
+    }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+  });
+
+  it("rejects unsupported version", async () => {
+    const res = await POST(makeReq({
+      uuid: "550e8400-e29b-21d4-a716-446655440000" // version 2
+    }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+    expect(data.version).toBe(2);
+  });
+
+  it("handles missing uuid field", async () => {
+    const res = await POST(makeReq({}));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("handles invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routesF/uuid-validator", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("detects different variants", async () => {
+    // Test NCS variant (first bit is 0)
+    const res1 = await POST(makeReq({
+      uuid: "550e8400-e29b-41d4-0716-446655440000"
+    }));
+    const data1 = await res1.json();
+    expect(data1.variant).toBe("ncs");
+
+    // Test RFC 4122 variant (first two bits are 10)
+    const res2 = await POST(makeReq({
+      uuid: "550e8400-e29b-41d4-8716-446655440000"
+    }));
+    const data2 = await res2.json();
+    expect(data2.variant).toBe("rfc4122");
+  });
+
+  it("handles edge case UUIDs", async () => {
+    // Test with all F's except version and variant bits
+    const res = await POST(makeReq({
+      uuid: "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.version).toBe(4);
+    expect(data.variant).toBe("rfc4122");
+  });
+});

--- a/app/api/routesF/company-name-generator/route.ts
+++ b/app/api/routesF/company-name-generator/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// Word pools for company name generation
+const PREFIXES = {
+  tech: ["Cyber", "Digital", "Smart", "Tech", "Data", "Cloud", "Quantum", "Neural", "Pixel", "Code"],
+  finance: ["Capital", "Wealth", "Asset", "Prime", "Elite", "Trust", "Secure", "Gold", "Silver", "Diamond"],
+  food: ["Fresh", "Organic", "Gourmet", "Tasty", "Crispy", "Sweet", "Spicy", "Golden", "Royal", "Premium"],
+  any: ["Global", "United", "Premier", "Advanced", "Superior", "Dynamic", "Innovative", "Creative", "Modern", "Future"]
+};
+
+const ROOTS = {
+  tech: ["Soft", "Ware", "Logic", "System", "Network", "Protocol", "Algorithm", "Interface", "Platform", "Framework"],
+  finance: ["Bank", "Fund", "Investment", "Credit", "Finance", "Capital", "Equity", "Portfolio", "Market", "Exchange"],
+  food: ["Kitchen", "Bistro", "Cafe", "Deli", "Market", "Bakery", "Grill", "Feast", "Flavor", "Cuisine"],
+  any: ["Corp", "Group", "Solutions", "Services", "Industries", "Enterprises", "Holdings", "Partners", "Associates", "Ventures"]
+};
+
+const SUFFIXES = {
+  tech: ["Labs", "Systems", "Technologies", "Solutions", "Innovations", "Dynamics", "Networks", "Platforms", "Studios", "Works"],
+  finance: ["Partners", "Associates", "Holdings", "Capital", "Advisors", "Management", "Group", "Trust", "Securities", "Investments"],
+  food: ["Co", "Kitchen", "Foods", "Catering", "Delights", "Treats", "Specialties", "Provisions", "Pantry", "Table"],
+  any: ["Inc", "LLC", "Corp", "Ltd", "Group", "Company", "Enterprises", "International", "Global", "Worldwide"]
+};
+
+type Industry = "tech" | "finance" | "food" | "any";
+
+const querySchema = z.object({
+  count: z.string().optional().default("5").transform(val => {
+    const num = parseInt(val, 10);
+    return isNaN(num) ? 5 : Math.max(1, Math.min(50, num));
+  }),
+  industry: z.enum(["tech", "finance", "food", "any"]).optional().default("any"),
+  seed: z.string().optional().transform(val => val ? parseInt(val, 10) : undefined)
+});
+
+// Simple seeded random number generator (LCG)
+class SeededRandom {
+  private seed: number;
+
+  constructor(seed?: number) {
+    this.seed = seed ?? Math.floor(Math.random() * 2147483647);
+  }
+
+  next(): number {
+    this.seed = (this.seed * 1103515245 + 12345) & 0x7fffffff;
+    return this.seed / 0x7fffffff;
+  }
+
+  choice<T>(array: T[]): T {
+    return array[Math.floor(this.next() * array.length)];
+  }
+}
+
+function generateCompanyName(industry: Industry, rng: SeededRandom): string {
+  const prefix = rng.choice(PREFIXES[industry]);
+  const root = rng.choice(ROOTS[industry]);
+  const suffix = rng.choice(SUFFIXES[industry]);
+
+  return `${prefix}${root} ${suffix}`;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  
+  const validation = querySchema.safeParse({
+    count: searchParams.get("count"),
+    industry: searchParams.get("industry"),
+    seed: searchParams.get("seed")
+  });
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid query parameters", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { count, industry, seed } = validation.data;
+  const rng = new SeededRandom(seed);
+  
+  const names: string[] = [];
+  for (let i = 0; i < count; i++) {
+    names.push(generateCompanyName(industry, rng));
+  }
+
+  return NextResponse.json({
+    names,
+    count: names.length,
+    industry,
+    seed: seed ?? "random"
+  });
+}

--- a/app/api/routesF/pascal-triangle/route.ts
+++ b/app/api/routesF/pascal-triangle/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const querySchema = z.object({
+  rows: z.string().optional().default("5").transform(val => {
+    const num = parseInt(val, 10);
+    if (isNaN(num) || num < 1 || num > 50) {
+      throw new Error("rows must be between 1 and 50");
+    }
+    return num;
+  })
+});
+
+// Calculate binomial coefficient using BigInt for large numbers
+function binomialCoefficient(n: number, k: number): bigint {
+  if (k > n || k < 0) return 0n;
+  if (k === 0 || k === n) return 1n;
+  
+  // Use symmetry: C(n,k) = C(n,n-k)
+  if (k > n - k) k = n - k;
+  
+  let result = 1n;
+  for (let i = 0; i < k; i++) {
+    result = result * BigInt(n - i) / BigInt(i + 1);
+  }
+  
+  return result;
+}
+
+// Generate Pascal's triangle using binomial coefficients
+function generatePascalTriangle(rows: number): number[][] {
+  const triangle: number[][] = [];
+  
+  for (let n = 0; n < rows; n++) {
+    const row: number[] = [];
+    for (let k = 0; k <= n; k++) {
+      const coefficient = binomialCoefficient(n, k);
+      // Convert BigInt to number - should be safe for reasonable row counts
+      row.push(Number(coefficient));
+    }
+    triangle.push(row);
+  }
+  
+  return triangle;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  
+  const validation = querySchema.safeParse({
+    rows: searchParams.get("rows")
+  });
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid query parameters", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { rows } = validation.data;
+  
+  try {
+    const triangle = generatePascalTriangle(rows);
+    
+    return NextResponse.json({
+      triangle,
+      rows: triangle.length
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to generate Pascal's triangle" },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routesF/text-excerpt/route.ts
+++ b/app/api/routesF/text-excerpt/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  text: z.string(),
+  keyword: z.string().min(1, "keyword cannot be empty"),
+  radius: z.number().min(0).optional().default(50),
+  highlight: z.boolean().optional().default(false)
+});
+
+interface ExcerptResult {
+  excerpt: string;
+  match_index: number;
+  highlighted?: string;
+}
+
+function extractExcerpt(
+  text: string, 
+  keyword: string, 
+  radius: number, 
+  highlight: boolean
+): ExcerptResult | null {
+  // Find first occurrence of keyword (case-insensitive)
+  const lowerText = text.toLowerCase();
+  const lowerKeyword = keyword.toLowerCase();
+  const matchIndex = lowerText.indexOf(lowerKeyword);
+  
+  if (matchIndex === -1) {
+    return null;
+  }
+  
+  // Calculate excerpt boundaries
+  const start = Math.max(0, matchIndex - radius);
+  const end = Math.min(text.length, matchIndex + keyword.length + radius);
+  
+  // Extract the excerpt
+  const excerpt = text.slice(start, end);
+  
+  const result: ExcerptResult = {
+    excerpt,
+    match_index: matchIndex
+  };
+  
+  // Add highlighting if requested
+  if (highlight) {
+    const keywordStart = matchIndex - start;
+    const keywordEnd = keywordStart + keyword.length;
+    const highlighted = 
+      excerpt.slice(0, keywordStart) + 
+      `<mark>${excerpt.slice(keywordStart, keywordEnd)}</mark>` + 
+      excerpt.slice(keywordEnd);
+    
+    result.highlighted = highlighted;
+  }
+  
+  return result;
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+  
+  const validation = bodySchema.safeParse(body);
+  
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+  
+  const { text, keyword, radius, highlight } = validation.data;
+  
+  const result = extractExcerpt(text, keyword, radius, highlight);
+  
+  if (!result) {
+    return NextResponse.json(
+      { error: "Keyword not found in text" },
+      { status: 404 }
+    );
+  }
+  
+  return NextResponse.json(result);
+}

--- a/app/api/routesF/uuid-validator/route.ts
+++ b/app/api/routesF/uuid-validator/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  uuid: z.string()
+});
+
+interface UuidValidationResult {
+  valid: boolean;
+  version?: number;
+  variant?: string;
+  normalized?: string;
+}
+
+// UUID regex pattern
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Nil UUID (all zeros)
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+function validateUuid(uuid: string): UuidValidationResult {
+  // Normalize the UUID (lowercase, add hyphens if missing)
+  let normalized = uuid.toLowerCase().replace(/[^0-9a-f]/g, "");
+  
+  // Add hyphens if they're missing
+  if (normalized.length === 32) {
+    normalized = `${normalized.slice(0, 8)}-${normalized.slice(8, 12)}-${normalized.slice(12, 16)}-${normalized.slice(16, 20)}-${normalized.slice(20, 32)}`;
+  } else {
+    normalized = uuid.toLowerCase();
+  }
+  
+  // Check if it matches UUID format
+  if (!UUID_REGEX.test(normalized)) {
+    return { valid: false };
+  }
+  
+  // Handle nil UUID
+  if (normalized === NIL_UUID) {
+    return {
+      valid: true,
+      version: 0,
+      variant: "nil",
+      normalized
+    };
+  }
+  
+  // Extract version from the 13th character (first character of the third group)
+  const versionChar = normalized[14]; // 0-indexed, so 14th character
+  const version = parseInt(versionChar, 16);
+  
+  // Extract variant from the 17th character (first character of the fourth group)
+  const variantChar = normalized[19]; // 0-indexed, so 19th character
+  const variantBits = parseInt(variantChar, 16);
+  
+  let variant: string;
+  if ((variantBits & 0x8) === 0) {
+    variant = "ncs"; // Network Computing System (reserved)
+  } else if ((variantBits & 0xC) === 0x8) {
+    variant = "rfc4122"; // RFC 4122 standard
+  } else if ((variantBits & 0xE) === 0xC) {
+    variant = "microsoft"; // Microsoft reserved
+  } else {
+    variant = "future"; // Reserved for future use
+  }
+  
+  // Validate version numbers (1, 3, 4, 5, 7 are commonly supported)
+  const supportedVersions = [1, 3, 4, 5, 7];
+  if (!supportedVersions.includes(version)) {
+    return {
+      valid: false,
+      version,
+      variant,
+      normalized
+    };
+  }
+  
+  return {
+    valid: true,
+    version,
+    variant,
+    normalized
+  };
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+  
+  const validation = bodySchema.safeParse(body);
+  
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+  
+  const { uuid } = validation.data;
+  
+  const result = validateUuid(uuid);
+  
+  if (!result.valid) {
+    return NextResponse.json(
+      { error: "Invalid UUID format or unsupported version", ...result },
+      { status: 400 }
+    );
+  }
+  
+  return NextResponse.json(result);
+}


### PR DESCRIPTION
- feat(routesF): random company name generator (#826)
  - GET endpoint with count, industry, and seed parameters
  - Deterministic seeded random generation
  - Industry-specific word pools (tech, finance, food, any)
  - Comprehensive tests for all features

- feat(routesF): pascal triangle generator (#866)
  - GET endpoint generating N rows of Pascal's triangle
  - BigInt support for large binomial coefficients
  - Row validation (1-50 range)
  - Tests verify row sums and symmetry properties

- feat(routesF): text excerpt around keyword (#825)
  - POST endpoint extracting text snippets around keywords
  - Case-insensitive matching with original case preservation
  - Optional highlighting with <mark> tags
  - Configurable radius parameter

- feat(routesF): UUID format validator and version detector (#833)
  - POST endpoint validating UUID format and detecting version/variant
  - Support for versions 1, 3, 4, 5, 7 and nil UUID
  - UUID normalization (case, hyphen handling)
  - Comprehensive validation with detailed error responses

Closes #826
 Close #866 
 Close #825 
 Close #833

