### PR TITLE
feat(routesF): add random named color picker endpoint

### DIFF
--- a/app/api/routesF/random-named-color-picker/color-data.ts
+++ b/app/api/routesF/random-named-color-picker/color-data.ts
@@ -1,0 +1,45 @@
+export type ColorGroup = "reds" | "blues";
+
+export type CssNamedColor = {
+  name: string;
+  hex: string;
+  group: ColorGroup;
+};
+
+export const CSS_NAMED_COLORS: readonly CssNamedColor[] = [
+  { name: "IndianRed", hex: "#CD5C5C", group: "reds" },
+  { name: "LightCoral", hex: "#F08080", group: "reds" },
+  { name: "Salmon", hex: "#FA8072", group: "reds" },
+  { name: "DarkSalmon", hex: "#E9967A", group: "reds" },
+  { name: "LightSalmon", hex: "#FFA07A", group: "reds" },
+  { name: "Crimson", hex: "#DC143C", group: "reds" },
+  { name: "Red", hex: "#FF0000", group: "reds" },
+  { name: "FireBrick", hex: "#B22222", group: "reds" },
+  { name: "DarkRed", hex: "#8B0000", group: "reds" },
+  { name: "Coral", hex: "#FF7F50", group: "reds" },
+  { name: "Tomato", hex: "#FF6347", group: "reds" },
+  { name: "OrangeRed", hex: "#FF4500", group: "reds" },
+  { name: "Pink", hex: "#FFC0CB", group: "reds" },
+  { name: "LightPink", hex: "#FFB6C1", group: "reds" },
+  { name: "HotPink", hex: "#FF69B4", group: "reds" },
+  { name: "DeepPink", hex: "#FF1493", group: "reds" },
+  { name: "PaleVioletRed", hex: "#DB7093", group: "reds" },
+  { name: "MediumVioletRed", hex: "#C71585", group: "reds" },
+  { name: "LightSkyBlue", hex: "#87CEFA", group: "blues" },
+  { name: "SkyBlue", hex: "#87CEEB", group: "blues" },
+  { name: "DeepSkyBlue", hex: "#00BFFF", group: "blues" },
+  { name: "DodgerBlue", hex: "#1E90FF", group: "blues" },
+  { name: "CornflowerBlue", hex: "#6495ED", group: "blues" },
+  { name: "SteelBlue", hex: "#4682B4", group: "blues" },
+  { name: "RoyalBlue", hex: "#4169E1", group: "blues" },
+  { name: "Blue", hex: "#0000FF", group: "blues" },
+  { name: "MediumBlue", hex: "#0000CD", group: "blues" },
+  { name: "DarkBlue", hex: "#00008B", group: "blues" },
+  { name: "Navy", hex: "#000080", group: "blues" },
+  { name: "MidnightBlue", hex: "#191970", group: "blues" },
+  { name: "MediumSlateBlue", hex: "#7B68EE", group: "blues" },
+  { name: "SlateBlue", hex: "#6A5ACD", group: "blues" },
+  { name: "DarkSlateBlue", hex: "#483D8B", group: "blues" },
+  { name: "PowderBlue", hex: "#B0E0E6", group: "blues" },
+  { name: "LightBlue", hex: "#ADD8E6", group: "blues" },
+];

--- a/app/api/routesF/random-named-color-picker/random.ts
+++ b/app/api/routesF/random-named-color-picker/random.ts
@@ -1,0 +1,20 @@
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+export function shuffleDeterministic<T>(items: readonly T[], seed: number): T[] {
+  const random = createSeededRandom(seed);
+  const shuffled = [...items];
+
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+}

