### PR TITLE
Add utility API routes for jokes, dates, smoothing, and determinants

### DIFF
--- a/app/api/routes-f/exponential-smoothing/__tests__/route.test.ts
+++ b/app/api/routes-f/exponential-smoothing/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import { exponentialSmooth } from "../smoothing";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/exponential-smoothing", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/exponential-smoothing", () => {
+  it("follows the exponential smoothing recurrence", async () => {
+    const data = [10, 12, 13, 15];
+    const alpha = 0.3;
+    const res = await POST(makeReq({ data, alpha, forecast: 2 }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.smoothed[0]).toBe(data[0]);
+
+    for (let i = 1; i < data.length; i += 1) {
+      expect(body.smoothed[i]).toBeCloseTo(
+        alpha * data[i] + (1 - alpha) * body.smoothed[i - 1],
+        10
+      );
+    }
+
+    expect(body.forecast).toEqual([body.smoothed.at(-1), body.smoothed.at(-1)]);
+  });
+
+  it("defaults alpha to 0.3 and forecast to 1", async () => {
+    const res = await POST(makeReq({ data: [1, 2, 3] }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.forecast).toHaveLength(1);
+    expect(body.smoothed[1]).toBeCloseTo(0.3 * 2 + 0.7 * 1, 10);
+  });
+
+  it("rejects alpha outside (0, 1)", async () => {
+    const invalid = await POST(makeReq({ data: [1, 2], alpha: 1 }));
+    const zero = await POST(makeReq({ data: [1, 2], alpha: 0 }));
+
+    expect(invalid.status).toBe(400);
+    expect(zero.status).toBe(400);
+  });
+
+  it("rejects empty data", async () => {
+    const res = await POST(makeReq({ data: [] }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("exponentialSmooth", () => {
+  it("returns an empty smoothed array for empty input", () => {
+    expect(exponentialSmooth([], 0.5, 2)).toEqual({ smoothed: [], forecast: [0, 0] });
+  });
+});

--- a/app/api/routes-f/exponential-smoothing/route.ts
+++ b/app/api/routes-f/exponential-smoothing/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { exponentialSmooth } from "./smoothing";
+
+type SmoothingBody = {
+  data?: unknown;
+  alpha?: unknown;
+  forecast?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: SmoothingBody;
+
+  try {
+    body = (await req.json()) as SmoothingBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { data, alpha = 0.3, forecast = 1 } = body;
+
+  if (!Array.isArray(data) || data.length === 0 || data.some((value) => typeof value !== "number" || !Number.isFinite(value))) {
+    return badRequest("data must be a non-empty array of finite numbers.");
+  }
+
+  if (typeof alpha !== "number" || !Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    return badRequest("alpha must be a number in the open interval (0, 1).");
+  }
+
+  if (!Number.isInteger(forecast) || forecast < 0) {
+    return badRequest("forecast must be a non-negative integer.");
+  }
+
+  const result = exponentialSmooth(data, alpha, forecast);
+  return NextResponse.json(result);
+}

--- a/app/api/routes-f/exponential-smoothing/smoothing.ts
+++ b/app/api/routes-f/exponential-smoothing/smoothing.ts
@@ -1,0 +1,20 @@
+export function exponentialSmooth(
+  data: number[],
+  alpha: number,
+  forecastSteps: number
+): { smoothed: number[]; forecast: number[] } {
+  if (data.length === 0) {
+    return { smoothed: [], forecast: Array.from({ length: forecastSteps }, () => 0) };
+  }
+
+  const smoothed: number[] = [data[0]];
+
+  for (let i = 1; i < data.length; i += 1) {
+    smoothed.push(alpha * data[i] + (1 - alpha) * smoothed[i - 1]);
+  }
+
+  const lastLevel = smoothed[smoothed.length - 1];
+  const forecast = Array.from({ length: forecastSteps }, () => lastLevel);
+
+  return { smoothed, forecast };
+}

--- a/app/api/routesF/date-interval/calendar.ts
+++ b/app/api/routesF/date-interval/calendar.ts
@@ -1,0 +1,73 @@
+export type IntervalDelta = {
+  years?: number;
+  months?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+};
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function addCalendarYears(year: number, month: number, day: number, years: number) {
+  const newYear = year + years;
+  if (month === 1 && day === 29 && !isLeapYear(newYear)) {
+    return { year: newYear, month, day: 28 };
+  }
+  return { year: newYear, month, day };
+}
+
+function addCalendarMonths(year: number, month: number, day: number, months: number) {
+  const totalMonths = year * 12 + month + months;
+  const newYear = Math.floor(totalMonths / 12);
+  const newMonth = ((totalMonths % 12) + 12) % 12;
+  const maxDay = daysInMonth(newYear, newMonth);
+  const newDay = Math.min(day, maxDay);
+  return { year: newYear, month: newMonth, day: newDay };
+}
+
+export function addIntervalsToDate(isoDate: string, delta: IntervalDelta): string {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date");
+  }
+
+  const years = delta.years ?? 0;
+  const months = delta.months ?? 0;
+  const days = delta.days ?? 0;
+  const hours = delta.hours ?? 0;
+  const minutes = delta.minutes ?? 0;
+
+  let year = date.getUTCFullYear();
+  let month = date.getUTCMonth();
+  let day = date.getUTCDate();
+
+  if (years !== 0) {
+    ({ year, month, day } = addCalendarYears(year, month, day, years));
+  }
+
+  if (months !== 0) {
+    ({ year, month, day } = addCalendarMonths(year, month, day, months));
+  }
+
+  const resultMs =
+    Date.UTC(
+      year,
+      month,
+      day,
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds()
+    ) +
+    days * 86_400_000 +
+    hours * 3_600_000 +
+    minutes * 60_000;
+
+  return new Date(resultMs).toISOString();
+}

--- a/app/api/routesF/date-interval/route.test.ts
+++ b/app/api/routesF/date-interval/route.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { addIntervalsToDate } from "./calendar";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/date-interval", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/date-interval", () => {
+  it("clamps Jan 31 plus one month to the last day of February", async () => {
+    const res = await POST(
+      makeReq({ date: "2023-01-31T12:00:00.000Z", add: { months: 1 } })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.result).toBe("2023-02-28T12:00:00.000Z");
+  });
+
+  it("clamps Jan 31 plus one month in a leap year to Feb 29", async () => {
+    const res = await POST(
+      makeReq({ date: "2024-01-31T00:00:00.000Z", add: { months: 1 } })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.result).toBe("2024-02-29T00:00:00.000Z");
+  });
+
+  it("supports negative month intervals", async () => {
+    const res = await POST(
+      makeReq({ date: "2023-03-31T08:30:00.000Z", add: { months: -1 } })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.result).toBe("2023-02-28T08:30:00.000Z");
+  });
+
+  it("supports negative day intervals", async () => {
+    const res = await POST(
+      makeReq({ date: "2024-03-15T10:00:00.000Z", add: { days: -5 } })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.result).toBe("2024-03-10T10:00:00.000Z");
+  });
+
+  it("adds hours and minutes", async () => {
+    const res = await POST(
+      makeReq({ date: "2024-06-01T10:00:00.000Z", add: { hours: 2, minutes: 30 } })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.result).toBe("2024-06-01T12:30:00.000Z");
+  });
+
+  it("rejects invalid dates", async () => {
+    const res = await POST(makeReq({ date: "not-a-date", add: { days: 1 } }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("addIntervalsToDate", () => {
+  it("clamps Feb 29 when adding years to a non-leap year", () => {
+    expect(addIntervalsToDate("2024-02-29T00:00:00.000Z", { years: 1 })).toBe(
+      "2025-02-28T00:00:00.000Z"
+    );
+  });
+});

--- a/app/api/routesF/date-interval/route.ts
+++ b/app/api/routesF/date-interval/route.ts
@@ -1,0 +1,52 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { addIntervalsToDate, type IntervalDelta } from "./calendar";
+
+type DateIntervalBody = {
+  date?: unknown;
+  add?: unknown;
+};
+
+function isIntervalDelta(value: unknown): value is IntervalDelta {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const keys = ["years", "months", "days", "hours", "minutes"] as const;
+
+  if (Object.keys(record).length === 0) {
+    return false;
+  }
+
+  return Object.keys(record).every((key) => keys.includes(key as (typeof keys)[number])) &&
+    keys.every((key) => record[key] === undefined || Number.isInteger(record[key]));
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: DateIntervalBody;
+
+  try {
+    body = (await req.json()) as DateIntervalBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  if (typeof body.date !== "string") {
+    return badRequest("date must be an ISO date string.");
+  }
+
+  if (!isIntervalDelta(body.add)) {
+    return badRequest("add must be an object with integer years, months, days, hours, and/or minutes.");
+  }
+
+  try {
+    const result = addIntervalsToDate(body.date, body.add);
+    return NextResponse.json({ result });
+  } catch {
+    return badRequest("date must be a valid ISO date string.");
+  }
+}

--- a/app/api/routesF/determinant/lu.ts
+++ b/app/api/routesF/determinant/lu.ts
@@ -1,0 +1,35 @@
+export function determinant(matrix: number[][]): number {
+  const n = matrix.length;
+  const a = matrix.map((row) => [...row]);
+  let det = 1;
+  let sign = 1;
+
+  for (let i = 0; i < n; i += 1) {
+    let pivotRow = i;
+    for (let j = i + 1; j < n; j += 1) {
+      if (Math.abs(a[j][i]) > Math.abs(a[pivotRow][i])) {
+        pivotRow = j;
+      }
+    }
+
+    if (a[pivotRow][i] === 0) {
+      return 0;
+    }
+
+    if (pivotRow !== i) {
+      [a[i], a[pivotRow]] = [a[pivotRow], a[i]];
+      sign *= -1;
+    }
+
+    det *= a[i][i];
+
+    for (let j = i + 1; j < n; j += 1) {
+      const factor = a[j][i] / a[i][i];
+      for (let k = i; k < n; k += 1) {
+        a[j][k] -= factor * a[i][k];
+      }
+    }
+  }
+
+  return sign * det;
+}

--- a/app/api/routesF/determinant/route.test.ts
+++ b/app/api/routesF/determinant/route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { determinant } from "./lu";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/determinant", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/determinant", () => {
+  it("computes the determinant of a 2x2 matrix", async () => {
+    const res = await POST(makeReq({ matrix: [[4, 3], [6, 3]] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.determinant).toBe(-6);
+  });
+
+  it("computes the determinant of a 3x3 matrix", async () => {
+    const res = await POST(
+      makeReq({
+        matrix: [
+          [6, 1, 1],
+          [4, -2, 5],
+          [2, 8, 7],
+        ],
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.determinant).toBe(-306);
+  });
+
+  it("returns 1 for the identity matrix", async () => {
+    const res = await POST(
+      makeReq({
+        matrix: [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1],
+        ],
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.determinant).toBe(1);
+  });
+
+  it("returns 0 for a singular matrix", async () => {
+    const res = await POST(
+      makeReq({
+        matrix: [
+          [1, 2],
+          [2, 4],
+        ],
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.determinant).toBe(0);
+  });
+
+  it("rejects non-square matrices", async () => {
+    const res = await POST(makeReq({ matrix: [[1, 2, 3], [4, 5, 6]] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects matrices larger than 10x10", async () => {
+    const matrix = Array.from({ length: 11 }, (_, row) =>
+      Array.from({ length: 11 }, (_, col) => (row === col ? 1 : 0))
+    );
+    const res = await POST(makeReq({ matrix }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("determinant", () => {
+  it("matches the 2x2 formula", () => {
+    expect(determinant([[1, 2], [3, 4]])).toBe(-2);
+  });
+});

--- a/app/api/routesF/determinant/route.ts
+++ b/app/api/routesF/determinant/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { determinant } from "./lu";
+
+const MAX_SIZE = 10;
+
+type DeterminantBody = {
+  matrix?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function isValidMatrix(matrix: unknown): matrix is number[][] {
+  if (!Array.isArray(matrix) || matrix.length === 0 || matrix.length > MAX_SIZE) {
+    return false;
+  }
+
+  const width = matrix[0]?.length;
+  if (!Number.isInteger(width) || width === 0 || width > MAX_SIZE) {
+    return false;
+  }
+
+  return matrix.every(
+    (row) =>
+      Array.isArray(row) &&
+      row.length === width &&
+      row.every((value) => typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+export async function POST(req: NextRequest) {
+  let body: DeterminantBody;
+
+  try {
+    body = (await req.json()) as DeterminantBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  if (!isValidMatrix(body.matrix)) {
+    return badRequest("matrix must be a square array of finite numbers with size at most 10.");
+  }
+
+  const n = body.matrix.length;
+  if (body.matrix.some((row) => row.length !== n)) {
+    return badRequest("matrix must be square.");
+  }
+
+  return NextResponse.json({ determinant: determinant(body.matrix) });
+}

--- a/app/api/routesF/pg-jokes/jokes-data.ts
+++ b/app/api/routesF/pg-jokes/jokes-data.ts
@@ -1,0 +1,225 @@
+import type { JokeCategory, JokeEntry, JokeFilterCategory } from "./types";
+
+export const JOKE_CATEGORIES: readonly JokeCategory[] = ["pun", "knock-knock", "one-liner"];
+
+export const FILTER_CATEGORIES: readonly JokeFilterCategory[] = [
+  ...JOKE_CATEGORIES,
+  "any",
+];
+
+const JOKES: JokeEntry[] = [
+  // pun (34)
+  { category: "pun", joke: "I used to hate facial hair, but then it grew on me." },
+  { category: "pun", joke: "Why don't eggs tell jokes? They'd crack each other up." },
+  { category: "pun", joke: "Time flies like an arrow; fruit flies like a banana." },
+  { category: "pun", joke: "I wondered why the baseball was getting bigger. Then it hit me." },
+  { category: "pun", joke: "A bicycle can't stand on its own because it is two-tired." },
+  { category: "pun", joke: "I told my suitcase there would be no vacation this year. Now I'm dealing with emotional baggage." },
+  { category: "pun", joke: "The scarecrow won an award because he was outstanding in his field." },
+  { category: "pun", joke: "I only know 25 letters of the alphabet. I don't know y." },
+  { category: "pun", joke: "Singing in the shower is fun until you get soap in your mouth. Then it becomes a soap opera." },
+  { category: "pun", joke: "What do you call a fake noodle? An impasta." },
+  { category: "pun", joke: "Why did the coffee file a police report? It got mugged." },
+  { category: "pun", joke: "I used to play piano by ear, but now I use my hands." },
+  { category: "pun", joke: "What do you call cheese that isn't yours? Nacho cheese." },
+  { category: "pun", joke: "I told my wife she was drawing her eyebrows too high. She looked surprised." },
+  { category: "pun", joke: "Why don't scientists trust atoms? Because they make up everything." },
+  { category: "pun", joke: "What do you call a bear with no teeth? A gummy bear." },
+  { category: "pun", joke: "I made a pencil with two erasers. It was pointless." },
+  { category: "pun", joke: "What do you call a factory that makes okay products? A satisfactory." },
+  { category: "pun", joke: "Why did the math book look sad? It had too many problems." },
+  { category: "pun", joke: "I ordered a chicken and an egg online. I'll let you know which comes first." },
+  { category: "pun", joke: "What do you call a parade of rabbits hopping backward? A receding hare-line." },
+  { category: "pun", joke: "I used to be a baker, but I couldn't make enough dough." },
+  { category: "pun", joke: "What do you call a sleeping bull? A bulldozer." },
+  { category: "pun", joke: "Why did the picture go to jail? It was framed." },
+  { category: "pun", joke: "I told a chemistry joke, but there was no reaction." },
+  { category: "pun", joke: "What do you call a belt made of watches? A waist of time." },
+  { category: "pun", joke: "Why did the golfer bring two pairs of pants? In case he got a hole in one." },
+  { category: "pun", joke: "I used to hate gardening, but then it grew on me." },
+  { category: "pun", joke: "What do you call a fish wearing a bowtie? Sofishticated." },
+  { category: "pun", joke: "Why don't oysters donate to charity? Because they are shellfish." },
+  { category: "pun", joke: "I got fired from the keyboard factory for not putting in enough shifts." },
+  { category: "pun", joke: "What do you call a can opener that doesn't work? A can't opener." },
+  { category: "pun", joke: "Why did the stadium get hot after the game? All the fans left." },
+  { category: "pun", joke: "I named my dog Five Miles so I can tell people I walk Five Miles every day." },
+  // one-liner (33)
+  { category: "one-liner", joke: "I have a split personality — and we are both comedians." },
+  { category: "one-liner", joke: "I'm reading a book about anti-gravity. It's impossible to put down." },
+  { category: "one-liner", joke: "My therapist says I have a preoccupation with vengeance. We'll see about that." },
+  { category: "one-liner", joke: "I threw a boomerang a few years ago. I now live in constant fear." },
+  { category: "one-liner", joke: "I haven't slept for ten days, because that would be too long." },
+  { category: "one-liner", joke: "I used to think I was indecisive, but now I'm not so sure." },
+  { category: "one-liner", joke: "The early bird might get the worm, but the second mouse gets the cheese." },
+  { category: "one-liner", joke: "I told my computer I needed a break, and now it won't stop sending me Kit-Kat ads." },
+  { category: "one-liner", joke: "I'm on a whiskey diet. I've lost three days already." },
+  { category: "one-liner", joke: "I asked the librarian if the library had books on paranoia. She whispered, 'They're right behind you.'" },
+  { category: "one-liner", joke: "I have the heart of a lion and a lifetime ban from the zoo." },
+  { category: "one-liner", joke: "My wallet is like an onion — opening it makes me cry." },
+  { category: "one-liner", joke: "I don't trust stairs. They're always up to something." },
+  { category: "one-liner", joke: "Parallel lines have so much in common. It's a shame they'll never meet." },
+  { category: "one-liner", joke: "I told my wife she should embrace her mistakes. She hugged me." },
+  { category: "one-liner", joke: "I'm great at multitasking. I can waste time, be unproductive, and procrastinate all at once." },
+  { category: "one-liner", joke: "My bed is a magical place where I suddenly remember everything I forgot to do." },
+  { category: "one-liner", joke: "I put my phone in airplane mode, but it's not flying." },
+  { category: "one-liner", joke: "I'm not arguing, I'm just explaining why I'm right." },
+  { category: "one-liner", joke: "Common sense is like deodorant. The people who need it most never use it." },
+  { category: "one-liner", joke: "I don't need a hair stylist; my pillow gives me a new hairstyle every morning." },
+  { category: "one-liner", joke: "Life is short. Smile while you still have teeth." },
+  { category: "one-liner", joke: "I told my plants a joke. They cracked up." },
+  { category: "one-liner", joke: "My favorite exercise is a cross between a lunge and a crunch. I call it lunch." },
+  { category: "one-liner", joke: "I'm not lazy. I'm on energy-saving mode." },
+  { category: "one-liner", joke: "I tried to organize a hide-and-seek tournament, but good players are hard to find." },
+  { category: "one-liner", joke: "I'm writing a book about reverse psychology. Do not read it." },
+  { category: "one-liner", joke: "My password is the last 16 digits of pi. Nobody can guess that." },
+  { category: "one-liner", joke: "I would tell you a construction joke, but I'm still working on it." },
+  { category: "one-liner", joke: "I'm afraid for the calendar. Its days are numbered." },
+  { category: "one-liner", joke: "I used to be addicted to soap, but I'm clean now." },
+  { category: "one-liner", joke: "I told my computer to go to sleep. It said goodnight and closed all my tabs." },
+  { category: "one-liner", joke: "I'm not superstitious, but I am a little stitious." },
+  { category: "one-liner", joke: "I have a joke about trickle-down economics, but 99% of you won't get it." },
+  // knock-knock (33)
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nBoo.\nBoo who?\nDon't cry, it's just a joke!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nLettuce.\nLettuce who?\nLettuce in, it's cold out here!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nOrange.\nOrange who?\nOrange you glad I didn't say banana?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nAtch.\nAtch who?\nBless you!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nCow says.\nCow says who?\nNo, silly — cow says moo!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nTank.\nTank who?\nYou're welcome!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nHarry.\nHarry who?\nHarry up and answer the door!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nAlpaca.\nAlpaca who?\nAlpaca the suitcase — you load the car!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nInterrupting cow.\nInterrupting cow wh—\nMOO!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nWooden shoe.\nWooden shoe who?\nWooden shoe like to hear another joke?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nOlive.\nOlive who?\nOlive you and wanted to say hello!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nDishes.\nDishes who?\nDishes the police — open up!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nJustin.\nJustin who?\nJustin time for dinner!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nKen.\nKen who?\nKen we go inside? It's raining!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nLuke.\nLuke who?\nLuke through the peephole and find out!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nNobel.\nNobel who?\nNobel — that's why I knocked!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nDwayne.\nDwayne who?\nDwayne the bathtub — I'm dwowning!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nAmos.\nAmos who?\nA mosquito bit me!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nIce cream.\nIce cream who?\nIce cream if you don't let me in!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nCereal.\nCereal who?\nCereal-sly glad you answered!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nButter.\nButter who?\nButter be quick — I'm melting out here!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nWanda.\nWanda who?\nWanda hang out this weekend?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nAnnie.\nAnnie who?\nAnnie body home?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nHoward.\nHoward who?\nHoward I know until you open the door?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nDoris.\nDoris who?\nDoris locked — that's why I'm knocking!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nYoda lady.\nYoda lady who?\nGood job yodeling!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nMikey.\nMikey who?\nMikey doesn't fit in the lock!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nRadio.\nRadio who?\nRadio not, here I come!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nVenice.\nVenice who?\nVenice your birthday coming up?",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nDonut.\nDonut who?\nDonut ask, donut tell!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nEurope.\nEurope who?\nNo, you're a poo!",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nBroken pencil.\nBroken pencil who?\nNever mind, it's pointless.",
+  },
+  {
+    category: "knock-knock",
+    joke: "Knock knock.\nWho's there?\nMustache.\nMustache who?\nMustache you a question, but I'll shave it for later!",
+  },
+];
+
+export function getJokePool(category: JokeFilterCategory): JokeEntry[] {
+  if (category === "any") {
+    return JOKES;
+  }
+  return JOKES.filter((entry) => entry.category === category);
+}
+
+export function isFilterCategory(value: string): value is JokeFilterCategory {
+  return (FILTER_CATEGORIES as readonly string[]).includes(value);
+}

--- a/app/api/routesF/pg-jokes/rng.ts
+++ b/app/api/routesF/pg-jokes/rng.ts
@@ -1,0 +1,11 @@
+export function createSeededRandom(seed: number) {
+  let state = seed >>> 0;
+
+  return function () {
+    state = Math.imul(state + 0x6d2b79f5, 1);
+    let t = state;
+    t ^= t >>> 15;
+    t = Math.imul(t | 1, t ^ (t + Math.imul(t ^ (t >>> 7), t | 61)));
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/app/api/routesF/pg-jokes/route.test.ts
+++ b/app/api/routesF/pg-jokes/route.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "./route";
+import { getJokePool } from "./jokes-data";
+
+function makeReq(query: string) {
+  return new globalThis.Request(`http://localhost/api/routesF/pg-jokes?${query}`);
+}
+
+describe("/api/routesF/pg-jokes", () => {
+  it("returns a joke from the pun category", async () => {
+    const res = await GET(makeReq("category=pun&seed=42"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.category).toBe("pun");
+    expect(typeof data.joke).toBe("string");
+    expect(data.joke.length).toBeGreaterThan(0);
+    expect(getJokePool("pun").some((entry) => entry.joke === data.joke)).toBe(true);
+  });
+
+  it("returns a joke from the knock-knock category", async () => {
+    const res = await GET(makeReq("category=knock-knock&seed=7"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.category).toBe("knock-knock");
+    expect(getJokePool("knock-knock").some((entry) => entry.joke === data.joke)).toBe(true);
+  });
+
+  it("returns a joke from the one-liner category", async () => {
+    const res = await GET(makeReq("category=one-liner&seed=99"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.category).toBe("one-liner");
+    expect(getJokePool("one-liner").some((entry) => entry.joke === data.joke)).toBe(true);
+  });
+
+  it("allows category any and returns jokes from any category", async () => {
+    const res = await GET(makeReq("category=any&seed=15"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(["pun", "knock-knock", "one-liner"]).toContain(data.category);
+    expect(getJokePool("any").some((entry) => entry.joke === data.joke)).toBe(true);
+  });
+
+  it("returns deterministic results for the same seed and category", async () => {
+    const first = await GET(makeReq("category=pun&seed=42"));
+    const second = await GET(makeReq("category=pun&seed=42"));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await first.json()).toEqual(await second.json());
+  });
+
+  it("rejects invalid category values", async () => {
+    const res = await GET(makeReq("category=sci-fi&seed=1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing seed", async () => {
+    const res = await GET(makeReq("category=pun"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/pg-jokes/route.ts
+++ b/app/api/routesF/pg-jokes/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { createSeededRandom } from "./rng";
+import { getJokePool, isFilterCategory } from "./jokes-data";
+
+function parseSeed(value: string | null): number | null {
+  if (value === null || value.trim() === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get("category");
+  const seed = parseSeed(searchParams.get("seed"));
+
+  if (!category || seed === null) {
+    return NextResponse.json(
+      { error: "Missing required parameters: category, seed" },
+      { status: 400 }
+    );
+  }
+
+  if (!isFilterCategory(category)) {
+    return NextResponse.json({ error: "Invalid category" }, { status: 400 });
+  }
+
+  const pool = getJokePool(category);
+  const random = createSeededRandom(seed);
+  const index = Math.floor(random() * pool.length);
+  const selected = pool[index];
+
+  return NextResponse.json({
+    joke: selected.joke,
+    category: selected.category,
+  });
+}

--- a/app/api/routesF/pg-jokes/types.ts
+++ b/app/api/routesF/pg-jokes/types.ts
@@ -1,0 +1,8 @@
+export type JokeCategory = "pun" | "knock-knock" | "one-liner";
+
+export type JokeFilterCategory = JokeCategory | "any";
+
+export type JokeEntry = {
+  joke: string;
+  category: JokeCategory;
+};


### PR DESCRIPTION
## Summary

Implements four scoped utility API routes, each self-contained within its folder per issue requirements:

- **#828** — `GET /api/routesF/pg-jokes` — Returns a deterministic random PG joke from a bundled bank of ~100 jokes, filterable by `category` (`pun`, `knock-knock`, `one-liner`, `any`) and `seed`.
- **#837** — `POST /api/routesF/date-interval` — Calendar-aware date arithmetic with month-end clamping (e.g. Jan 31 + 1 month → Feb 28/29); supports negative intervals via `add`.
- **#884** — `POST /api/routes-f/exponential-smoothing` — Simple exponential smoothing with configurable `alpha` (0, 1) and `forecast` steps; returns `smoothed` and `forecast` arrays.
- **#893** — `POST /api/routesF/determinant` — Square matrix determinant via LU decomposition; rejects non-square matrices and caps size at 10×10.

Closes #828
Closes #837
Closes #884
Closes #893

## Test plan

- [ ] `npm test -- --testPathPatterns="routesF/(pg-jokes|date-interval|determinant)|routes-f/exponential-smoothing"`
- [ ] **PG jokes** — `GET /api/routesF/pg-jokes?category=pun&seed=42` returns `{ joke, category }`; same seed yields same joke; invalid category returns 400
- [ ] **Date interval** — `POST /api/routesF/date-interval` with `{ "date": "2023-01-31T12:00:00.000Z", "add": { "months": 1 } }` returns Feb 28; negative months/days work
- [ ] **Exponential smoothing** — `POST /api/routes-f/exponential-smoothing` with `{ "data": [10, 12, 13, 15] }` returns recurrence-consistent `smoothed`; `alpha` outside (0, 1) returns 400
- [ ] **Determinant** — `POST /api/routesF/determinant` with 2×2, 3×3, identity, and singular matrices; non-square and >10×10 return 400