### PR TITLE
feat(routesF): SSN validator, compound/simple interest, IRR, time-until

### DIFF
--- a/app/api/routesF/compound-vs-simple/route.ts
+++ b/app/api/routesF/compound-vs-simple/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { principal, rate, years, compounds_per_year = 1 } = body;
+
+    if (typeof principal !== 'number' || principal <= 0) {
+      return NextResponse.json({ error: 'principal must be a positive number' }, { status: 400 });
+    }
+    if (typeof rate !== 'number' || rate < 0) {
+      return NextResponse.json({ error: 'rate must be a non-negative number (e.g. 0.05 for 5%)' }, { status: 400 });
+    }
+    if (typeof years !== 'number' || years <= 0) {
+      return NextResponse.json({ error: 'years must be a positive number' }, { status: 400 });
+    }
+    if (typeof compounds_per_year !== 'number' || compounds_per_year < 1) {
+      return NextResponse.json({ error: 'compounds_per_year must be >= 1' }, { status: 400 });
+    }
+
+    const simpleInterest  = principal * rate * years;
+    const simpleTotal     = principal + simpleInterest;
+
+    const compoundTotal    = principal * Math.pow(1 + rate / compounds_per_year, compounds_per_year * years);
+    const compoundInterest = compoundTotal - principal;
+
+    const difference = compoundTotal - simpleTotal;
+
+    return NextResponse.json({
+      simple: {
+        interest: parseFloat(simpleInterest.toFixed(2)),
+        total:    parseFloat(simpleTotal.toFixed(2)),
+      },
+      compound: {
+        interest: parseFloat(compoundInterest.toFixed(2)),
+        total:    parseFloat(compoundTotal.toFixed(2)),
+        compounds_per_year,
+      },
+      difference: parseFloat(difference.toFixed(2)),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/irr/route.ts
+++ b/app/api/routesF/irr/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+
+function computeNPV(cashFlows: number[], rate: number): number {
+  return cashFlows.reduce((npv, cf, t) => npv + cf / Math.pow(1 + rate, t), 0);
+}
+
+function computeIRR(cashFlows: number[]): number | null {
+  // Validate: first cash flow should be negative (initial investment)
+  if (cashFlows[0] >= 0) return null;
+  // At least one positive cash flow required
+  if (!cashFlows.slice(1).some((cf) => cf > 0)) return null;
+
+  // Bisection method
+  let low = -0.999;
+  let high = 10.0; // 1000% upper bound
+
+  if (computeNPV(cashFlows, low) * computeNPV(cashFlows, high) > 0) return null;
+
+  for (let i = 0; i < 1000; i++) {
+    const mid = (low + high) / 2;
+    const npv = computeNPV(cashFlows, mid);
+    if (Math.abs(npv) < 1e-7) return mid;
+    if (computeNPV(cashFlows, low) * npv < 0) high = mid;
+    else low = mid;
+  }
+
+  return (low + high) / 2;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { cash_flows } = body;
+
+    if (!Array.isArray(cash_flows) || cash_flows.length < 2) {
+      return NextResponse.json(
+        { error: 'cash_flows must be an array with at least 2 values' },
+        { status: 400 },
+      );
+    }
+    if (!cash_flows.every((v) => typeof v === 'number')) {
+      return NextResponse.json({ error: 'All cash_flows values must be numbers' }, { status: 400 });
+    }
+
+    const irr = computeIRR(cash_flows);
+
+    if (irr === null) {
+      return NextResponse.json({ error: 'IRR could not be computed for the given cash flows' }, { status: 422 });
+    }
+
+    return NextResponse.json({
+      irr: parseFloat((irr * 100).toFixed(4)),
+      irr_decimal: parseFloat(irr.toFixed(6)),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/ssn-validator/route.ts
+++ b/app/api/routesF/ssn-validator/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { ssn } = body;
+
+    if (typeof ssn !== 'string') {
+      return NextResponse.json({ error: 'Missing or invalid ssn' }, { status: 400 });
+    }
+
+    // Strip formatting — accept dashes or plain digits
+    const digits = ssn.replace(/-/g, '');
+
+    if (!/^\d{9}$/.test(digits)) {
+      return NextResponse.json({ valid: false, reason: 'SSN must be exactly 9 digits' });
+    }
+
+    const area   = parseInt(digits.slice(0, 3), 10);
+    const group  = parseInt(digits.slice(3, 5), 10);
+    const serial = parseInt(digits.slice(5, 9), 10);
+
+    if (area === 0) {
+      return NextResponse.json({ valid: false, reason: 'Area number cannot be 000' });
+    }
+    if (area === 666) {
+      return NextResponse.json({ valid: false, reason: 'Area number 666 is not assigned' });
+    }
+    if (area >= 900) {
+      return NextResponse.json({ valid: false, reason: 'Area numbers 900–999 are not assigned' });
+    }
+    if (group === 0) {
+      return NextResponse.json({ valid: false, reason: 'Group number cannot be 00' });
+    }
+    if (serial === 0) {
+      return NextResponse.json({ valid: false, reason: 'Serial number cannot be 0000' });
+    }
+
+    const normalized = `${digits.slice(0, 3)}-${digits.slice(3, 5)}-${digits.slice(5)}`;
+    return NextResponse.json({ valid: true, normalized });
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/time-until/route.ts
+++ b/app/api/routesF/time-until/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { target_time, now: nowParam, timezone = 'UTC' } = body;
+
+    if (typeof target_time !== 'string' || !/^\d{2}:\d{2}$/.test(target_time)) {
+      return NextResponse.json(
+        { error: 'target_time must be in HH:MM format' },
+        { status: 400 },
+      );
+    }
+
+    const [hh, mm] = target_time.split(':').map(Number);
+    if (hh > 23 || mm > 59) {
+      return NextResponse.json({ error: 'target_time is not a valid clock time' }, { status: 400 });
+    }
+
+    // Resolve "now"
+    const nowDate = nowParam ? new Date(nowParam) : new Date();
+    if (isNaN(nowDate.getTime())) {
+      return NextResponse.json({ error: 'now is not a valid ISO date string' }, { status: 400 });
+    }
+
+    // Build target datetime in the requested timezone using Intl
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      hour12: false,
+    });
+
+    const parts = Object.fromEntries(
+      fmt.formatToParts(nowDate).map(({ type, value }) => [type, value]),
+    );
+
+    // Construct today's target in the given timezone
+    const todayTarget = new Date(
+      `${parts.year}-${parts.month}-${parts.day}T${target_time.padStart(5, '0')}:00`,
+    );
+
+    // Convert the local timezone-aware date to UTC offset by computing the diff
+    const localOffset = nowDate.getTime() - new Date(
+      `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`,
+    ).getTime();
+
+    let nextOccurrence = new Date(todayTarget.getTime() - localOffset);
+    if (nextOccurrence <= nowDate) {
+      nextOccurrence = new Date(nextOccurrence.getTime() + 24 * 60 * 60 * 1000);
+    }
+
+    const secondsUntil = Math.round((nextOccurrence.getTime() - nowDate.getTime()) / 1000);
+
+    return NextResponse.json({
+      seconds_until: secondsUntil,
+      next_occurrence: nextOccurrence.toISOString(),
+    });
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+}


### PR DESCRIPTION
Closes #839
Closes #853
Closes #894
Closes #900

All files scoped to `app/api/routesF/` per constraint.

- **#839** `ssn-validator` — validates US SSN structure: rejects area 000/666/900-999, group 00, serial 0000; returns `{ valid, normalized, reason? }`
- **#853** `compound-vs-simple` — compares compound vs simple interest given `{ principal, rate, years, compounds_per_year }`; returns both totals and difference
- **#894** `irr` — computes Internal Rate of Return via bisection on `{ cash_flows[] }`; returns `irr` (%) and `irr_decimal`
- **#900** `time-until` — computes seconds until next `HH:MM` occurrence given `{ target_time, now?, timezone? }`; rolls to tomorrow if already passed