### PR TITLE
feat: add routes-f math and date utilities

### DIFF
--- a/app/api/routes-f/cagr/__tests__/route.test.ts
+++ b/app/api/routes-f/cagr/__tests__/route.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/cagr", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/cagr", () => {
+  it("calculates CAGR for a known growth example", async () => {
+    const res = await POST(
+      makeReq({ begin_value: 1000, end_value: 2000, years: 5 })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.cagr_percent).toBeCloseTo(14.869835, 5);
+  });
+
+  it("calculates negative CAGR when value declines", async () => {
+    const res = await POST(
+      makeReq({ begin_value: 1000, end_value: 500, years: 5 })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.cagr_percent).toBeCloseTo(-12.944943, 5);
+  });
+
+  it("rejects non-positive values and years", async () => {
+    const res = await POST(
+      makeReq({ begin_value: 0, end_value: 1000, years: 5 })
+    );
+    const yearsRes = await POST(
+      makeReq({ begin_value: 1000, end_value: 1100, years: -1 })
+    );
+
+    expect(res.status).toBe(400);
+    expect(yearsRes.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/cagr/route.ts
+++ b/app/api/routes-f/cagr/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function finitePositive(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+export async function POST(req: NextRequest) {
+  let body: { begin_value?: unknown; end_value?: unknown; years?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const beginValue = finitePositive(body.begin_value);
+  const endValue = finitePositive(body.end_value);
+  const years = finitePositive(body.years);
+
+  if (beginValue === null || endValue === null || years === null) {
+    return NextResponse.json(
+      { error: "begin_value, end_value, and years must be positive numbers." },
+      { status: 400 }
+    );
+  }
+
+  const cagrPercent = (Math.pow(endValue / beginValue, 1 / years) - 1) * 100;
+
+  return NextResponse.json({
+    cagr_percent: cagrPercent,
+  });
+}

--- a/app/api/routes-f/catalan/__tests__/route.test.ts
+++ b/app/api/routes-f/catalan/__tests__/route.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+function makeReq(n: string) {
+  return new NextRequest(`http://localhost/api/routes-f/catalan?n=${n}`);
+}
+
+describe("GET /api/routes-f/catalan", () => {
+  it("returns C(0)=1", async () => {
+    const res = await GET(makeReq("0"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.catalan).toBe("1");
+    expect(body.sequence).toEqual(["1"]);
+  });
+
+  it("returns C(4)=14", async () => {
+    const res = await GET(makeReq("4"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.catalan).toBe("14");
+    expect(body.sequence).toEqual(["1", "1", "2", "5", "14"]);
+  });
+
+  it("returns C(10)=16796", async () => {
+    const res = await GET(makeReq("10"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.catalan).toBe("16796");
+  });
+
+  it("rejects n outside the supported range", async () => {
+    const res = await GET(makeReq("1001"));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/catalan/route.ts
+++ b/app/api/routes-f/catalan/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_N = 1000;
+
+function parseN(req: NextRequest): number | null {
+  const value = req.nextUrl.searchParams.get("n");
+  if (value === null || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 && n <= MAX_N ? n : null;
+}
+
+function catalanSequence(n: number): bigint[] {
+  const sequence: bigint[] = [1n];
+
+  for (let i = 0; i < n; i += 1) {
+    const current = sequence[i];
+    const next = (current * BigInt(2 * (2 * i + 1))) / BigInt(i + 2);
+    sequence.push(next);
+  }
+
+  return sequence;
+}
+
+export async function GET(req: NextRequest) {
+  const n = parseN(req);
+
+  if (n === null) {
+    return NextResponse.json(
+      { error: `n must be an integer in [0, ${MAX_N}].` },
+      { status: 400 }
+    );
+  }
+
+  const sequence = catalanSequence(n).map(value => value.toString());
+
+  return NextResponse.json({
+    catalan: sequence[n],
+    sequence,
+  });
+}

--- a/app/api/routes-f/matrix-multiply/__tests__/route.test.ts
+++ b/app/api/routes-f/matrix-multiply/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/matrix-multiply", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/matrix-multiply", () => {
+  it("multiplies square matrices", async () => {
+    const res = await POST(
+      makeReq({
+        a: [
+          [1, 2],
+          [3, 4],
+        ],
+        b: [
+          [5, 6],
+          [7, 8],
+        ],
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.result).toEqual([
+      [19, 22],
+      [43, 50],
+    ]);
+    expect(body.dimensions.result).toEqual({ rows: 2, columns: 2 });
+  });
+
+  it("multiplies rectangular matrices", async () => {
+    const res = await POST(
+      makeReq({
+        a: [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        b: [
+          [7, 8],
+          [9, 10],
+          [11, 12],
+        ],
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.result).toEqual([
+      [58, 64],
+      [139, 154],
+    ]);
+  });
+
+  it("preserves a matrix multiplied by identity", async () => {
+    const matrix = [
+      [2, -1],
+      [0, 3],
+    ];
+    const res = await POST(
+      makeReq({
+        a: matrix,
+        b: [
+          [1, 0],
+          [0, 1],
+        ],
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.result).toEqual(matrix);
+  });
+
+  it("rejects incompatible dimensions", async () => {
+    const res = await POST(
+      makeReq({
+        a: [[1, 2]],
+        b: [[1, 2]],
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/matrix-multiply/route.ts
+++ b/app/api/routes-f/matrix-multiply/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MAX_DIMENSION = 100;
+
+type Matrix = number[][];
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function validateMatrix(value: unknown, name: string): Matrix | string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return `${name} must be a non-empty number matrix.`;
+  }
+
+  if (value.length > MAX_DIMENSION) {
+    return `${name} cannot exceed ${MAX_DIMENSION} rows.`;
+  }
+
+  const firstRow = value[0];
+  if (!Array.isArray(firstRow) || firstRow.length === 0) {
+    return `${name} must contain non-empty rows.`;
+  }
+
+  const columnCount = firstRow.length;
+  if (columnCount > MAX_DIMENSION) {
+    return `${name} cannot exceed ${MAX_DIMENSION} columns.`;
+  }
+
+  for (const row of value) {
+    if (!Array.isArray(row) || row.length !== columnCount) {
+      return `${name} must be rectangular.`;
+    }
+
+    if (!row.every(cell => typeof cell === "number" && Number.isFinite(cell))) {
+      return `${name} must contain only finite numbers.`;
+    }
+  }
+
+  return value as Matrix;
+}
+
+function multiplyMatrices(a: Matrix, b: Matrix): Matrix {
+  const rows = a.length;
+  const inner = b.length;
+  const columns = b[0].length;
+  const result: Matrix = Array.from({ length: rows }, () =>
+    Array.from({ length: columns }, () => 0)
+  );
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < columns; col += 1) {
+      let sum = 0;
+      for (let i = 0; i < inner; i += 1) {
+        sum += a[row][i] * b[i][col];
+      }
+      result[row][col] = sum;
+    }
+  }
+
+  return result;
+}
+
+export async function POST(req: NextRequest) {
+  let body: { a?: unknown; b?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const a = validateMatrix(body.a, "a");
+  if (typeof a === "string") {
+    return badRequest(a);
+  }
+
+  const b = validateMatrix(body.b, "b");
+  if (typeof b === "string") {
+    return badRequest(b);
+  }
+
+  if (a[0].length !== b.length) {
+    return badRequest("Matrix dimensions are incompatible for multiplication.");
+  }
+
+  const result = multiplyMatrices(a, b);
+
+  return NextResponse.json({
+    result,
+    dimensions: {
+      a: { rows: a.length, columns: a[0].length },
+      b: { rows: b.length, columns: b[0].length },
+      result: { rows: result.length, columns: result[0]?.length ?? 0 },
+    },
+  });
+}

--- a/app/api/routesF/days-between/route.test.ts
+++ b/app/api/routesF/days-between/route.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/days-between", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routesF/days-between", () => {
+  it("returns zero for the same day", async () => {
+    const res = await POST(makeReq({ from: "2026-05-28", to: "2026-05-28" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      calendar_days: 0,
+      business_days: 0,
+      weekends: 0,
+      holidays_in_range: [],
+    });
+  });
+
+  it("handles reversed date order", async () => {
+    const res = await POST(makeReq({ from: "2026-05-04", to: "2026-05-01" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.calendar_days).toBe(3);
+    expect(body.weekends).toBe(2);
+    expect(body.business_days).toBe(1);
+  });
+
+  it("excludes holidays from business days", async () => {
+    const res = await POST(
+      makeReq({ from: "2026-01-01", to: "2026-01-03", country: "US" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.calendar_days).toBe(2);
+    expect(body.business_days).toBe(1);
+    expect(body.holidays_in_range).toEqual([
+      { date: "2026-01-01", name: "New Year's Day" },
+    ]);
+  });
+
+  it("uses country-specific holidays", async () => {
+    const res = await POST(
+      makeReq({ from: "2026-10-01", to: "2026-10-02", country: "NG" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.business_days).toBe(0);
+    expect(body.holidays_in_range[0]).toEqual({
+      date: "2026-10-01",
+      name: "Independence Day",
+    });
+  });
+});

--- a/app/api/routesF/days-between/route.ts
+++ b/app/api/routesF/days-between/route.ts
@@ -1,0 +1,123 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type Holiday = {
+  date: string;
+  name: string;
+};
+
+const HOLIDAYS: Record<string, Holiday[]> = {
+  US: [
+    { date: "2026-01-01", name: "New Year's Day" },
+    { date: "2026-01-19", name: "Martin Luther King Jr. Day" },
+    { date: "2026-02-16", name: "Presidents' Day" },
+    { date: "2026-05-25", name: "Memorial Day" },
+    { date: "2026-06-19", name: "Juneteenth" },
+    { date: "2026-07-03", name: "Independence Day observed" },
+    { date: "2026-09-07", name: "Labor Day" },
+    { date: "2026-10-12", name: "Columbus Day" },
+    { date: "2026-11-11", name: "Veterans Day" },
+    { date: "2026-11-26", name: "Thanksgiving Day" },
+    { date: "2026-12-25", name: "Christmas Day" },
+  ],
+  NG: [
+    { date: "2026-01-01", name: "New Year's Day" },
+    { date: "2026-03-20", name: "Eid al-Fitr" },
+    { date: "2026-03-21", name: "Eid al-Fitr Holiday" },
+    { date: "2026-04-03", name: "Good Friday" },
+    { date: "2026-04-06", name: "Easter Monday" },
+    { date: "2026-05-01", name: "Workers' Day" },
+    { date: "2026-05-27", name: "Eid al-Adha" },
+    { date: "2026-06-12", name: "Democracy Day" },
+    { date: "2026-10-01", name: "Independence Day" },
+    { date: "2026-12-25", name: "Christmas Day" },
+    { date: "2026-12-26", name: "Boxing Day" },
+  ],
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function parseIsoDate(value: unknown): Date | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+}
+
+function dateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function isWeekend(date: Date) {
+  const day = date.getUTCDay();
+  return day === 0 || day === 6;
+}
+
+function addDays(date: Date, days: number) {
+  return new Date(date.getTime() + days * MS_PER_DAY);
+}
+
+export async function POST(req: NextRequest) {
+  let body: { from?: unknown; to?: unknown; country?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const from = parseIsoDate(body.from);
+  const to = parseIsoDate(body.to);
+  if (!from || !to) {
+    return badRequest("from and to must be valid ISO date strings.");
+  }
+
+  const country =
+    typeof body.country === "string" ? body.country.toUpperCase() : "US";
+  const holidays = HOLIDAYS[country] ?? HOLIDAYS.US;
+  const holidayMap = new Map(holidays.map(holiday => [holiday.date, holiday]));
+
+  const start = from <= to ? from : to;
+  const end = from <= to ? to : from;
+  const calendarDays = Math.round(
+    (end.getTime() - start.getTime()) / MS_PER_DAY
+  );
+  let weekends = 0;
+  let businessDays = 0;
+  const holidaysInRange: Holiday[] = [];
+
+  for (let offset = 0; offset < calendarDays; offset += 1) {
+    const current = addDays(start, offset);
+    const key = dateKey(current);
+    const weekend = isWeekend(current);
+    const holiday = holidayMap.get(key);
+
+    if (weekend) {
+      weekends += 1;
+    }
+    if (holiday) {
+      holidaysInRange.push(holiday);
+    }
+    if (!weekend && !holiday) {
+      businessDays += 1;
+    }
+  }
+
+  return NextResponse.json({
+    calendar_days: calendarDays,
+    business_days: businessDays,
+    weekends,
+    holidays_in_range: holidaysInRange,
+  });
+}


### PR DESCRIPTION
## Description
Adds four scoped API utilities requested for the routes-f/routesF wave: matrix multiplication, CAGR calculation, Catalan numbers, and date/business-day difference calculation.

Closes #869
Closes #873
Closes #867
Closes #899

## Changes proposed

### What were you told to do?
Switch to `dev`, pull `upstream/dev`, then close issues #869, #873, #867, and #899 with one PR.

### What did I do?
#### routes-f math utilities
- Added `POST /api/routes-f/matrix-multiply` with rectangular matrix validation, 100x100 caps, dimension checks, result dimensions, and square/rectangular/identity tests.
- Added `POST /api/routes-f/cagr` with positive input validation and known CAGR formula coverage.
- Added `GET /api/routes-f/catalan?n=` using BigInt-safe recurrence, n range validation `[0, 1000]`, and known value tests for C(0), C(4), and C(10).

#### routesF date utility
- Added `POST /api/routesF/days-between` with calendar days, business days, weekend count, holiday detection, reversed date support, and country-specific holiday samples for US/NG.
- Added tests for same-day, reversed ranges, holiday ranges, and country-specific holidays.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --runTestsByPath app/api/routes-f/matrix-multiply/__tests__/route.test.ts app/api/routes-f/cagr/__tests__/route.test.ts app/api/routes-f/catalan/__tests__/route.test.ts app/api/routesF/days-between/route.test.ts --runInBand` passed: 15 tests.
- `npx eslint app/api/routes-f/matrix-multiply/route.ts app/api/routes-f/matrix-multiply/__tests__/route.test.ts app/api/routes-f/cagr/route.ts app/api/routes-f/cagr/__tests__/route.test.ts app/api/routes-f/catalan/route.ts app/api/routes-f/catalan/__tests__/route.test.ts app/api/routesF/days-between/route.ts app/api/routesF/days-between/route.test.ts` passed.
- `npm run type-check` passed.
- Commit hook completed `npm run type-check` and `npm run build` successfully. Build emitted existing local environment warnings for missing Upstash/Mux/Postgres credentials, but completed successfully.