### PR TITLE
feat: ordinal formatter, sitemap XML, text fingerprint, nanoid generator (#813 #811 #808 #804)

### DIFF
--- a/app/api/routes-f/__tests__/nanoid.test.ts
+++ b/app/api/routes-f/__tests__/nanoid.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../nanoid/route";
+import { generateId } from "../nanoid/_lib/helpers";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/nanoid", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("generateId", () => {
+  it("returns a string of the requested size", () => {
+    expect(generateId(21, "abc123").length).toBe(21);
+    expect(generateId(10, "abc").length).toBe(10);
+    expect(generateId(1, "ab").length).toBe(1);
+  });
+
+  it("only uses characters from the given alphabet", () => {
+    const alphabet = "abc";
+    const id = generateId(100, alphabet);
+    for (const ch of id) {
+      expect(alphabet).toContain(ch);
+    }
+  });
+
+  it("generates unique IDs across many calls", () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => generateId(21, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")));
+    expect(ids.size).toBe(1000);
+  });
+});
+
+describe("POST /api/routes-f/nanoid", () => {
+  it("returns 1 ID of length 21 with defaults", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(200);
+    const { ids } = await res.json();
+    expect(ids).toHaveLength(1);
+    expect(ids[0]).toHaveLength(21);
+  });
+
+  it("respects custom count", async () => {
+    const res = await POST(makeReq({ count: 5 }));
+    expect(res.status).toBe(200);
+    const { ids } = await res.json();
+    expect(ids).toHaveLength(5);
+  });
+
+  it("respects custom size", async () => {
+    const res = await POST(makeReq({ size: 10 }));
+    expect(res.status).toBe(200);
+    const { ids } = await res.json();
+    expect(ids[0]).toHaveLength(10);
+  });
+
+  it("respects custom alphabet", async () => {
+    const alphabet = "01";
+    const res = await POST(makeReq({ size: 32, alphabet }));
+    expect(res.status).toBe(200);
+    const { ids } = await res.json();
+    for (const ch of ids[0]) {
+      expect(alphabet).toContain(ch);
+    }
+  });
+
+  it("generates unique IDs across 100 requests", async () => {
+    const res = await POST(makeReq({ count: 100 }));
+    expect(res.status).toBe(200);
+    const { ids } = await res.json();
+    expect(new Set(ids).size).toBe(100);
+  });
+
+  it("returns 400 when count exceeds 100", async () => {
+    const res = await POST(makeReq({ count: 101 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when count is not a positive integer", async () => {
+    const res = await POST(makeReq({ count: 0 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when size is not a positive integer", async () => {
+    const res = await POST(makeReq({ size: -1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when alphabet has fewer than 2 characters", async () => {
+    const res = await POST(makeReq({ alphabet: "a" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/nanoid", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/__tests__/sitemap-xml.test.ts
+++ b/app/api/routes-f/__tests__/sitemap-xml.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../sitemap-xml/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/sitemap-xml", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/sitemap-xml", () => {
+  it("generates a valid sitemap with a single required loc", async () => {
+    const res = await POST(makeReq({ urls: [{ loc: "https://example.com/" }] }));
+    expect(res.status).toBe(200);
+    const { sitemap } = await res.json();
+    expect(sitemap).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(sitemap).toContain("<urlset");
+    expect(sitemap).toContain("<loc>https://example.com/</loc>");
+    expect(sitemap).toContain("</urlset>");
+  });
+
+  it("includes optional fields when provided", async () => {
+    const res = await POST(
+      makeReq({
+        urls: [
+          {
+            loc: "https://example.com/page",
+            lastmod: "2024-01-15",
+            changefreq: "weekly",
+            priority: 0.8,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const { sitemap } = await res.json();
+    expect(sitemap).toContain("<lastmod>2024-01-15</lastmod>");
+    expect(sitemap).toContain("<changefreq>weekly</changefreq>");
+    expect(sitemap).toContain("<priority>0.8</priority>");
+  });
+
+  it("omits optional fields when not provided", async () => {
+    const res = await POST(makeReq({ urls: [{ loc: "https://example.com/" }] }));
+    expect(res.status).toBe(200);
+    const { sitemap } = await res.json();
+    expect(sitemap).not.toContain("<lastmod>");
+    expect(sitemap).not.toContain("<changefreq>");
+    expect(sitemap).not.toContain("<priority>");
+  });
+
+  it("handles multiple URL entries", async () => {
+    const res = await POST(
+      makeReq({
+        urls: [
+          { loc: "https://example.com/" },
+          { loc: "https://example.com/about", priority: 0.5 },
+          { loc: "https://example.com/blog", changefreq: "daily" },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const { sitemap } = await res.json();
+    expect((sitemap.match(/<url>/g) ?? []).length).toBe(3);
+  });
+
+  it("escapes XML special characters in loc", async () => {
+    const res = await POST(
+      makeReq({ urls: [{ loc: "https://example.com/path?a=1&b=2" }] })
+    );
+    expect(res.status).toBe(200);
+    const { sitemap } = await res.json();
+    expect(sitemap).toContain("&amp;");
+    expect(sitemap).not.toContain("&b=");
+  });
+
+  it("rejects invalid loc (not a URL)", async () => {
+    const res = await POST(makeReq({ urls: [{ loc: "not-a-url" }] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects priority outside [0, 1]", async () => {
+    const res = await POST(
+      makeReq({ urls: [{ loc: "https://example.com/", priority: 1.5 }] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid changefreq", async () => {
+    const res = await POST(
+      makeReq({ urls: [{ loc: "https://example.com/", changefreq: "sometimes" }] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty urls array", async () => {
+    const res = await POST(makeReq({ urls: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing urls field", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/sitemap-xml", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts priority of exactly 0 and 1", async () => {
+    const res = await POST(
+      makeReq({
+        urls: [
+          { loc: "https://example.com/low", priority: 0 },
+          { loc: "https://example.com/high", priority: 1 },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/routes-f/__tests__/text-fingerprint.test.ts
+++ b/app/api/routes-f/__tests__/text-fingerprint.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../text-fingerprint/route";
+import { fingerprint, normalizeText } from "../text-fingerprint/_lib/helpers";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/text-fingerprint", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("normalizeText", () => {
+  it("lowercases text", () => {
+    expect(normalizeText("Hello World")).toBe("hello world");
+  });
+
+  it("strips punctuation and collapses resulting whitespace", () => {
+    // comma and ! become spaces → collapse → "hello world"
+    expect(normalizeText("hello, world!")).toBe("hello world");
+    // apostrophe → space, period → space, collapse → "it s a test"
+    expect(normalizeText("it's a test.")).toBe("it s a test");
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(normalizeText("  foo   bar  ")).toBe("foo bar");
+  });
+});
+
+describe("fingerprint", () => {
+  it("returns a sha256 hex fingerprint and normalized text", () => {
+    const result = fingerprint("Hello World");
+    expect(result.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.normalized).toBe("hello world");
+  });
+
+  it("same fingerprint for texts differing only in word order", () => {
+    const a = fingerprint("foo bar baz");
+    const b = fingerprint("baz foo bar");
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  it("same fingerprint for texts differing only in case", () => {
+    const a = fingerprint("Hello World");
+    const b = fingerprint("hello world");
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  it("same fingerprint for texts differing only in punctuation and order", () => {
+    const a = fingerprint("The quick, brown fox!");
+    const b = fingerprint("fox brown quick the");
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  it("different fingerprint for genuinely different content", () => {
+    const a = fingerprint("hello world");
+    const b = fingerprint("goodbye world");
+    expect(a.fingerprint).not.toBe(b.fingerprint);
+  });
+
+  it("is idempotent for same input", () => {
+    const a = fingerprint("test text");
+    const b = fingerprint("test text");
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  it("handles empty string", () => {
+    const result = fingerprint("");
+    expect(result.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.normalized).toBe("");
+  });
+});
+
+describe("POST /api/routes-f/text-fingerprint", () => {
+  it("returns fingerprint and normalized for valid text", async () => {
+    const res = await POST(makeReq({ text: "Hello World" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("fingerprint");
+    expect(data).toHaveProperty("normalized");
+    expect(data.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns same fingerprint for order-swapped text", async () => {
+    const res1 = await POST(makeReq({ text: "apple banana cherry" }));
+    const res2 = await POST(makeReq({ text: "cherry apple banana" }));
+    const d1 = await res1.json();
+    const d2 = await res2.json();
+    expect(d1.fingerprint).toBe(d2.fingerprint);
+  });
+
+  it("returns 400 for missing text field", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when text is not a string", async () => {
+    const res = await POST(makeReq({ text: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-object body", async () => {
+    const res = await POST(makeReq("just a string"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/text-fingerprint", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/nanoid/_lib/helpers.ts
+++ b/app/api/routes-f/nanoid/_lib/helpers.ts
@@ -1,0 +1,76 @@
+import { randomBytes } from "crypto";
+
+const DEFAULT_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+const DEFAULT_SIZE = 21;
+const DEFAULT_COUNT = 1;
+const MAX_COUNT = 100;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function generateId(size: number, alphabet: string): string {
+  const alphabetLength = alphabet.length;
+  // Use rejection sampling to avoid modulo bias
+  const mask = Math.pow(2, Math.ceil(Math.log2(alphabetLength))) - 1;
+  const bytesNeeded = Math.ceil((size * 1.6) / 1); // slight overallocation
+  let id = "";
+
+  while (id.length < size) {
+    const bytes = randomBytes(bytesNeeded);
+    for (let i = 0; i < bytes.length && id.length < size; i++) {
+      const byte = bytes[i] & mask;
+      if (byte < alphabetLength) {
+        id += alphabet[byte];
+      }
+    }
+  }
+
+  return id;
+}
+
+export function parseAndGenerate(input: unknown): { ids: string[] } {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  let count = DEFAULT_COUNT;
+  let size = DEFAULT_SIZE;
+  let alphabet = DEFAULT_ALPHABET;
+
+  if (input.count !== undefined) {
+    if (
+      typeof input.count !== "number" ||
+      !Number.isInteger(input.count) ||
+      input.count < 1
+    ) {
+      throw new Error("count must be a positive integer.");
+    }
+    if (input.count > MAX_COUNT) {
+      throw new Error(`count must not exceed ${MAX_COUNT}.`);
+    }
+    count = input.count;
+  }
+
+  if (input.size !== undefined) {
+    if (
+      typeof input.size !== "number" ||
+      !Number.isInteger(input.size) ||
+      input.size < 1
+    ) {
+      throw new Error("size must be a positive integer.");
+    }
+    size = input.size;
+  }
+
+  if (input.alphabet !== undefined) {
+    if (typeof input.alphabet !== "string" || input.alphabet.length < 2) {
+      throw new Error("alphabet must be a string with at least 2 characters.");
+    }
+    alphabet = input.alphabet;
+  }
+
+  const ids = Array.from({ length: count }, () => generateId(size, alphabet));
+  return { ids };
+}

--- a/app/api/routes-f/nanoid/_lib/types.ts
+++ b/app/api/routes-f/nanoid/_lib/types.ts
@@ -1,0 +1,3 @@
+export interface NanoidResponse {
+  ids: string[];
+}

--- a/app/api/routes-f/nanoid/route.ts
+++ b/app/api/routes-f/nanoid/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { parseAndGenerate } from "./_lib/helpers";
+import type { NanoidResponse } from "./_lib/types";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    const result = parseAndGenerate(body);
+    return NextResponse.json(result satisfies NanoidResponse);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to generate IDs.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/sitemap-xml/_lib/helpers.ts
+++ b/app/api/routes-f/sitemap-xml/_lib/helpers.ts
@@ -1,0 +1,122 @@
+import type { ChangeFreq, UrlEntry } from "./types";
+
+const MAX_URLS = 50_000;
+
+const VALID_CHANGEFREQS: ChangeFreq[] = [
+  "always",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
+  "never",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function isValidUrl(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function parseUrlEntry(value: unknown, index: number): UrlEntry {
+  if (!isRecord(value)) {
+    throw new Error(`urls[${index}] must be an object.`);
+  }
+
+  if (typeof value.loc !== "string" || !value.loc.trim()) {
+    throw new Error(`urls[${index}].loc must be a non-empty string.`);
+  }
+
+  const loc = value.loc.trim();
+  if (!isValidUrl(loc)) {
+    throw new Error(`urls[${index}].loc must be a valid http/https URL.`);
+  }
+
+  const entry: UrlEntry = { loc };
+
+  if (value.lastmod !== undefined) {
+    if (typeof value.lastmod !== "string") {
+      throw new Error(`urls[${index}].lastmod must be a string.`);
+    }
+    entry.lastmod = value.lastmod.trim();
+  }
+
+  if (value.changefreq !== undefined) {
+    if (
+      typeof value.changefreq !== "string" ||
+      !VALID_CHANGEFREQS.includes(value.changefreq as ChangeFreq)
+    ) {
+      throw new Error(
+        `urls[${index}].changefreq must be one of: ${VALID_CHANGEFREQS.join(", ")}.`
+      );
+    }
+    entry.changefreq = value.changefreq as ChangeFreq;
+  }
+
+  if (value.priority !== undefined) {
+    const p = Number(value.priority);
+    if (!Number.isFinite(p) || p < 0 || p > 1) {
+      throw new Error(`urls[${index}].priority must be a number in [0, 1].`);
+    }
+    entry.priority = p;
+  }
+
+  return entry;
+}
+
+function buildUrlElement(entry: UrlEntry): string {
+  const lines: string[] = [`  <url>`, `    <loc>${escapeXml(entry.loc)}</loc>`];
+
+  if (entry.lastmod !== undefined) {
+    lines.push(`    <lastmod>${escapeXml(entry.lastmod)}</lastmod>`);
+  }
+  if (entry.changefreq !== undefined) {
+    lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+  }
+  if (entry.priority !== undefined) {
+    lines.push(`    <priority>${entry.priority.toFixed(1)}</priority>`);
+  }
+
+  lines.push(`  </url>`);
+  return lines.join("\n");
+}
+
+export function buildSitemap(input: unknown): string {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  if (!Array.isArray(input.urls) || input.urls.length === 0) {
+    throw new Error("urls must be a non-empty array.");
+  }
+
+  if (input.urls.length > MAX_URLS) {
+    throw new Error(`urls must contain at most ${MAX_URLS} entries.`);
+  }
+
+  const entries = input.urls.map(parseUrlEntry);
+  const urlElements = entries.map(buildUrlElement).join("\n");
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `${urlElements}\n` +
+    `</urlset>`
+  );
+}

--- a/app/api/routes-f/sitemap-xml/_lib/types.ts
+++ b/app/api/routes-f/sitemap-xml/_lib/types.ts
@@ -1,0 +1,19 @@
+export type ChangeFreq =
+  | "always"
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "yearly"
+  | "never";
+
+export interface UrlEntry {
+  loc: string;
+  lastmod?: string;
+  changefreq?: ChangeFreq;
+  priority?: number;
+}
+
+export interface SitemapResponse {
+  sitemap: string;
+}

--- a/app/api/routes-f/sitemap-xml/route.ts
+++ b/app/api/routes-f/sitemap-xml/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { buildSitemap } from "./_lib/helpers";
+import type { SitemapResponse } from "./_lib/types";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    const sitemap = buildSitemap(body);
+    return NextResponse.json({ sitemap } satisfies SitemapResponse);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to generate sitemap.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/text-fingerprint/_lib/helpers.ts
+++ b/app/api/routes-f/text-fingerprint/_lib/helpers.ts
@@ -1,0 +1,34 @@
+import { createHash } from "crypto";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")   // strip punctuation → space
+    .replace(/\s+/g, " ")       // collapse whitespace
+    .trim();
+}
+
+export function fingerprint(text: string): { fingerprint: string; normalized: string } {
+  const normalized = normalizeText(text);
+  const tokens = normalized.split(" ").filter(Boolean);
+  // deduplicate then sort so order-independent texts yield the same hash
+  const canonical = [...new Set(tokens)].sort().join(" ");
+  const hash = createHash("sha256").update(canonical, "utf8").digest("hex");
+  return { fingerprint: hash, normalized };
+}
+
+export function parseAndFingerprint(input: unknown): { fingerprint: string; normalized: string } {
+  if (!isRecord(input)) {
+    throw new Error("Request body must be an object.");
+  }
+
+  if (typeof input.text !== "string") {
+    throw new Error("text must be a string.");
+  }
+
+  return fingerprint(input.text);
+}

--- a/app/api/routes-f/text-fingerprint/_lib/types.ts
+++ b/app/api/routes-f/text-fingerprint/_lib/types.ts
@@ -1,0 +1,4 @@
+export interface FingerprintResponse {
+  fingerprint: string;
+  normalized: string;
+}

--- a/app/api/routes-f/text-fingerprint/route.ts
+++ b/app/api/routes-f/text-fingerprint/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { parseAndFingerprint } from "./_lib/helpers";
+import type { FingerprintResponse } from "./_lib/types";
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  try {
+    const result = parseAndFingerprint(body);
+    return NextResponse.json(result satisfies FingerprintResponse);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to compute fingerprint.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routesF/ordinal-number-formatter/route.test.ts
+++ b/app/api/routesF/ordinal-number-formatter/route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, toOrdinal } from "./route";
+
+function makeReq(n: string) {
+  return new NextRequest(
+    `http://localhost/api/routesF/ordinal-number-formatter?n=${n}`
+  );
+}
+
+describe("toOrdinal", () => {
+  it("handles st suffix (1, 21, 31, 101)", () => {
+    expect(toOrdinal(1)).toEqual({ ordinal: "1st", suffix: "st" });
+    expect(toOrdinal(21)).toEqual({ ordinal: "21st", suffix: "st" });
+    expect(toOrdinal(31)).toEqual({ ordinal: "31st", suffix: "st" });
+    expect(toOrdinal(101)).toEqual({ ordinal: "101st", suffix: "st" });
+  });
+
+  it("handles nd suffix (2, 22, 102)", () => {
+    expect(toOrdinal(2)).toEqual({ ordinal: "2nd", suffix: "nd" });
+    expect(toOrdinal(22)).toEqual({ ordinal: "22nd", suffix: "nd" });
+    expect(toOrdinal(102)).toEqual({ ordinal: "102nd", suffix: "nd" });
+  });
+
+  it("handles rd suffix (3, 23, 103)", () => {
+    expect(toOrdinal(3)).toEqual({ ordinal: "3rd", suffix: "rd" });
+    expect(toOrdinal(23)).toEqual({ ordinal: "23rd", suffix: "rd" });
+    expect(toOrdinal(103)).toEqual({ ordinal: "103rd", suffix: "rd" });
+  });
+
+  it("handles th suffix for all other cases", () => {
+    expect(toOrdinal(4)).toEqual({ ordinal: "4th", suffix: "th" });
+    expect(toOrdinal(10)).toEqual({ ordinal: "10th", suffix: "th" });
+    expect(toOrdinal(20)).toEqual({ ordinal: "20th", suffix: "th" });
+    expect(toOrdinal(100)).toEqual({ ordinal: "100th", suffix: "th" });
+  });
+
+  it("handles teen special cases (11, 12, 13 are always th)", () => {
+    expect(toOrdinal(11)).toEqual({ ordinal: "11th", suffix: "th" });
+    expect(toOrdinal(12)).toEqual({ ordinal: "12th", suffix: "th" });
+    expect(toOrdinal(13)).toEqual({ ordinal: "13th", suffix: "th" });
+    expect(toOrdinal(111)).toEqual({ ordinal: "111th", suffix: "th" });
+    expect(toOrdinal(112)).toEqual({ ordinal: "112th", suffix: "th" });
+    expect(toOrdinal(113)).toEqual({ ordinal: "113th", suffix: "th" });
+  });
+
+  it("handles negatives correctly", () => {
+    expect(toOrdinal(-1)).toEqual({ ordinal: "-1st", suffix: "st" });
+    expect(toOrdinal(-11)).toEqual({ ordinal: "-11th", suffix: "th" });
+    expect(toOrdinal(-21)).toEqual({ ordinal: "-21st", suffix: "st" });
+    expect(toOrdinal(-13)).toEqual({ ordinal: "-13th", suffix: "th" });
+  });
+
+  it("handles zero", () => {
+    expect(toOrdinal(0)).toEqual({ ordinal: "0th", suffix: "th" });
+  });
+
+  it("handles large numbers", () => {
+    expect(toOrdinal(1001)).toEqual({ ordinal: "1001st", suffix: "st" });
+    expect(toOrdinal(10011)).toEqual({ ordinal: "10011th", suffix: "th" });
+    expect(toOrdinal(10021)).toEqual({ ordinal: "10021st", suffix: "st" });
+  });
+});
+
+describe("GET /api/routesF/ordinal-number-formatter", () => {
+  it("returns ordinal for n=21", async () => {
+    const res = await GET(makeReq("21"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ordinal: "21st", suffix: "st" });
+  });
+
+  it("returns ordinal for n=11 (teen special case)", async () => {
+    const res = await GET(makeReq("11"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ordinal: "11th", suffix: "th" });
+  });
+
+  it("returns ordinal for negative n=-13", async () => {
+    const res = await GET(makeReq("-13"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ordinal: "-13th", suffix: "th" });
+  });
+
+  it("returns 400 when n is missing", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routesF/ordinal-number-formatter"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/required/i);
+  });
+
+  it("returns 400 for non-integer n", async () => {
+    const res = await GET(makeReq("3.14"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-numeric n", async () => {
+    const res = await GET(makeReq("abc"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/ordinal-number-formatter/route.ts
+++ b/app/api/routesF/ordinal-number-formatter/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+type OrdinalSuffix = "st" | "nd" | "rd" | "th";
+
+function getOrdinalSuffix(n: number): OrdinalSuffix {
+  const abs = Math.abs(n);
+  const mod100 = abs % 100;
+  // 11, 12, 13 are always "th" regardless of ones digit
+  if (mod100 >= 11 && mod100 <= 13) {
+    return "th";
+  }
+  const mod10 = abs % 10;
+  if (mod10 === 1) return "st";
+  if (mod10 === 2) return "nd";
+  if (mod10 === 3) return "rd";
+  return "th";
+}
+
+export function toOrdinal(n: number): { ordinal: string; suffix: OrdinalSuffix } {
+  const suffix = getOrdinalSuffix(n);
+  return { ordinal: `${n}${suffix}`, suffix };
+}
+
+export async function GET(req: NextRequest) {
+  const nParam = req.nextUrl.searchParams.get("n");
+
+  if (!nParam) {
+    return NextResponse.json(
+      { error: "n query parameter is required." },
+      { status: 400 }
+    );
+  }
+
+  if (!/^-?\d+$/.test(nParam.trim())) {
+    return NextResponse.json(
+      { error: "n must be an integer." },
+      { status: 400 }
+    );
+  }
+
+  const n = parseInt(nParam.trim(), 10);
+
+  if (!Number.isFinite(n)) {
+    return NextResponse.json(
+      { error: "n is out of safe integer range." },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(toOrdinal(n));
+}


### PR DESCRIPTION
## Summary

Resolves four assigned issues in a single combined PR. Each feature is scoped entirely to its route subfolder as required by the issue constraints.

- Closes #813 — **ordinal number formatter** (`app/api/routesF/ordinal-number-formatter/`)
- Closes #811 — **sitemap XML generator** (`app/api/routes-f/sitemap-xml/`)
- Closes #808 — **text fingerprint for dedup** (`app/api/routes-f/text-fingerprint/`)
- Closes #804 — **nanoid-style ID generator** (`app/api/routes-f/nanoid/`)

---

### #813 — Ordinal Number Formatter (`GET /api/routesF/ordinal-number-formatter?n=`)

- Returns `{ ordinal, suffix }` — e.g. `?n=21` → `{ ordinal: "21st", suffix: "st" }`
- Correctly handles 11/12/13 teen special-cases (always `th`)
- Supports negative integers
- Tests cover: ones-digit rules, teen cases, large numbers, missing/invalid `n`

### #811 — Sitemap XML Generator (`POST /api/routes-f/sitemap-xml`)

- Accepts `{ urls: [{ loc, lastmod?, changefreq?, priority? }] }`
- Returns `{ sitemap: string }` as well-formed XML (UTF-8, sitemaps.org schema)
- Validates: `loc` must be a valid http/https URL; `priority` in `[0, 1]`; `changefreq` must be one of the seven standard values; caps at 50 000 entries
- Escapes XML special characters in `loc`
- Tests cover: optional fields, multi-URL, XML escaping, all validation paths

### #808 — Text Fingerprint for Dedup (`POST /api/routes-f/text-fingerprint`)

- Accepts `{ text }`, returns `{ fingerprint, normalized }`
- Pipeline: lowercase → strip punctuation → collapse whitespace → deduplicate tokens → sort → SHA-256
- Two texts differing only in word order, case, or punctuation yield the same fingerprint
- Tests verify dedup invariant, idempotency, different-content divergence

### #804 — Nanoid-style ID Generator (`POST /api/routes-f/nanoid`)

- Accepts `{ count?, size?, alphabet? }` — defaults: `size=21`, `count=1`, max `count=100`
- Uses `crypto.randomBytes` with rejection sampling (avoids modulo bias)
- Returns `{ ids: string[] }`
- Tests verify: correct length, alphabet containment, uniqueness across 1 000 IDs, all validation errors

## Test plan

- [x] All 4 test suites pass (verified locally before commit)
- [x] Files scoped strictly to their respective route subfolders — no changes outside `app/api/routes-f/` or `app/api/routesF/`
- [x] No shared lib/utils imports — all logic is self-contained per issue constraints
- [x] Error paths return `400` with a descriptive `error` field
- [x] TypeScript types defined in `_lib/types.ts` for routes-f pattern; inline for routesF pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)