### PR TITLE
feat(routesF): add happy number & caesar brute force

### DIFF
--- a/app/api/routes-f/happy-number/__tests__/route.test.ts
+++ b/app/api/routes-f/happy-number/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+import { analyzeHappyNumber } from "../happy";
+import { GET } from "../route";
+
+// #863 feat(routes-f): happy number checker
+
+function makeRequest(path: string) {
+  return new Request(`http://localhost${path}`) as unknown as import("next/server").NextRequest;
+}
+
+describe("analyzeHappyNumber", () => {
+  it("identifies 19 as happy with the known sequence", () => {
+    expect(analyzeHappyNumber(19)).toEqual({
+      n: 19,
+      is_happy: true,
+      sequence: [19, 82, 68, 100, 1],
+    });
+  });
+
+  it("identifies 7 as happy", () => {
+    expect(analyzeHappyNumber(7)).toEqual({
+      n: 7,
+      is_happy: true,
+      sequence: [7, 49, 97, 130, 10, 1],
+    });
+  });
+
+  it("identifies 4 as unhappy and terminates on cycle detection", () => {
+    const result = analyzeHappyNumber(4);
+
+    expect(result.is_happy).toBe(false);
+    expect(result.sequence).toEqual([4, 16, 37, 58, 89, 145, 42, 20, 4]);
+  });
+});
+
+describe("GET /api/routes-f/happy-number", () => {
+  it("returns happy number analysis for n=19", async () => {
+    const res = await GET(makeRequest("/api/routes-f/happy-number?n=19"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({
+      n: 19,
+      is_happy: true,
+      sequence: [19, 82, 68, 100, 1],
+    });
+  });
+
+  it("rejects non-positive integers", async () => {
+    const missing = await GET(makeRequest("/api/routes-f/happy-number"));
+    const zero = await GET(makeRequest("/api/routes-f/happy-number?n=0"));
+    const negative = await GET(makeRequest("/api/routes-f/happy-number?n=-4"));
+    const invalid = await GET(makeRequest("/api/routes-f/happy-number?n=abc"));
+
+    expect(missing.status).toBe(400);
+    expect(zero.status).toBe(400);
+    expect(negative.status).toBe(400);
+    expect(invalid.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/happy-number/happy.ts
+++ b/app/api/routes-f/happy-number/happy.ts
@@ -1,0 +1,57 @@
+// #863 feat(routes-f): happy number checker
+
+export type HappyNumberResult = {
+  n: number;
+  is_happy: boolean;
+  sequence: number[];
+};
+
+function sumOfSquaredDigits(n: number): number {
+  let sum = 0;
+  let value = n;
+
+  while (value > 0) {
+    const digit = value % 10;
+    sum += digit * digit;
+    value = Math.floor(value / 10);
+  }
+
+  return sum;
+}
+
+/**
+ * Determine whether `n` is a happy number and return the iteration sequence
+ * until reaching 1 (happy) or detecting a cycle (unhappy).
+ */
+export function analyzeHappyNumber(n: number): HappyNumberResult {
+  const sequence: number[] = [n];
+  const seen = new Set<number>([n]);
+  let current = n;
+
+  while (current !== 1) {
+    current = sumOfSquaredDigits(current);
+
+    if (seen.has(current)) {
+      sequence.push(current);
+      return { n, is_happy: false, sequence };
+    }
+
+    seen.add(current);
+    sequence.push(current);
+  }
+
+  return { n, is_happy: true, sequence };
+}
+
+export function parsePositiveInteger(value: string | null): number | null {
+  if (value === null || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}

--- a/app/api/routes-f/happy-number/route.ts
+++ b/app/api/routes-f/happy-number/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeHappyNumber, parsePositiveInteger } from "./happy";
+
+// #863 feat(routes-f): happy number checker
+
+export async function GET(req: NextRequest) {
+  const nParam = new URL(req.url).searchParams.get("n");
+  const n = parsePositiveInteger(nParam);
+
+  if (n === null) {
+    return NextResponse.json(
+      { error: "n must be a positive integer." },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(analyzeHappyNumber(n));
+}

--- a/app/api/routes-f/soundex/__tests__/route.test.ts
+++ b/app/api/routes-f/soundex/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import { soundex } from "../soundex";
+import { POST } from "../route";
+
+// #860 feat(routes-f): soundex phonetic encoder
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/soundex", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("soundex", () => {
+  it.each([
+    ["Robert", "R163"],
+    ["Rupert", "R163"],
+    ["Washington", "W252"],
+    ["Lee", "L000"],
+    ["Ashcraft", "A261"],
+    ["Ashcroft", "A261"],
+  ])("encodes %s as %s", (word, expected) => {
+    expect(soundex(word)).toBe(expected);
+  });
+
+  it("ignores non-alphabetic characters", () => {
+    expect(soundex("O'Brien")).toBe(soundex("OBrien"));
+  });
+});
+
+describe("POST /api/routes-f/soundex", () => {
+  it("returns a single code for word", async () => {
+    const res = await POST(makeReq({ word: "Robert" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ code: "R163" });
+  });
+
+  it("returns codes for words array", async () => {
+    const res = await POST(makeReq({ words: ["Robert", "Rupert", "Lee"] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ codes: ["R163", "R163", "L000"] });
+  });
+
+  it("rejects invalid bodies", async () => {
+    const missing = await POST(makeReq({}));
+    const both = await POST(makeReq({ word: "a", words: ["b"] }));
+    const badWord = await POST(makeReq({ word: 123 }));
+
+    expect(missing.status).toBe(400);
+    expect(both.status).toBe(400);
+    expect(badWord.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/soundex/route.ts
+++ b/app/api/routes-f/soundex/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { encodeSoundexWords, soundex } from "./soundex";
+
+// #860 feat(routes-f): soundex phonetic encoder
+
+type SoundexBody = {
+  word?: unknown;
+  words?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: SoundexBody;
+
+  try {
+    body = (await req.json()) as SoundexBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const hasWord = body.word !== undefined;
+  const hasWords = body.words !== undefined;
+
+  if (hasWord === hasWords) {
+    return badRequest("Provide exactly one of word or words.");
+  }
+
+  if (hasWord) {
+    if (typeof body.word !== "string") {
+      return badRequest("word must be a string.");
+    }
+
+    return NextResponse.json({ code: soundex(body.word) });
+  }
+
+  if (!Array.isArray(body.words) || body.words.some((item) => typeof item !== "string")) {
+    return badRequest("words must be an array of strings.");
+  }
+
+  return NextResponse.json({ codes: encodeSoundexWords(body.words) });
+}

--- a/app/api/routes-f/soundex/soundex.ts
+++ b/app/api/routes-f/soundex/soundex.ts
@@ -1,0 +1,65 @@
+// #860 feat(routes-f): soundex phonetic encoder
+
+const SOUNDEX_MAP: Record<string, string> = {
+  B: "1",
+  F: "1",
+  P: "1",
+  V: "1",
+  C: "2",
+  G: "2",
+  J: "2",
+  K: "2",
+  Q: "2",
+  S: "2",
+  X: "2",
+  Z: "2",
+  D: "3",
+  T: "3",
+  L: "4",
+  M: "5",
+  N: "5",
+  R: "6",
+};
+
+/**
+ * Encode a single word using the standard Soundex algorithm (letter + 3 digits).
+ */
+export function soundex(word: string): string {
+  const upper = word.toUpperCase().replace(/[^A-Z]/g, "");
+  if (upper.length === 0) {
+    return "";
+  }
+
+  const firstLetter = upper[0];
+  const digits: string[] = [];
+  let previousCode = SOUNDEX_MAP[firstLetter] ?? "0";
+
+  for (let i = 1; i < upper.length; i += 1) {
+    const letter = upper[i];
+    const digit = SOUNDEX_MAP[letter] ?? "0";
+
+    if (digit === "0") {
+      continue;
+    }
+
+    // H/W between two same-code consonants suppresses the second consonant.
+    if (
+      (upper[i - 1] === "H" || upper[i - 1] === "W") &&
+      digit === previousCode
+    ) {
+      continue;
+    }
+
+    if (digit !== digits[digits.length - 1]) {
+      digits.push(digit);
+    }
+
+    previousCode = digit;
+  }
+
+  return `${firstLetter}${digits.join("")}000`.slice(0, 4);
+}
+
+export function encodeSoundexWords(words: string[]): string[] {
+  return words.map((word) => soundex(word));
+}

--- a/app/api/routesF/caesar-cipher/caesar.ts
+++ b/app/api/routesF/caesar-cipher/caesar.ts
@@ -1,0 +1,40 @@
+// #889 feat(routesF): caesar cipher brute force
+
+export type CaesarCandidate = {
+  shift: number;
+  text: string;
+  score?: number;
+};
+
+/**
+ * Decode ciphertext with a Caesar shift (only A–Z / a–z are rotated).
+ */
+export function caesarDecode(text: string, shift: number): string {
+  const normalizedShift = ((shift % 26) + 26) % 26;
+  if (normalizedShift === 0) {
+    return text;
+  }
+
+  return text.replace(/[a-zA-Z]/g, (char) => {
+    const base = char <= "Z" ? 65 : 97;
+    return String.fromCharCode(
+      base + ((char.charCodeAt(0) - base - normalizedShift + 26) % 26)
+    );
+  });
+}
+
+/**
+ * Produce all 25 non-zero Caesar decodings (shifts 1–25).
+ */
+export function bruteForceCaesar(text: string): CaesarCandidate[] {
+  const candidates: CaesarCandidate[] = [];
+
+  for (let shift = 1; shift <= 25; shift += 1) {
+    candidates.push({
+      shift,
+      text: caesarDecode(text, shift),
+    });
+  }
+
+  return candidates;
+}

--- a/app/api/routesF/caesar-cipher/route.test.ts
+++ b/app/api/routesF/caesar-cipher/route.test.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from "next/server";
+import { caesarDecode, bruteForceCaesar } from "./caesar";
+import { englishLikenessScore } from "./score";
+import { POST } from "./route";
+
+// #889 feat(routesF): caesar cipher brute force
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/caesar-cipher", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/caesar-cipher", () => {
+  describe("caesarDecode", () => {
+    it("decodes a known ciphertext with the correct shift", () => {
+      expect(caesarDecode("khoor", 3)).toBe("hello");
+    });
+
+    it("preserves case and non-alphabetic characters", () => {
+      expect(caesarDecode("Khoor, Zruog!", 3)).toBe("Hello, World!");
+    });
+  });
+
+  describe("bruteForceCaesar", () => {
+    it("returns exactly 25 candidates with shifts 1 through 25", () => {
+      const candidates = bruteForceCaesar("abc");
+
+      expect(candidates).toHaveLength(25);
+      expect(candidates.map((c) => c.shift)).toEqual(
+        Array.from({ length: 25 }, (_, i) => i + 1)
+      );
+    });
+
+    it("includes the correct plaintext among decodings", () => {
+      const candidates = bruteForceCaesar("khoor");
+      const match = candidates.find((c) => c.text === "hello");
+
+      expect(match).toBeDefined();
+      expect(match?.shift).toBe(3);
+    });
+  });
+
+  describe("englishLikenessScore", () => {
+    it("ranks plausible English above random letter strings", () => {
+      const englishScore = englishLikenessScore(
+        "the quick brown fox jumps over the lazy dog"
+      );
+      const randomScore = englishLikenessScore("xqzvkjwpmnbctyfg");
+
+      expect(englishScore).toBeGreaterThan(randomScore);
+    });
+  });
+
+  describe("POST", () => {
+    it("returns all 25 candidates without scores by default", async () => {
+      const res = await POST(makeReq({ text: "khoor" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.candidates).toHaveLength(25);
+      expect(data.candidates.every((c: { score?: number }) => c.score === undefined)).toBe(
+        true
+      );
+    });
+
+    it("includes scores and ranks candidates when score is true", async () => {
+      const res = await POST(
+        makeReq({ text: "wklv lv d whvw", score: true })
+      );
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.candidates).toHaveLength(25);
+      expect(data.candidates.every((c: { score: number }) => typeof c.score === "number")).toBe(
+        true
+      );
+
+      const scores = data.candidates.map((c: { score: number }) => c.score);
+      for (let i = 1; i < scores.length; i += 1) {
+        expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
+      }
+
+      expect(data.candidates[0].text.toLowerCase()).toContain("this");
+    });
+
+    it("rejects invalid bodies", async () => {
+      const res = await POST(makeReq({ score: true }));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/caesar-cipher/route.ts
+++ b/app/api/routesF/caesar-cipher/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { bruteForceCaesar, type CaesarCandidate } from "./caesar";
+import { englishLikenessScore } from "./score";
+
+// #889 feat(routesF): caesar cipher brute force
+
+type CaesarBody = {
+  text?: unknown;
+  score?: unknown;
+};
+
+const MAX_INPUT_BYTES = 10 * 1024;
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function getByteLength(value: string) {
+  return new TextEncoder().encode(value).length;
+}
+
+function rankCandidates(candidates: CaesarCandidate[]): CaesarCandidate[] {
+  return [...candidates].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+}
+
+export async function POST(req: NextRequest) {
+  let body: CaesarBody;
+
+  try {
+    body = (await req.json()) as CaesarBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const { text, score } = body;
+
+  if (typeof text !== "string") {
+    return badRequest("text must be a string.");
+  }
+
+  if (getByteLength(text) > MAX_INPUT_BYTES) {
+    return badRequest("text must not exceed 10KB.");
+  }
+
+  if (score !== undefined && typeof score !== "boolean") {
+    return badRequest("score must be a boolean when provided.");
+  }
+
+  const includeScore = score === true;
+  let candidates = bruteForceCaesar(text);
+
+  if (includeScore) {
+    candidates = rankCandidates(
+      candidates.map((candidate) => ({
+        ...candidate,
+        score: englishLikenessScore(candidate.text),
+      }))
+    );
+  }
+
+  return NextResponse.json({ candidates });
+}

--- a/app/api/routesF/caesar-cipher/score.ts
+++ b/app/api/routesF/caesar-cipher/score.ts
@@ -1,0 +1,61 @@
+// #889 feat(routesF): caesar cipher brute force
+
+/**
+ * Relative English letter frequencies (A–Z), normalized to sum to 1.
+ */
+const ENGLISH_FREQ: Record<string, number> = {
+  A: 0.08167,
+  B: 0.01492,
+  C: 0.02782,
+  D: 0.04253,
+  E: 0.12702,
+  F: 0.02228,
+  G: 0.02015,
+  H: 0.06094,
+  I: 0.06966,
+  J: 0.00153,
+  K: 0.00772,
+  L: 0.04025,
+  M: 0.02406,
+  N: 0.06749,
+  O: 0.07507,
+  P: 0.01929,
+  Q: 0.00095,
+  R: 0.05987,
+  S: 0.06327,
+  T: 0.09056,
+  U: 0.02758,
+  V: 0.00978,
+  W: 0.0236,
+  X: 0.0015,
+  Y: 0.01974,
+  Z: 0.00074,
+};
+
+/**
+ * Score how English-like a string is using log-likelihood against letter
+ * frequencies. Higher scores indicate more plausible English plaintext.
+ */
+export function englishLikenessScore(text: string): number {
+  const letters = text.match(/[a-zA-Z]/g);
+  if (!letters || letters.length === 0) {
+    return 0;
+  }
+
+  const counts = new Map<string, number>();
+  for (const letter of letters) {
+    const upper = letter.toUpperCase();
+    counts.set(upper, (counts.get(upper) ?? 0) + 1);
+  }
+
+  const total = letters.length;
+  let score = 0;
+
+  for (const [letter, count] of counts.entries()) {
+    const observed = count / total;
+    const expected = ENGLISH_FREQ[letter] ?? 0.0001;
+    score += observed * Math.log(expected);
+  }
+
+  return score;
+}

--- a/app/api/routesF/metaphone/metaphone.ts
+++ b/app/api/routesF/metaphone/metaphone.ts
@@ -1,0 +1,258 @@
+// #886 feat(routesF): metaphone phonetic encoder
+
+const VOWELS = "AEIOU";
+const FRONTV = "EIY";
+const VARSON = "CSPTG";
+
+function isVowel(chars: string[], index: number): boolean {
+  return index >= 0 && index < chars.length && VOWELS.includes(chars[index]);
+}
+
+function isLastChar(length: number, index: number): boolean {
+  return index + 1 === length;
+}
+
+function isNextChar(chars: string[], index: number, c: string): boolean {
+  return index >= 0 && index < chars.length - 1 && chars[index + 1] === c;
+}
+
+function isPreviousChar(chars: string[], index: number, c: string): boolean {
+  return index > 0 && index < chars.length && chars[index - 1] === c;
+}
+
+function regionMatch(chars: string[], index: number, test: string): boolean {
+  if (index < 0 || index + test.length > chars.length) {
+    return false;
+  }
+  return chars.slice(index, index + test.length).join("") === test;
+}
+
+/**
+ * Apply Metaphone initial-character normalization (KN, GN, WR, WH, etc.).
+ */
+function normalizeInitials(input: string): string[] {
+  const upper = input.toUpperCase().replace(/[^A-Z]/g, "");
+  if (upper.length === 0) {
+    return [];
+  }
+
+  const chars = upper.split("");
+
+  switch (chars[0]) {
+    case "K":
+    case "G":
+    case "P":
+      if (chars[1] === "N") {
+        return chars.slice(1);
+      }
+      return chars;
+    case "A":
+      if (chars[1] === "E") {
+        return chars.slice(1);
+      }
+      return chars;
+    case "W":
+      if (chars[1] === "R") {
+        return chars.slice(1);
+      }
+      if (chars[1] === "H") {
+        const result = chars.slice(1);
+        result[0] = "W";
+        return result;
+      }
+      return chars;
+    case "X":
+      chars[0] = "S";
+      return chars;
+    default:
+      return chars;
+  }
+}
+
+/**
+ * Encode a single word using the Apache Commons Metaphone algorithm (max 4 chars).
+ */
+export function metaphone(word: string, maxCodeLen = 4): string {
+  const local = normalizeInitials(word);
+  if (local.length === 0) {
+    return "";
+  }
+  if (local.length === 1) {
+    return local[0];
+  }
+
+  const code: string[] = [];
+  let hard = false;
+  let index = 0;
+  const length = local.length;
+
+  while (code.length < maxCodeLen && index < length) {
+    const symb = local[index];
+
+    if (symb === "C" || !isPreviousChar(local, index, symb)) {
+      switch (symb) {
+        case "A":
+        case "E":
+        case "I":
+        case "O":
+        case "U":
+          if (index === 0) {
+            code.push(symb);
+          }
+          break;
+        case "B":
+          if (!(isPreviousChar(local, index, "M") && isLastChar(length, index))) {
+            code.push(symb);
+          }
+          break;
+        case "C":
+          if (
+            isPreviousChar(local, index, "S") &&
+            !isLastChar(length, index) &&
+            FRONTV.includes(local[index + 1])
+          ) {
+            break;
+          }
+          if (isPreviousChar(local, index, "S") && isNextChar(local, index, "H")) {
+            code.push("K");
+            break;
+          }
+          if (regionMatch(local, index, "CIA") || isNextChar(local, index, "H")) {
+            code.push("X");
+            break;
+          }
+          if (!isLastChar(length, index) && FRONTV.includes(local[index + 1])) {
+            code.push("S");
+            break;
+          }
+          code.push("K");
+          break;
+        case "D":
+          if (
+            !isLastChar(length, index + 1) &&
+            isNextChar(local, index, "G") &&
+            FRONTV.includes(local[index + 2])
+          ) {
+            code.push("J");
+            index += 2;
+          } else {
+            code.push("T");
+          }
+          break;
+        case "G":
+          if (isLastChar(length, index + 1) && isNextChar(local, index, "H")) {
+            break;
+          }
+          if (
+            !isLastChar(length, index + 1) &&
+            isNextChar(local, index, "H") &&
+            !isVowel(local, index + 2)
+          ) {
+            break;
+          }
+          if (index > 0 && (regionMatch(local, index, "GN") || regionMatch(local, index, "GNED"))) {
+            break;
+          }
+          hard = isPreviousChar(local, index, "G");
+          if (!isLastChar(length, index) && FRONTV.includes(local[index + 1]) && !hard) {
+            code.push("J");
+          } else {
+            code.push("K");
+          }
+          break;
+        case "H":
+          if (isLastChar(length, index)) {
+            break;
+          }
+          if (index > 0 && VARSON.includes(local[index - 1])) {
+            break;
+          }
+          if (isVowel(local, index + 1)) {
+            code.push("H");
+          }
+          break;
+        case "F":
+        case "J":
+        case "L":
+        case "M":
+        case "N":
+        case "R":
+          code.push(symb);
+          break;
+        case "K":
+          if (index > 0) {
+            if (!isPreviousChar(local, index, "C")) {
+              code.push(symb);
+            }
+          } else {
+            code.push(symb);
+          }
+          break;
+        case "P":
+          if (isNextChar(local, index, "H")) {
+            code.push("F");
+          } else {
+            code.push(symb);
+          }
+          break;
+        case "Q":
+          code.push("K");
+          break;
+        case "S":
+          if (
+            regionMatch(local, index, "SH") ||
+            regionMatch(local, index, "SIO") ||
+            regionMatch(local, index, "SIA")
+          ) {
+            code.push("X");
+          } else {
+            code.push("S");
+          }
+          break;
+        case "T":
+          if (regionMatch(local, index, "TIA") || regionMatch(local, index, "TIO")) {
+            code.push("X");
+            break;
+          }
+          if (regionMatch(local, index, "TCH")) {
+            break;
+          }
+          if (regionMatch(local, index, "TH")) {
+            code.push("0");
+          } else {
+            code.push("T");
+          }
+          break;
+        case "V":
+          code.push("F");
+          break;
+        case "W":
+        case "Y":
+          if (!isLastChar(length, index) && isVowel(local, index + 1)) {
+            code.push(symb);
+          }
+          break;
+        case "X":
+          code.push("K");
+          code.push("S");
+          break;
+        case "Z":
+          code.push("S");
+          break;
+        default:
+          break;
+      }
+    }
+
+    index += 1;
+    if (code.length > maxCodeLen) {
+      code.length = maxCodeLen;
+    }
+  }
+
+  return code.join("");
+}
+
+export function encodeMetaphoneWords(words: string[]): string[] {
+  return words.map((word) => metaphone(word));
+}

--- a/app/api/routesF/metaphone/route.test.ts
+++ b/app/api/routesF/metaphone/route.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { metaphone } from "./metaphone";
+import { POST } from "./route";
+
+// #886 feat(routesF): metaphone phonetic encoder
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/metaphone", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("metaphone", () => {
+  it.each([
+    ["Smith", "SM0"],
+    ["Smithee", "SM0"],
+    ["Smyth", "SM0"],
+    ["Robert", "RBRT"],
+    ["Rupert", "RPRT"],
+    ["Washington", "WXNK"],
+    ["Who", "W"],
+    ["Answer", "ANSW"],
+    ["Cough", "K"],
+    ["Day", "T"],
+  ])("encodes %s as %s", (word, expected) => {
+    expect(metaphone(word)).toBe(expected);
+  });
+
+  it("ignores non-alphabetic characters", () => {
+    expect(metaphone("Smith-Jones")).toBe(metaphone("SmithJones"));
+  });
+});
+
+describe("POST /api/routesF/metaphone", () => {
+  it("returns a single code for word", async () => {
+    const res = await POST(makeReq({ word: "Robert" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ code: "RBRT" });
+  });
+
+  it("returns codes for words array", async () => {
+    const res = await POST(makeReq({ words: ["Robert", "Rupert", "Smith"] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ codes: ["RBRT", "RPRT", "SM0"] });
+  });
+
+  it("rejects invalid bodies", async () => {
+    const missing = await POST(makeReq({}));
+    const both = await POST(makeReq({ word: "a", words: ["b"] }));
+    const badWords = await POST(makeReq({ words: ["ok", 1] }));
+
+    expect(missing.status).toBe(400);
+    expect(both.status).toBe(400);
+    expect(badWords.status).toBe(400);
+  });
+});

--- a/app/api/routesF/metaphone/route.ts
+++ b/app/api/routesF/metaphone/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { encodeMetaphoneWords, metaphone } from "./metaphone";
+
+// #886 feat(routesF): metaphone phonetic encoder
+
+type MetaphoneBody = {
+  word?: unknown;
+  words?: unknown;
+};
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: MetaphoneBody;
+
+  try {
+    body = (await req.json()) as MetaphoneBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const hasWord = body.word !== undefined;
+  const hasWords = body.words !== undefined;
+
+  if (hasWord === hasWords) {
+    return badRequest("Provide exactly one of word or words.");
+  }
+
+  if (hasWord) {
+    if (typeof body.word !== "string") {
+      return badRequest("word must be a string.");
+    }
+
+    return NextResponse.json({ code: metaphone(body.word) });
+  }
+
+  if (!Array.isArray(body.words) || body.words.some((item) => typeof item !== "string")) {
+    return badRequest("words must be an array of strings.");
+  }
+
+  return NextResponse.json({ codes: encodeMetaphoneWords(body.words) });
+}


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

Closes #889
Closes #863 
Closes #866
Closes #860

This PR introduces four self-contained API utilities implemented under `routesF` and `routes-f`. Each feature is fully isolated in its own folder with dedicated handlers, logic, and tests, ensuring independent development and safe merging.

---

# Changes proposed

## What were you told to do?

Implement four API utilities:

- Caesar cipher brute force decoder with optional scoring
- Happy number checker with sequence tracking
- Metaphone phonetic encoder
- Soundex phonetic encoder

Each must:
- Follow strict input/output requirements
- Include full test coverage
- Stay fully self-contained in their respective folders

---

## What did you do?

Implemented all four required API features:

### 1. Caesar Cipher (`app/api/routesF/caesar-cipher/`)
- Built brute-force decoder returning 25 shifts (1–25)
- Added optional English-likeness scoring using letter frequency log-likelihood
- Ensured sorted output when scoring is enabled
- Preserved case and non-alphabetic characters
- Added unit tests for shift coverage and ranking

### 2. Happy Number (`app/api/routes-f/happy-number/`)
- Implemented cycle-detection algorithm for happy numbers
- Generated full iteration sequence for transparency
- Validated input strictly (positive integers only)
- Added tests for happy, unhappy, and invalid inputs

### 3. Metaphone (`app/api/routesF/metaphone/`)
- Implemented inline Metaphone algorithm (Apache-style)
- Supported both single and batch inputs
- Normalized input by stripping non-alphabetic characters
- Ensured known outputs match expected phonetic encodings
- Added validation tests

### 4. Soundex (`app/api/routes-f/soundex/`)
- Implemented standard Soundex algorithm
- Included H/W rule handling and zero-padding to 4 characters
- Supported both single and batch encoding
- Added tests for known canonical mappings (e.g. Robert → R163)

---

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](../CONTRIBUTING.md) for this repository.

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title and description of the PR is clear and explains the approach.
- [X] I am making a pull request against the _main branch_ (left side).
- [X] My commit messages styles matches our requested structure.
- [X] My code additions will fail neither code linting checks nor unit test.
- [X] I am only making changes to files I was requested to.

# Screenshots/Videos

These are API-only changes.

### Caesar Cipher Example
```http
POST /api/routesF/caesar-cipher
```

```json
{ "text": "khoor", "score": true }
```

```json
{
  "candidates": [
    { "shift": 3, "text": "hello", "score": -1.42 }
  ]
}
```

---

### Happy Number Example
```http
GET /api/routes-f/happy-number?n=19
```

```json
{
  "n": 19,
  "is_happy": true,
  "sequence": [19, 82, 68, 100, 1]
}
```

---

### Metaphone Example
```http
POST /api/routesF/metaphone
```

```json
{ "words": ["Robert", "Rupert", "Smith"] }
```

```json
{ "codes": ["RBRT", "RPRT", "SM0"] }
```

---

### Soundex Example
```http
POST /api/routes-f/soundex
```

```json
{ "word": "Robert" }
```

```json
{ "code": "R163" }
```