### PR TITLE
feat(routesF): add wrap-search-terms endpoint (#847)

### DIFF
--- a/app/api/routesF/wrap-search-terms/route.test.ts
+++ b/app/api/routesF/wrap-search-terms/route.test.ts
@@ -1,0 +1,96 @@
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+
+describe('/api/routesF/wrap-search-terms', () => {
+  it('wraps multiple terms and handles case insensitivity by default', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'Hello world, hello universe!',
+        terms: ['hello', 'world']
+      })
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.result).toBe('**Hello** **world**, **hello** universe!');
+    expect(json.match_count).toBe(3);
+  });
+
+  it('handles case sensitivity when specified', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'Hello world, hello universe!',
+        terms: ['hello'],
+        case_sensitive: true
+      })
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.result).toBe('Hello world, **hello** universe!');
+    expect(json.match_count).toBe(1);
+  });
+
+  it('avoids overlapping double-wrapping', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'abracadabra',
+        terms: ['abrac', 'cadab'],
+        marker: '%%'
+      })
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.result).toBe('%%abracadab%%ra');
+    expect(json.match_count).toBe(2);
+  });
+
+  it('handles custom markers', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'apple banana cherry',
+        terms: ['banana'],
+        marker: '<mark>'
+      })
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.result).toBe('apple <mark>banana<mark> cherry');
+  });
+
+  it('handles terms completely enclosed by other terms', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: 'foo bar baz',
+        terms: ['foo bar', 'bar'],
+        marker: '++'
+      })
+    });
+    const res = await POST(req);
+    const json = await res.json();
+    expect(json.result).toBe('++foo bar++ baz');
+    expect(json.match_count).toBe(2);
+  });
+  
+  it('rejects invalid inputs', async () => {
+    const req = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({ text: 123, terms: ['test'] })
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const req2 = new NextRequest('http://localhost/api/routesF/wrap-search-terms', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'test', terms: [123] })
+    });
+    const res2 = await POST(req2);
+    expect(res2.status).toBe(400);
+  });
+});

--- a/app/api/routesF/wrap-search-terms/route.ts
+++ b/app/api/routesF/wrap-search-terms/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { text, terms, marker = '**', case_sensitive = false } = body;
+
+    if (typeof text !== 'string') {
+      return NextResponse.json({ error: 'text must be a string' }, { status: 400 });
+    }
+    if (!Array.isArray(terms) || !terms.every(t => typeof t === 'string' && t.length > 0)) {
+      return NextResponse.json({ error: 'terms must be an array of non-empty strings' }, { status: 400 });
+    }
+    if (typeof marker !== 'string') {
+      return NextResponse.json({ error: 'marker must be a string' }, { status: 400 });
+    }
+
+    const intervals: [number, number][] = [];
+
+    const flags = case_sensitive ? 'g' : 'gi';
+
+    for (const term of terms) {
+      const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(escapedTerm, flags);
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        intervals.push([match.index, match.index + match[0].length]);
+        if (match.index === regex.lastIndex) {
+          regex.lastIndex++;
+        }
+      }
+    }
+
+    const match_count = intervals.length;
+
+    if (intervals.length === 0) {
+      return NextResponse.json({ result: text, match_count: 0 });
+    }
+
+    intervals.sort((a, b) => a[0] - b[0] || b[1] - a[1]);
+
+    const merged: [number, number][] = [intervals[0]];
+    for (let i = 1; i < intervals.length; i++) {
+      const current = intervals[i];
+      const previous = merged[merged.length - 1];
+
+      if (current[0] <= previous[1]) {
+        previous[1] = Math.max(previous[1], current[1]);
+      } else {
+        merged.push(current);
+      }
+    }
+
+    let result = '';
+    let lastIndex = 0;
+    for (const [start, end] of merged) {
+      result += text.slice(lastIndex, start);
+      result += marker + text.slice(start, end) + marker;
+      lastIndex = end;
+    }
+    result += text.slice(lastIndex);
+
+    return NextResponse.json({ result, match_count });
+
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+}


### PR DESCRIPTION
## Summary
Closes #847

Implements a feature to wrap occurrences of search terms in text with markers, while avoiding overlapping double-wrapping.

## Endpoint
**`POST /api/routesF/wrap-search-terms`**

**Request Body:**
```json
{
  "text": "abracadabra",
  "terms": ["abrac", "cadab"],
  "marker": "%%",
  "case_sensitive": false
}
```

**Response (200):**
```json
{
  "result": "%%abracadab%%ra",
  "match_count": 2
}
```

## Features
- **Overlapping Protection:** Matches are combined so that overlapping intervals are merged and highlighted as a single block rather than nested tags.
- **Case Sensitivity Toggle:** Optional `case_sensitive` parameter.
- **Customizable Markers:** Optional `marker` parameter (defaults to `**`).
- **Strictly Scoped:** All files reside entirely inside `app/api/routesF/`.