--- a/app/api/routesF/random-named-color-picker/route.test.ts
+++ b/app/api/routesF/random-named-color-picker/route.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeRequest(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/random-named-color-picker");
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  return new NextRequest(url.toString(), { method: "GET" });
+}
+
+describe("/api/routesF/random-named-color-picker", () => {
+  it("returns requested number of colors with expected shape", async () => {
+    const response = await GET(makeRequest({ count: "5", seed: "42", group: "any" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.colors).toHaveLength(5);
+    expect(payload.colors[0]).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+        hex: expect.stringMatching(/^#[0-9A-F]{6}$/i),
+        rgb: expect.stringMatching(/^rgb\(\d{1,3}, \d{1,3}, \d{1,3}\)$/),
+      })
+    );
+  });
+
+  it("filters only red-group named colors", async () => {
+    const response = await GET(makeRequest({ count: "10", seed: "5", group: "reds" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    const redColorNames = new Set([
+      "IndianRed",
+      "LightCoral",
+      "Salmon",
+      "DarkSalmon",
+      "LightSalmon",
+      "Crimson",
+      "Red",
+      "FireBrick",
+      "DarkRed",
+      "Coral",
+      "Tomato",
+      "OrangeRed",
+      "Pink",
+      "LightPink",
+      "HotPink",
+      "DeepPink",
+      "PaleVioletRed",
+      "MediumVioletRed",
+    ]);
+    payload.colors.forEach((color: { name: string }) => {
+      expect(redColorNames.has(color.name)).toBe(true);
+    });
+  });
+
+  it("filters only blue-group named colors", async () => {
+    const response = await GET(makeRequest({ count: "10", seed: "5", group: "blues" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    const blueColorNames = new Set([
+      "LightSkyBlue",
+      "SkyBlue",
+      "DeepSkyBlue",
+      "DodgerBlue",
+      "CornflowerBlue",
+      "SteelBlue",
+      "RoyalBlue",
+      "Blue",
+      "MediumBlue",
+      "DarkBlue",
+      "Navy",
+      "MidnightBlue",
+      "MediumSlateBlue",
+      "SlateBlue",
+      "DarkSlateBlue",
+      "PowderBlue",
+      "LightBlue",
+    ]);
+    payload.colors.forEach((color: { name: string }) => {
+      expect(blueColorNames.has(color.name)).toBe(true);
+    });
+  });
+
+  it("returns deterministic output with same seed", async () => {
+    const firstResponse = await GET(makeRequest({ count: "6", seed: "42", group: "any" }));
+    const secondResponse = await GET(makeRequest({ count: "6", seed: "42", group: "any" }));
+
+    const firstPayload = await firstResponse.json();
+    const secondPayload = await secondResponse.json();
+
+    expect(firstPayload.colors).toEqual(secondPayload.colors);
+  });
+
+  it("returns different output for different seeds", async () => {
+    const firstResponse = await GET(makeRequest({ count: "6", seed: "42", group: "any" }));
+    const secondResponse = await GET(makeRequest({ count: "6", seed: "43", group: "any" }));
+
+    const firstPayload = await firstResponse.json();
+    const secondPayload = await secondResponse.json();
+
+    expect(firstPayload.colors).not.toEqual(secondPayload.colors);
+  });
+
+  it("returns 400 for invalid group", async () => {
+    const response = await GET(makeRequest({ group: "greens" }));
+    expect(response.status).toBe(400);
+  });
+});

--- a/app/api/routesF/random-named-color-picker/route.test.ts
+++ b/app/api/routesF/random-named-color-picker/route.test.ts
@@ -14,6 +14,14 @@ function makeRequest(params: Record<string, string> = {}) {
 }
 
 describe("/api/routesF/random-named-color-picker", () => {
+  it("uses defaults when optional params are missing", async () => {
+    const response = await GET(makeRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.colors).toHaveLength(5);
+  });
+
   it("returns requested number of colors with expected shape", async () => {
     const response = await GET(makeRequest({ count: "5", seed: "42", group: "any" }));
     const payload = await response.json();
@@ -111,5 +119,13 @@ describe("/api/routesF/random-named-color-picker", () => {
   it("returns 400 for invalid group", async () => {
     const response = await GET(makeRequest({ group: "greens" }));
     expect(response.status).toBe(400);
+  });
+
+  it("clamps count to avoid over-fetching the color pool", async () => {
+    const response = await GET(makeRequest({ count: "100", group: "blues", seed: "9" }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.colors.length).toBeLessThanOrEqual(17);
   });
 });

--- a/app/api/routesF/random-named-color-picker/route.ts
+++ b/app/api/routesF/random-named-color-picker/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { CSS_NAMED_COLORS, ColorGroup } from "./color-data";
+import { shuffleDeterministic } from "./random";
+
+type QueryGroup = ColorGroup | "any";
+
+type ColorResponseItem = {
+  name: string;
+  hex: string;
+  rgb: string;
+};
+
+function parseCount(value: string | null): number {
+  if (!value) return 5;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) return 5;
+  return Math.min(parsed, 50);
+}
+
+function parseSeed(value: string | null): number {
+  if (!value) return Date.now();
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) ? parsed : 0;
+}
+
+function parseGroup(value: string | null): QueryGroup | null {
+  if (!value) return "any";
+  if (value === "any" || value === "reds" || value === "blues") return value;
+  return null;
+}
+
+function hexToRgb(hex: string): string {
+  const normalizedHex = hex.replace("#", "");
+  const red = Number.parseInt(normalizedHex.slice(0, 2), 16);
+  const green = Number.parseInt(normalizedHex.slice(2, 4), 16);
+  const blue = Number.parseInt(normalizedHex.slice(4, 6), 16);
+
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+function pickPool(group: QueryGroup) {
+  if (group === "any") return CSS_NAMED_COLORS;
+  return CSS_NAMED_COLORS.filter((color) => color.group === group);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const count = parseCount(searchParams.get("count"));
+  const seed = parseSeed(searchParams.get("seed"));
+  const group = parseGroup(searchParams.get("group"));
+
+  if (group === null) {
+    return NextResponse.json(
+      { error: "group must be one of: reds, blues, any" },
+      { status: 400 }
+    );
+  }
+
+  const pool = pickPool(group);
+  const shuffled = shuffleDeterministic(pool, seed);
+  const selected = shuffled.slice(0, Math.min(count, pool.length));
+  const colors: ColorResponseItem[] = selected.map((color) => ({
+    name: color.name,
+    hex: color.hex,
+    rgb: hexToRgb(color.hex),
+  }));
+
+  return NextResponse.json({ colors });
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/routesF/random-named-color-picker` with support for `count`, `seed`, and `group=reds|blues|any`.
- Bundle CSS named color entries with hex values and route-scoped group metadata inside `app/api/routesF/random-named-color-picker/`.
- Return deterministic seeded output as `{ colors: [{ name, hex, rgb }] }` with validation for invalid groups.

## Verification
- Added route-level tests for deterministic seeded output.
- Added route-level tests for `reds` and `blues` group filtering.
- Added coverage for response shape, defaults, invalid group handling, and count bounds.

Closes #846

Made with [Cursor](https://cursor.com)