### PR TITLE
feat: add routesF API endpoints

### DIFF
--- a/app/api/routes-f/sieve-of-eratosthenes/route.test.ts
+++ b/app/api/routes-f/sieve-of-eratosthenes/route.test.ts
@@ -1,0 +1,78 @@
+import { GET } from './route';
+
+describe('Sieve of Eratosthenes API', () => {
+  it('should return 400 when limit parameter is missing', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when limit is below 2', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=1', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when limit exceeds 1000000', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=1000001', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when limit is not a valid number', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=abc', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 25 primes up to 100', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=100', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.count).toBe(25);
+    expect(data.primes).toEqual([
+      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+    ]);
+  });
+
+  it('should return correct primes up to 10', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=10', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.count).toBe(4);
+    expect(data.primes).toEqual([2, 3, 5, 7]);
+  });
+
+  it('should return empty array for limit 2 with 1 prime', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=2', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.count).toBe(1);
+    expect(data.primes).toEqual([2]);
+  });
+
+  it('should handle large limits efficiently', async () => {
+    const req = new Request('http://localhost/api/routes-f/sieve-of-eratosthenes?limit=10000', {
+      method: 'GET',
+    });
+    const res = await GET(req);
+    const data = await res.json();
+    expect(data.primes[0]).toBe(2);
+    expect(data.primes[data.primes.length - 1]).toBe(9973);
+    expect(data.count).toBe(1229);
+  });
+});

--- a/app/api/routes-f/sieve-of-eratosthenes/route.ts
+++ b/app/api/routes-f/sieve-of-eratosthenes/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+
+function sieveOfEratosthenes(limit: number): number[] {
+  if (limit < 2) return [];
+
+  const isPrime = Array(limit + 1).fill(true);
+  isPrime[0] = isPrime[1] = false;
+
+  for (let i = 2; i * i <= limit; i++) {
+    if (isPrime[i]) {
+      for (let j = i * i; j <= limit; j += i) {
+        isPrime[j] = false;
+      }
+    }
+  }
+
+  const primes: number[] = [];
+  for (let i = 2; i <= limit; i++) {
+    if (isPrime[i]) {
+      primes.push(i);
+    }
+  }
+
+  return primes;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limitParam = searchParams.get('limit');
+
+  if (!limitParam) {
+    return NextResponse.json(
+      { error: 'Missing limit parameter' },
+      { status: 400 }
+    );
+  }
+
+  const limit = parseInt(limitParam, 10);
+
+  if (isNaN(limit) || limit < 2 || limit > 1000000) {
+    return NextResponse.json(
+      { error: 'Limit must be between 2 and 1000000' },
+      { status: 400 }
+    );
+  }
+
+  const primes = sieveOfEratosthenes(limit);
+
+  return NextResponse.json({
+    primes,
+    count: primes.length,
+  });
+}

