### PR TITLE
feat: add leap year, z-score, json format, and business hours routes

### DIFF
--- a/app/api/routes-f/business-hours/route.ts
+++ b/app/api/routes-f/business-hours/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function parseTime(t: string): { h: number; m: number } {
+  const [h, m] = t.split(":").map(Number);
+  return { h, m };
+}
+
+function toMinutes(h: number, m: number): number {
+  return h * 60 + m;
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    timestamp?: unknown;
+    timezone?: unknown;
+    open?: unknown;
+    close?: unknown;
+    days?: unknown;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const {
+    timestamp,
+    timezone = "UTC",
+    open = "09:00",
+    close = "17:00",
+    days = [1, 2, 3, 4, 5],
+  } = body;
+
+  if (typeof timestamp !== "string") {
+    return NextResponse.json({ error: "timestamp is required (ISO string)" }, { status: 400 });
+  }
+
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) {
+    return NextResponse.json({ error: "Invalid timestamp" }, { status: 400 });
+  }
+
+  const tz = typeof timezone === "string" ? timezone : "UTC";
+  const allowedDays = Array.isArray(days) ? (days as number[]) : [1, 2, 3, 4, 5];
+
+  const localStr = date.toLocaleString("en-US", { timeZone: tz, hour12: false });
+  const local = new Date(localStr);
+  const dayOfWeek = local.getDay(); // 0=Sun
+  const currentMins = toMinutes(local.getHours(), local.getMinutes());
+
+  const { h: oh, m: om } = parseTime(typeof open === "string" ? open : "09:00");
+  const { h: ch, m: cm } = parseTime(typeof close === "string" ? close : "17:00");
+  const openMins = toMinutes(oh, om);
+  const closeMins = toMinutes(ch, cm);
+
+  const isOpen =
+    allowedDays.includes(dayOfWeek) &&
+    currentMins >= openMins &&
+    currentMins < closeMins;
+
+  if (isOpen) {
+    return NextResponse.json({ is_open: true });
+  }
+
+  // Find next open time
+  let next = new Date(date);
+  for (let i = 1; i <= 7; i++) {
+    next = new Date(next.getTime() + 24 * 60 * 60 * 1000);
+    const nextLocalStr = next.toLocaleString("en-US", { timeZone: tz, hour12: false });
+    const nextLocal = new Date(nextLocalStr);
+    if (allowedDays.includes(nextLocal.getDay())) {
+      // set to open time
+      nextLocal.setHours(oh, om, 0, 0);
+      return NextResponse.json({ is_open: false, next_open: nextLocal.toISOString() });
+    }
+  }
+
+  return NextResponse.json({ is_open: false });
+}

--- a/app/api/routes-f/json-format/route.ts
+++ b/app/api/routes-f/json-format/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+function sortKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.keys(obj as Record<string, unknown>)
+        .sort()
+        .map((k) => [k, sortKeys((obj as Record<string, unknown>)[k])])
+    );
+  }
+  return obj;
+}
+
+export async function POST(req: NextRequest) {
+  const contentLength = Number(req.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_BYTES) {
+    return NextResponse.json({ error: "Input exceeds 5MB limit" }, { status: 413 });
+  }
+
+  let body: { input?: unknown; mode?: unknown; indent?: unknown; sort_keys?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { input, mode, indent = 2, sort_keys = false } = body;
+
+  if (typeof input !== "string") {
+    return NextResponse.json({ valid: false, error: "input must be a string" }, { status: 400 });
+  }
+  if (mode !== "minify" && mode !== "prettify") {
+    return NextResponse.json({ error: "mode must be minify or prettify" }, { status: 400 });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (e) {
+    return NextResponse.json({ valid: false, error: (e as Error).message });
+  }
+
+  const data = sort_keys ? sortKeys(parsed) : parsed;
+  const output =
+    mode === "minify"
+      ? JSON.stringify(data)
+      : JSON.stringify(data, null, typeof indent === "number" ? indent : 2);
+
+  return NextResponse.json({ output });
+}

--- a/app/api/routes-f/leap-year/route.ts
+++ b/app/api/routes-f/leap-year/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function getNextLeapYears(from: number, count = 5): number[] {
+  const result: number[] = [];
+  let y = from + 1;
+  while (result.length < count) {
+    if (isLeapYear(y)) result.push(y);
+    y++;
+  }
+  return result;
+}
+
+function leapReason(year: number): string {
+  if (year % 400 === 0) return "Divisible by 400";
+  if (year % 100 === 0) return "Divisible by 100 but not 400 — not a leap year";
+  if (year % 4 === 0) return "Divisible by 4 but not 100";
+  return "Not divisible by 4";
+}
+
+export async function GET(req: NextRequest) {
+  const yearParam = new URL(req.url).searchParams.get("year");
+  const year = yearParam ? parseInt(yearParam, 10) : NaN;
+
+  if (!yearParam || isNaN(year)) {
+    return NextResponse.json({ error: "year query param is required" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    is_leap: isLeapYear(year),
+    reason: leapReason(year),
+    next_leap_years: getNextLeapYears(year),
+  });
+}

--- a/app/api/routes-f/z-score/route.ts
+++ b/app/api/routes-f/z-score/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function mean(data: number[]): number {
+  return data.reduce((s, v) => s + v, 0) / data.length;
+}
+
+function sampleStddev(data: number[], avg: number): number {
+  const variance = data.reduce((s, v) => s + (v - avg) ** 2, 0) / (data.length - 1);
+  return Math.sqrt(variance);
+}
+
+export async function POST(req: NextRequest) {
+  let body: { data?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const data = body.data;
+  if (!Array.isArray(data) || data.length < 2 || data.some((v) => typeof v !== "number")) {
+    return NextResponse.json({ error: "data must be an array of at least 2 numbers" }, { status: 400 });
+  }
+
+  const avg = mean(data);
+  const stddev = sampleStddev(data, avg);
+
+  if (stddev === 0) {
+    return NextResponse.json({ error: "Zero variance — z-scores are undefined" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    mean: avg,
+    stddev,
+    z_scores: data.map((v) => (v - avg) / stddev),
+  });
+}


### PR DESCRIPTION
Closes #877
Closes #871
Closes #859
Closes #818

Adds four utility API routes under `app/api/routes-f/`:
- `leap-year/` — GET ?year=N returns is_leap, reason, and next 5 leap years
- `z-score/` — POST { data } returns mean, stddev (sample), and z_scores array; rejects zero-variance
- `json-format/` — POST { input, mode, indent, sort_keys } minifies or prettifies JSON up to 5MB
- `business-hours/` — POST { timestamp, timezone, open, close, days } returns is_open and next_open