### PR TITLE
feat(routes-f): add utility math and card routes

### DIFF
--- a/app/api/routes-f/age-units/__tests__/route.test.ts
+++ b/app/api/routes-f/age-units/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: object) {
+  return new Request("http://localhost/api/routes-f/age-units", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f age-units", () => {
+  it("computes exact birthday values", async () => {
+    const res = await POST(
+      makeRequest({
+        birthdate: "2000-05-28T00:00:00.000Z",
+        on_date: "2026-05-28T00:00:00.000Z",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.years).toBe(26);
+    expect(json.total_months).toBe(312);
+  });
+
+  it("handles leap-year births before the leap-day anniversary is reached", async () => {
+    const res = await POST(
+      makeRequest({
+        birthdate: "2000-02-29T00:00:00.000Z",
+        on_date: "2021-02-28T00:00:00.000Z",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.years).toBe(20);
+    expect(json.total_months).toBe(251);
+  });
+
+  it("rejects future birthdates", async () => {
+    const res = await POST(
+      makeRequest({
+        birthdate: "2030-01-01T00:00:00.000Z",
+        on_date: "2026-01-01T00:00:00.000Z",
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/age-units/route.ts
+++ b/app/api/routes-f/age-units/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const schema = z.object({
+  birthdate: z.string().datetime({ offset: true }).or(z.string().date()),
+  on_date: z
+    .string()
+    .datetime({ offset: true })
+    .or(z.string().date())
+    .optional(),
+});
+
+function parseDate(value: string): Date {
+  return new Date(value);
+}
+
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime());
+}
+
+function getCompletedYears(birthdate: Date, onDate: Date): number {
+  let years = onDate.getUTCFullYear() - birthdate.getUTCFullYear();
+  const birthMonth = birthdate.getUTCMonth();
+  const currentMonth = onDate.getUTCMonth();
+
+  if (
+    currentMonth < birthMonth ||
+    (currentMonth === birthMonth &&
+      onDate.getUTCDate() < birthdate.getUTCDate())
+  ) {
+    years -= 1;
+  }
+
+  return years;
+}
+
+function getCompletedMonths(birthdate: Date, onDate: Date): number {
+  let months =
+    (onDate.getUTCFullYear() - birthdate.getUTCFullYear()) * 12 +
+    (onDate.getUTCMonth() - birthdate.getUTCMonth());
+
+  if (onDate.getUTCDate() < birthdate.getUTCDate()) {
+    months -= 1;
+  }
+
+  return months;
+}
+
+export async function POST(req: NextRequest) {
+  let rawBody: unknown;
+
+  try {
+    rawBody = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        issues: parsed.error.issues.map(issue => ({
+          field: issue.path.join(".") || "body",
+          message: issue.message,
+        })),
+      },
+      { status: 400 }
+    );
+  }
+
+  const birthdate = parseDate(parsed.data.birthdate);
+  const onDate = parseDate(parsed.data.on_date ?? new Date().toISOString());
+
+  if (!isValidDate(birthdate) || !isValidDate(onDate)) {
+    return NextResponse.json({ error: "Invalid date input" }, { status: 400 });
+  }
+
+  if (birthdate > onDate) {
+    return NextResponse.json(
+      { error: "birthdate cannot be in the future" },
+      { status: 400 }
+    );
+  }
+
+  const diffMs = onDate.getTime() - birthdate.getTime();
+  const totalHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const totalWeeks = Math.floor(totalDays / 7);
+
+  return NextResponse.json({
+    years: getCompletedYears(birthdate, onDate),
+    total_months: getCompletedMonths(birthdate, onDate),
+    total_weeks: totalWeeks,
+    total_days: totalDays,
+    total_hours: totalHours,
+  });
+}

--- a/app/api/routes-f/deck/__tests__/route.test.ts
+++ b/app/api/routes-f/deck/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: object) {
+  return new Request("http://localhost/api/routes-f/deck", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f deck", () => {
+  it("shuffles deterministically with the same seed", async () => {
+    const body = {
+      hands: 2,
+      cards_per_hand: 5,
+      seed: "streamfi-seed",
+      jokers: false,
+    };
+
+    const firstRes = await POST(makeRequest(body));
+    const secondRes = await POST(makeRequest(body));
+    const first = await firstRes.json();
+    const second = await secondRes.json();
+
+    expect(first).toEqual(second);
+  });
+
+  it("deals unique cards without duplicates", async () => {
+    const res = await POST(
+      makeRequest({
+        hands: 4,
+        cards_per_hand: 5,
+        seed: 42,
+        jokers: true,
+      })
+    );
+    const json = await res.json();
+    const dealt = [...json.hands.flat(), ...json.remaining];
+    const unique = new Set(dealt);
+
+    expect(res.status).toBe(200);
+    expect(dealt).toHaveLength(54);
+    expect(unique.size).toBe(54);
+  });
+
+  it("rejects requests that exceed deck size", async () => {
+    const res = await POST(
+      makeRequest({
+        hands: 11,
+        cards_per_hand: 5,
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/deck/route.ts
+++ b/app/api/routes-f/deck/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const schema = z.object({
+  hands: z.number().int().min(1).max(54).optional().default(1),
+  cards_per_hand: z.number().int().min(1).max(54).optional().default(5),
+  seed: z.union([z.string(), z.number()]).optional(),
+  jokers: z.boolean().optional().default(false),
+});
+
+const SUITS = ["C", "D", "H", "S"] as const;
+const RANKS = [
+  "A",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "J",
+  "Q",
+  "K",
+] as const;
+
+function buildDeck(includeJokers: boolean): string[] {
+  const deck = SUITS.flatMap(suit => RANKS.map(rank => `${rank}${suit}`));
+  return includeJokers ? [...deck, "BLACK_JOKER", "RED_JOKER"] : deck;
+}
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function createSeededRandom(seed: string | number | undefined): () => number {
+  if (seed === undefined) {
+    return Math.random;
+  }
+
+  let state = hashSeed(String(seed));
+
+  return () => {
+    state += 0x6d2b79f5;
+    let next = state;
+    next = Math.imul(next ^ (next >>> 15), next | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffleDeck(deck: string[], random: () => number): string[] {
+  const copy = [...deck];
+
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+  }
+
+  return copy;
+}
+
+export async function POST(req: NextRequest) {
+  let rawBody: unknown;
+
+  try {
+    rawBody = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        issues: parsed.error.issues.map(issue => ({
+          field: issue.path.join(".") || "body",
+          message: issue.message,
+        })),
+      },
+      { status: 400 }
+    );
+  }
+
+  const { hands, cards_per_hand, seed, jokers } = parsed.data;
+  const deck = buildDeck(jokers);
+
+  if (hands * cards_per_hand > deck.length) {
+    return NextResponse.json(
+      { error: "hands * cards_per_hand cannot exceed deck size" },
+      { status: 400 }
+    );
+  }
+
+  const shuffled = shuffleDeck(deck, createSeededRandom(seed));
+  const dealtHands: string[][] = [];
+  let cursor = 0;
+
+  for (let handIndex = 0; handIndex < hands; handIndex += 1) {
+    dealtHands.push(shuffled.slice(cursor, cursor + cards_per_hand));
+    cursor += cards_per_hand;
+  }
+
+  return NextResponse.json({
+    hands: dealtHands,
+    remaining: shuffled.slice(cursor),
+  });
+}

--- a/app/api/routes-f/digital-root/__tests__/route.test.ts
+++ b/app/api/routes-f/digital-root/__tests__/route.test.ts
@@ -1,0 +1,48 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+import { GET } from "../route";
+
+function makeRequest(path: string) {
+  return new Request(
+    `http://localhost${path}`
+  ) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f digital-root", () => {
+  it("returns zero for 0", async () => {
+    const res = await GET(makeRequest("/api/routes-f/digital-root?n=0"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ digital_root: 0, persistence: 0 });
+  });
+
+  it("returns zero persistence for a single-digit number", async () => {
+    const res = await GET(makeRequest("/api/routes-f/digital-root?n=7"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ digital_root: 7, persistence: 0 });
+  });
+
+  it("computes digital root and additive persistence for multi-step input", async () => {
+    const res = await GET(makeRequest("/api/routes-f/digital-root?n=12345"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ digital_root: 6, persistence: 2 });
+  });
+
+  it("rejects invalid input", async () => {
+    const res = await GET(makeRequest("/api/routes-f/digital-root?n=-9"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/digital-root/route.ts
+++ b/app/api/routes-f/digital-root/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function sumDigits(value: string): number {
+  return value.split("").reduce((sum, digit) => sum + Number(digit), 0);
+}
+
+function getPersistence(value: string): number {
+  let current = value;
+  let steps = 0;
+
+  while (current.length > 1) {
+    current = String(sumDigits(current));
+    steps += 1;
+  }
+
+  return steps;
+}
+
+function getDigitalRoot(value: string): number {
+  if (value === "0") {
+    return 0;
+  }
+
+  const numericValue = Number(value);
+  return 1 + ((numericValue - 1) % 9);
+}
+
+export async function GET(req: NextRequest) {
+  const n = new URL(req.url).searchParams.get("n");
+
+  if (!n || !/^\d+$/.test(n)) {
+    return NextResponse.json(
+      { error: "n must be a non-negative integer" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({
+    digital_root: getDigitalRoot(n),
+    persistence: getPersistence(n),
+  });
+}

--- a/app/api/routes-f/percentile-rank/__tests__/route.test.ts
+++ b/app/api/routes-f/percentile-rank/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: object) {
+  return new Request("http://localhost/api/routes-f/percentile-rank", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+describe("routes-f percentile-rank", () => {
+  const sample = [10, 20, 30, 40, 50];
+
+  it("computes percentile rank for the minimum value", async () => {
+    const res = await POST(makeRequest({ data: sample, value: 10 }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      percentile_rank: 10,
+      count_below: 0,
+      count_equal: 1,
+    });
+  });
+
+  it("computes percentile rank for the median value", async () => {
+    const res = await POST(makeRequest({ data: sample, value: 30 }));
+    const json = await res.json();
+
+    expect(json).toEqual({
+      percentile_rank: 50,
+      count_below: 2,
+      count_equal: 1,
+    });
+  });
+
+  it("computes percentile rank for the maximum value", async () => {
+    const res = await POST(makeRequest({ data: sample, value: 50 }));
+    const json = await res.json();
+
+    expect(json).toEqual({
+      percentile_rank: 90,
+      count_below: 4,
+      count_equal: 1,
+    });
+  });
+
+  it("handles out-of-range values", async () => {
+    const belowRes = await POST(makeRequest({ data: sample, value: 1 }));
+    const aboveRes = await POST(makeRequest({ data: sample, value: 99 }));
+    const below = await belowRes.json();
+    const above = await aboveRes.json();
+
+    expect(below.percentile_rank).toBe(0);
+    expect(above.percentile_rank).toBe(100);
+  });
+});

--- a/app/api/routes-f/percentile-rank/route.ts
+++ b/app/api/routes-f/percentile-rank/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const schema = z.object({
+  data: z.array(z.number()).min(1, "data must contain at least one number"),
+  value: z.number(),
+});
+
+function getPercentileRank(data: number[], value: number) {
+  const countBelow = data.filter(entry => entry < value).length;
+  const countEqual = data.filter(entry => entry === value).length;
+
+  if (countEqual === 0 && value > Math.max(...data)) {
+    return {
+      percentileRank: 100,
+      countBelow: data.length,
+      countEqual: 0,
+    };
+  }
+
+  if (countEqual === 0 && value < Math.min(...data)) {
+    return {
+      percentileRank: 0,
+      countBelow: 0,
+      countEqual: 0,
+    };
+  }
+
+  return {
+    percentileRank: ((countBelow + 0.5 * countEqual) / data.length) * 100,
+    countBelow,
+    countEqual,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  let rawBody: unknown;
+
+  try {
+    rawBody = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        issues: parsed.error.issues.map(issue => ({
+          field: issue.path.join(".") || "body",
+          message: issue.message,
+        })),
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data, value } = parsed.data;
+  const result = getPercentileRank(data, value);
+
+  return NextResponse.json({
+    percentile_rank: Number(result.percentileRank.toFixed(2)),
+    count_below: result.countBelow,
+    count_equal: result.countEqual,
+  });
+}


### PR DESCRIPTION
## Description
Adds four new utility routes under `app/api/routes-f/` for digital root, age-in-multiple-units, percentile rank, and deterministic card deck shuffle/deal calculations.

Closes #862
Closes #896
Closes #885
Closes #882

## Changes proposed

### What were you told to do?
Implement four separate routes-f utility endpoints and keep all files scoped inside `app/api/routes-f/`, then ship them together in a single PR that closes the linked issues.

### What did I do?
#### Number and date utilities
- Added `GET /api/routes-f/digital-root` to compute digital root and additive persistence for non-negative integers.
- Added `POST /api/routes-f/age-units` to compute age in years, total months, weeks, days, and hours from a birthdate and optional reference date.

#### Dataset and card utilities
- Added `POST /api/routes-f/percentile-rank` to compute percentile rank plus `count_below` and `count_equal` using the standard percentile-rank formula.
- Added `POST /api/routes-f/deck` to shuffle and deal a seeded 52-card deck, with optional jokers and deterministic Fisher-Yates behavior.

#### Test coverage
- Added focused route tests for all four endpoints covering the required edge cases: zero/single-digit and multi-step persistence, leap-year births and exact birthdays, percentile rank for min/median/max/out-of-range values, and deterministic duplicate-free deck dealing.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the dev branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated with targeted Jest route tests for the four new endpoints. Note: project-wide `npm run type-check` on current `upstream/dev` still reports unrelated pre-existing baseline errors outside these four new route folders.