--- a/app/api/routesF/acronym-generator/route.test.ts
+++ b/app/api/routesF/acronym-generator/route.test.ts
@@ -1,0 +1,87 @@
+import { POST } from './route';
+
+describe('Acronym Generator API', () => {
+  it('should return 400 when phrase is missing', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when phrase is empty', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: '   ' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should skip stopwords by default', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: 'The Quick Brown Fox' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('QBF');
+    expect(data.words_used).toEqual(['quick', 'brown', 'fox']);
+  });
+
+  it('should generate acronym with stopwords when include_stopwords is true', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: 'The Quick Brown Fox', include_stopwords: true }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('TQBF');
+    expect(data.words_used).toEqual(['the', 'quick', 'brown', 'fox']);
+  });
+
+  it('should handle multiple stopwords', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: 'as if the world is round' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('WR');
+    expect(data.words_used).toEqual(['world', 'round']);
+  });
+
+  it('should handle single word phrases', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: 'hello' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('H');
+    expect(data.words_used).toEqual(['hello']);
+  });
+
+  it('should handle phrases with only stopwords', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: 'the and or' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('');
+    expect(data.words_used).toEqual([]);
+  });
+
+  it('should handle extra whitespace', async () => {
+    const req = new Request('http://localhost/api/routesF/acronym-generator', {
+      method: 'POST',
+      body: JSON.stringify({ phrase: '  Natural   Language   Processing  ' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.acronym).toBe('NLP');
+    expect(data.words_used).toEqual(['natural', 'language', 'processing']);
+  });
+});

--- a/app/api/routesF/acronym-generator/route.ts
+++ b/app/api/routesF/acronym-generator/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+
+const DEFAULT_STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'as', 'is', 'was', 'are', 'been', 'be',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'must', 'can', 'if', 'because', 'than',
+]);
+
+function generateAcronym(phrase: string, includeStopwords: boolean = false): { acronym: string; words_used: string[] } {
+  const words = phrase
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((word) => word.length > 0);
+
+  const filteredWords = includeStopwords
+    ? words
+    : words.filter((word) => !DEFAULT_STOPWORDS.has(word));
+
+  const acronym = filteredWords.map((word) => word.charAt(0).toUpperCase()).join('');
+
+  return {
+    acronym,
+    words_used: filteredWords,
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { phrase, include_stopwords = false } = body;
+
+    if (!phrase || typeof phrase !== 'string' || phrase.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Missing or invalid phrase' },
+        { status: 400 }
+      );
+    }
+
+    const result = generateAcronym(phrase, include_stopwords);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Invalid JSON body' },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routesF/qr-payload-builder/route.test.ts
+++ b/app/api/routesF/qr-payload-builder/route.test.ts
@@ -1,0 +1,139 @@
+import { POST } from './route';
+
+describe('QR Payload Builder API', () => {
+  it('should return 400 when type is missing', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({ data: {} }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for invalid type', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'invalid', data: {} }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should build WiFi payload', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'wifi',
+        data: { ssid: 'MyNetwork', password: 'secure123' },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toBe('WIFI:T:WPA;S:MyNetwork;P:secure123;;');
+  });
+
+  it('should build WiFi payload with custom security', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'wifi',
+        data: { ssid: 'OpenWifi', password: 'pass', security: 'NOPASS' },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toBe('WIFI:T:NOPASS;S:OpenWifi;P:pass;;');
+  });
+
+  it('should build vCard payload with full details', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'vcard',
+        data: {
+          firstName: 'John',
+          lastName: 'Doe',
+          phone: '1234567890',
+          email: 'john@example.com',
+          organization: 'Acme Corp',
+          url: 'https://example.com',
+        },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toContain('BEGIN:VCARD');
+    expect(result.payload).toContain('END:VCARD');
+    expect(result.payload).toContain('FN:John Doe');
+    expect(result.payload).toContain('TEL:1234567890');
+    expect(result.payload).toContain('EMAIL:john@example.com');
+    expect(result.payload).toContain('ORG:Acme Corp');
+    expect(result.payload).toContain('URL:https://example.com');
+  });
+
+  it('should build vCard payload with minimal details', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'vcard',
+        data: { firstName: 'Jane', lastName: 'Smith' },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toContain('FN:Jane Smith');
+    expect(result.payload).toContain('BEGIN:VCARD');
+  });
+
+  it('should build URL payload', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'url',
+        data: { url: 'https://example.com/page' },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toBe('https://example.com/page');
+  });
+
+  it('should build geo payload without altitude', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'geo',
+        data: { latitude: 40.7128, longitude: -74.006 },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toBe('geo:40.7128,-74.006');
+  });
+
+  it('should build geo payload with altitude', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'geo',
+        data: { latitude: 40.7128, longitude: -74.006, altitude: 10 },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toBe('geo:40.7128,-74.006,10');
+  });
+
+  it('should handle case-insensitive type', async () => {
+    const req = new Request('http://localhost/api/routesF/qr-payload-builder', {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'WIFI',
+        data: { ssid: 'Network', password: 'pass123' },
+      }),
+    });
+    const res = await POST(req);
+    const result = await res.json();
+    expect(result.payload).toContain('WIFI:');
+  });
+});

