### PR TITLE
Add unix timestamp and ISO date conversion route

### DIFF
--- a/app/api/routes-f/unix-date/__tests__/route.test.ts
+++ b/app/api/routes-f/unix-date/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/unix-date", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/unix-date", () => {
+  it("converts unix seconds to ISO", async () => {
+    const res = await POST(makeReq({ mode: "to_iso", value: 0, unit: "s" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      result: "1970-01-01T00:00:00.000Z",
+      unit: "s",
+    });
+  });
+
+  it("converts unix milliseconds to ISO", async () => {
+    const res = await POST(makeReq({ mode: "to_iso", value: 1716243825123, unit: "ms" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      result: "2024-05-20T22:23:45.123Z",
+      unit: "ms",
+    });
+  });
+
+  it("converts negative unix seconds before 1970", async () => {
+    const res = await POST(makeReq({ mode: "to_iso", value: -1, unit: "s" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      result: "1969-12-31T23:59:59.000Z",
+      unit: "s",
+    });
+  });
+
+  it("converts ISO dates to unix seconds", async () => {
+    const res = await POST(
+      makeReq({ mode: "to_unix", value: "2024-05-20T22:23:45.000Z", unit: "s" })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      result: 1716243825,
+      unit: "s",
+    });
+  });
+
+  it("converts ISO dates to unix milliseconds", async () => {
+    const res = await POST(
+      makeReq({ mode: "to_unix", value: "2024-05-20T22:23:45.123Z", unit: "ms" })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      result: 1716243825123,
+      unit: "ms",
+    });
+  });
+
+  it("round-trips seconds", async () => {
+    const toIso = await POST(makeReq({ mode: "to_iso", value: -123456789, unit: "s" }));
+    const isoBody = await toIso.json();
+    const toUnix = await POST(makeReq({ mode: "to_unix", value: isoBody.result, unit: "s" }));
+
+    expect(toUnix.status).toBe(200);
+    await expect(toUnix.json()).resolves.toEqual({
+      result: -123456789,
+      unit: "s",
+    });
+  });
+
+  it("round-trips milliseconds", async () => {
+    const toIso = await POST(makeReq({ mode: "to_iso", value: -123456789123, unit: "ms" }));
+    const isoBody = await toIso.json();
+    const toUnix = await POST(makeReq({ mode: "to_unix", value: isoBody.result, unit: "ms" }));
+
+    expect(toUnix.status).toBe(200);
+    await expect(toUnix.json()).resolves.toEqual({
+      result: -123456789123,
+      unit: "ms",
+    });
+  });
+
+  it("rejects invalid modes", async () => {
+    const res = await POST(makeReq({ mode: "convert", value: 0, unit: "s" }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/unix-date/_lib/convert.ts
+++ b/app/api/routes-f/unix-date/_lib/convert.ts
@@ -1,0 +1,70 @@
+import type { UnixDateRequest, UnixDateResponse, UnixDateUnit } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeUnit(value: unknown): UnixDateUnit {
+  if (value === undefined) {
+    return "s";
+  }
+
+  if (value === "s" || value === "ms") {
+    return value;
+  }
+
+  throw new Error("unit must be s or ms.");
+}
+
+function finiteNumber(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("value must be a finite number.");
+  }
+
+  return value;
+}
+
+function assertValidDate(date: Date): void {
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("value must be a valid ISO date or timestamp.");
+  }
+}
+
+export function convertUnixDate(input: unknown): UnixDateResponse {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  const request = input as UnixDateRequest;
+  const unit = normalizeUnit(request.unit);
+
+  if (request.mode === "to_iso") {
+    const timestamp = finiteNumber(request.value);
+    const date = new Date(unit === "s" ? timestamp * 1000 : timestamp);
+
+    assertValidDate(date);
+
+    return {
+      result: date.toISOString(),
+      unit,
+    };
+  }
+
+  if (request.mode === "to_unix") {
+    if (typeof request.value !== "string") {
+      throw new Error("value must be an ISO date string.");
+    }
+
+    const date = new Date(request.value);
+    assertValidDate(date);
+
+    const timestampMs = date.getTime();
+
+    return {
+      result: unit === "s" ? timestampMs / 1000 : timestampMs,
+      unit,
+    };
+  }
+
+  throw new Error("mode must be to_iso or to_unix.");
+}

--- a/app/api/routes-f/unix-date/_lib/types.ts
+++ b/app/api/routes-f/unix-date/_lib/types.ts
@@ -1,0 +1,13 @@
+export type UnixDateMode = "to_iso" | "to_unix";
+export type UnixDateUnit = "s" | "ms";
+
+export interface UnixDateRequest {
+  mode: UnixDateMode;
+  value: unknown;
+  unit?: UnixDateUnit;
+}
+
+export interface UnixDateResponse {
+  result: string | number;
+  unit: UnixDateUnit;
+}

--- a/app/api/routes-f/unix-date/route.ts
+++ b/app/api/routes-f/unix-date/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { convertUnixDate } from "./_lib/convert";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    return NextResponse.json(convertUnixDate(body));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to convert date.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}


### PR DESCRIPTION
Summary
- Added a scoped `/api/routes-f/unix-date` POST route for unix timestamp and ISO date conversion.

Issue
- Closes #878

Changes
- Supports `mode: to_iso` and `mode: to_unix`.
- Supports `unit: s` and `unit: ms`, defaulting to seconds when omitted.
- Handles negative timestamps for pre-1970 dates.
- Added route-local helper/types and Jest coverage for seconds, milliseconds, negative timestamps, and round-trips.

Validation
- `git diff --check` passed.
- `npm ci` was attempted but timed out after 10 minutes.
- `npm ci --ignore-scripts --no-audit --no-fund` was attempted but failed with `ENOTEMPTY` while cleaning `node_modules/next/...`; npm also reports the local Node `v23.1.0` is outside Jest package supported engines (`^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0`).
- Focused Jest tests were not run because Jest was not installed after the failed dependency install.

Notes
- All task files are scoped under `app/api/routes-f/unix-date/` per the issue constraint.
- Re-opened against `dev` as requested.