### PR TITLE
feat(routesF): add twin-primes finder endpoint (#891)

### DIFF
--- a/app/api/routesF/twin-primes/route.test.ts
+++ b/app/api/routesF/twin-primes/route.test.ts
@@ -1,0 +1,40 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+describe('/api/routesF/twin-primes', () => {
+  it('returns twin primes up to 100', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/twin-primes?limit=100');
+    const res = await GET(req);
+    const json = await res.json();
+    
+    expect(res.status).toBe(200);
+    expect(json.count).toBe(8);
+    expect(json.pairs).toContainEqual([3, 5]);
+    expect(json.pairs).toContainEqual([5, 7]);
+    expect(json.pairs).toContainEqual([11, 13]);
+  });
+
+  it('rejects missing limit', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/twin-primes');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects limit out of bounds (too low)', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/twin-primes?limit=2');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects limit out of bounds (too high)', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/twin-primes?limit=1000001');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid limit format', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/twin-primes?limit=abc');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/twin-primes/route.ts
+++ b/app/api/routesF/twin-primes/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const limitStr = searchParams.get('limit');
+
+  if (!limitStr) {
+    return NextResponse.json({ error: 'Missing limit parameter' }, { status: 400 });
+  }
+
+  const limit = parseInt(limitStr, 10);
+
+  if (isNaN(limit) || limit < 3 || limit > 1000000) {
+    return NextResponse.json({ error: 'limit must be an integer between 3 and 1000000' }, { status: 400 });
+  }
+
+  const isPrime = new Uint8Array(limit + 1);
+  isPrime.fill(1);
+  isPrime[0] = 0;
+  isPrime[1] = 0;
+
+  for (let p = 2; p * p <= limit; p++) {
+    if (isPrime[p] === 1) {
+      for (let i = p * p; i <= limit; i += p) {
+        isPrime[i] = 0;
+      }
+    }
+  }
+
+  const pairs: [number, number][] = [];
+  
+  for (let i = 3; i <= limit - 2; i += 2) {
+    if (isPrime[i] === 1 && isPrime[i + 2] === 1) {
+      pairs.push([i, i + 2]);
+    }
+  }
+
+  return NextResponse.json({
+    pairs,
+    count: pairs.length
+  });
+}


### PR DESCRIPTION
## Summary
Closes #891

Finds all twin prime pairs up to N using an efficient Sieve of Eratosthenes approach.

## Endpoint
**`GET /api/routesF/twin-primes?limit=100`**

**Response (200):**
```json
{
  "pairs": [
    [3, 5],
    [5, 7],
    [11, 13],
    [17, 19],
    [29, 31],
    [41, 43],
    [59, 61],
    [71, 73]
  ],
  "count": 8
}
```

**Error (400):**
Returned for missing `limit` or if `limit` is outside the bounds `[3, 1000000]`.

## Files Added
- `app/api/routesF/twin-primes/route.ts` - Contains the endpoint logic
- `app/api/routesF/twin-primes/route.test.ts` - 5 Jest unit tests verifying limit validations and twin prime calculation accuracy.

All files are strictly scoped inside `app/api/routesF/`.