--- a/app/api/routesF/qr-payload-builder/route.ts
+++ b/app/api/routesF/qr-payload-builder/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+
+function buildWiFiPayload(data: any): string {
+  const { ssid, password, security = 'WPA' } = data;
+  if (!ssid || !password) {
+    throw new Error('WiFi requires ssid and password');
+  }
+  return `WIFI:T:${security};S:${ssid};P:${password};;`;
+}
+
+function buildVCardPayload(data: any): string {
+  const { firstName, lastName, phone, email, organization, url } = data;
+  if (!firstName && !lastName) {
+    throw new Error('vCard requires at least firstName or lastName');
+  }
+
+  const lines = ['BEGIN:VCARD', 'VERSION:3.0'];
+
+  if (firstName || lastName) {
+    lines.push(`FN:${(firstName || '').trim()} ${(lastName || '').trim()}`.trim());
+    lines.push(`N:${lastName || ''};${firstName || ''};; ;`);
+  }
+
+  if (phone) {
+    lines.push(`TEL:${phone}`);
+  }
+
+  if (email) {
+    lines.push(`EMAIL:${email}`);
+  }
+
+  if (organization) {
+    lines.push(`ORG:${organization}`);
+  }
+
+  if (url) {
+    lines.push(`URL:${url}`);
+  }
+
+  lines.push('END:VCARD');
+
+  return lines.join('\n');
+}
+
+function buildURLPayload(data: any): string {
+  const { url } = data;
+  if (!url) {
+    throw new Error('URL requires url parameter');
+  }
+  return url;
+}
+
+function buildGeoPayload(data: any): string {
+  const { latitude, longitude, altitude } = data;
+  if (latitude === undefined || longitude === undefined) {
+    throw new Error('Geo requires latitude and longitude');
+  }
+
+  if (altitude !== undefined) {
+    return `geo:${latitude},${longitude},${altitude}`;
+  }
+
+  return `geo:${latitude},${longitude}`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { type, data } = body;
+
+    if (!type) {
+      return NextResponse.json(
+        { error: 'Missing type parameter' },
+        { status: 400 }
+      );
+    }
+
+    if (!data || typeof data !== 'object') {
+      return NextResponse.json(
+        { error: 'Missing or invalid data object' },
+        { status: 400 }
+      );
+    }
+
+    let payload: string;
+
+    switch (type.toLowerCase()) {
+      case 'wifi':
+        payload = buildWiFiPayload(data);
+        break;
+      case 'vcard':
+        payload = buildVCardPayload(data);
+        break;
+      case 'url':
+        payload = buildURLPayload(data);
+        break;
+      case 'geo':
+        payload = buildGeoPayload(data);
+        break;
+      default:
+        return NextResponse.json(
+          { error: 'Invalid type. Use wifi, vcard, url, or geo' },
+          { status: 400 }
+        );
+    }
+
+    return NextResponse.json({ payload });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || 'Invalid request' },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/routesF/whitespace-normalizer/route.test.ts
+++ b/app/api/routesF/whitespace-normalizer/route.test.ts
@@ -1,0 +1,101 @@
+import { POST } from './route';
+
+describe('Whitespace Normalizer API', () => {
+  it('should return 400 when text is missing', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('should collapse multiple spaces by default', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'hello    world  test' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('hello world test');
+  });
+
+  it('should collapse tabs by default', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'hello\t\tworld\ttest' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('hello world test');
+  });
+
+  it('should preserve newlines by default', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'line1\nline2\nline3' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('line1\nline2\nline3');
+  });
+
+  it('should trim lines when trim_lines is true', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: '  line1  \n  line2  \n  line3  ', trim_lines: true }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('line1\nline2\nline3');
+  });
+
+  it('should strip blank lines when strip_blank_lines is true', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'line1\n\nline2\n\n\nline3', strip_blank_lines: true }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('line1\nline2\nline3');
+  });
+
+  it('should combine collapse_spaces and trim_lines', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: '  hello    world  \n  foo    bar  ',
+        collapse_spaces: true,
+        trim_lines: true,
+      }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('hello world\nfoo bar');
+  });
+
+  it('should combine all options', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({
+        text: '  hello    world  \n\n  foo    bar  \n\n  ',
+        collapse_spaces: true,
+        trim_lines: true,
+        strip_blank_lines: true,
+      }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('hello world\nfoo bar');
+  });
+
+  it('should handle mixed tabs and spaces', async () => {
+    const req = new Request('http://localhost/api/routesF/whitespace-normalizer', {
+      method: 'POST',
+      body: JSON.stringify({ text: 'hello\t  \t world' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+    expect(data.result).toBe('hello world');
+  });
+});

--- a/app/api/routesF/whitespace-normalizer/route.ts
+++ b/app/api/routesF/whitespace-normalizer/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+
+function normalizeWhitespace(
+  text: string,
+  collapseSpaces: boolean = true,
+  trimLines: boolean = false,
+  stripBlankLines: boolean = false
+): string {
+  let result = text;
+
+  if (trimLines) {
+    result = result
+      .split('\n')
+      .map((line) => line.trim())
+      .join('\n');
+  }
+
+  if (collapseSpaces) {
+    result = result
+      .split('\n')
+      .map((line) => line.replace(/[ \t]+/g, ' '))
+      .join('\n');
+  }
+
+  if (stripBlankLines) {
+    result = result
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .join('\n');
+  }
+
+  return result;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const {
+      text,
+      collapse_spaces = true,
+      trim_lines = false,
+      strip_blank_lines = false,
+    } = body;
+
+    if (!text || typeof text !== 'string') {
+      return NextResponse.json(
+        { error: 'Missing or invalid text' },
+        { status: 400 }
+      );
+    }
+
+    const result = normalizeWhitespace(
+      text,
+      collapse_spaces,
+      trim_lines,
+      strip_blank_lines
+    );
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Invalid JSON body' },
+      { status: 400 }
+    );
+  }
+}


### PR DESCRIPTION
## What
Added four new API endpoint implementations for sieve of Eratosthenes, acronym generation, whitespace normalization, and QR payload building.

## Issues Resolved
Closes #864
Closes #848
Closes #903
Closes #836

## Changes

### #864 - feat(routes-f): sieve of eratosthenes
Added GET endpoint at app/api/routes-f/sieve-of-eratosthenes/ that returns all prime numbers up to N using the Sieve of Eratosthenes algorithm. Validates limit between 2 and 1000000 and returns primes array with count.

### #848 - feat(routesF): acronym generator
Added POST endpoint at app/api/routesF/acronym-generator/ that generates acronyms from phrases with optional stopword filtering. Returns the acronym and list of words used.

### #903 - feat(routesF): whitespace normalizer
Added POST endpoint at app/api/routesF/whitespace-normalizer/ that normalizes whitespace with options to collapse spaces, trim lines, and strip blank lines. Preserves single newlines by default.

### #836 - feat(routesF): qr payload builder
Added POST endpoint at app/api/routesF/qr-payload-builder/ that builds QR code payloads for WiFi (WIFI:T:...), vCard, URL, and geographic location formats.