### PR TITLE
feat(routes-f): recurring date series generator

### DIFF
--- a/app/api/routes-f/recurring-dates/__tests__/route.test.ts
+++ b/app/api/routes-f/recurring-dates/__tests__/route.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, generateSeries, MAX_DATES } from "../route";
+
+function postReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/recurring-dates", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("generateSeries", () => {
+  it("includes the start as the first occurrence", () => {
+    const { dates } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+      count: 3,
+    });
+    expect(dates[0]).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("generates daily series", () => {
+    const { dates, count } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+      count: 3,
+    });
+    expect(count).toBe(3);
+    expect(dates).toEqual([
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-02T00:00:00.000Z",
+      "2024-01-03T00:00:00.000Z",
+    ]);
+  });
+
+  it("generates weekly series and honours interval", () => {
+    const { dates } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "weekly",
+      interval: 2,
+      count: 3,
+    });
+    expect(dates).toEqual([
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-15T00:00:00.000Z",
+      "2024-01-29T00:00:00.000Z",
+    ]);
+  });
+
+  it("generates monthly series", () => {
+    const { dates } = generateSeries({
+      start: new Date("2024-01-15T09:30:00Z"),
+      frequency: "monthly",
+      interval: 1,
+      count: 3,
+    });
+    expect(dates).toEqual([
+      "2024-01-15T09:30:00.000Z",
+      "2024-02-15T09:30:00.000Z",
+      "2024-03-15T09:30:00.000Z",
+    ]);
+  });
+
+  it("generates yearly series", () => {
+    const { dates } = generateSeries({
+      start: new Date("2020-06-01T00:00:00Z"),
+      frequency: "yearly",
+      interval: 1,
+      count: 3,
+    });
+    expect(dates).toEqual([
+      "2020-06-01T00:00:00.000Z",
+      "2021-06-01T00:00:00.000Z",
+      "2022-06-01T00:00:00.000Z",
+    ]);
+  });
+
+  it("clamps month-end overflow and preserves the original anchor day", () => {
+    // Jan 31 monthly: Feb has no 31st, so clamp; but later months that DO have
+    // a 31st must restore it (anchored to the original day, not the clamp).
+    const { dates } = generateSeries({
+      start: new Date("2024-01-31T00:00:00Z"),
+      frequency: "monthly",
+      interval: 1,
+      count: 5,
+    });
+    expect(dates).toEqual([
+      "2024-01-31T00:00:00.000Z",
+      "2024-02-29T00:00:00.000Z", // 2024 is a leap year
+      "2024-03-31T00:00:00.000Z",
+      "2024-04-30T00:00:00.000Z",
+      "2024-05-31T00:00:00.000Z",
+    ]);
+  });
+
+  it("clamps Feb 29 yearly to Feb 28 in non-leap years and restores it on leap years", () => {
+    const { dates } = generateSeries({
+      start: new Date("2024-02-29T00:00:00Z"),
+      frequency: "yearly",
+      interval: 1,
+      count: 5,
+    });
+    expect(dates).toEqual([
+      "2024-02-29T00:00:00.000Z",
+      "2025-02-28T00:00:00.000Z",
+      "2026-02-28T00:00:00.000Z",
+      "2027-02-28T00:00:00.000Z",
+      "2028-02-29T00:00:00.000Z", // leap year again
+    ]);
+  });
+
+  it("stops at the `until` bound (inclusive)", () => {
+    const { dates, count } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+      until: new Date("2024-01-03T00:00:00Z"),
+    });
+    expect(count).toBe(3);
+    expect(dates[dates.length - 1]).toBe("2024-01-03T00:00:00.000Z");
+  });
+
+  it("returns only the start when `until` falls between occurrences", () => {
+    const { dates } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "weekly",
+      interval: 1,
+      until: new Date("2024-01-05T00:00:00Z"),
+    });
+    expect(dates).toEqual(["2024-01-01T00:00:00.000Z"]);
+  });
+
+  it("stops at whichever of count/until comes first", () => {
+    const { count } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+      count: 100,
+      until: new Date("2024-01-05T00:00:00Z"),
+    });
+    expect(count).toBe(5);
+  });
+
+  it("caps the output at MAX_DATES", () => {
+    const { dates, count } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+      count: 5000,
+    });
+    expect(count).toBe(MAX_DATES);
+    expect(dates).toHaveLength(MAX_DATES);
+  });
+
+  it("caps an unbounded rule (no count, no until) at MAX_DATES", () => {
+    const { count } = generateSeries({
+      start: new Date("2024-01-01T00:00:00Z"),
+      frequency: "daily",
+      interval: 1,
+    });
+    expect(count).toBe(MAX_DATES);
+  });
+});
+
+describe("POST /api/routes-f/recurring-dates", () => {
+  it("returns a series for a valid rule", async () => {
+    const res = await POST(
+      postReq({ start: "2024-01-01T00:00:00Z", frequency: "daily", count: 2 })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      dates: ["2024-01-01T00:00:00.000Z", "2024-01-02T00:00:00.000Z"],
+      count: 2,
+    });
+  });
+
+  it("defaults interval to 1 when omitted", async () => {
+    const res = await POST(
+      postReq({ start: "2024-01-01T00:00:00Z", frequency: "weekly", count: 2 })
+    );
+    const body = await res.json();
+    expect(body.dates).toEqual([
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-08T00:00:00.000Z",
+    ]);
+  });
+
+  it("rejects an invalid frequency", async () => {
+    const res = await POST(
+      postReq({ start: "2024-01-01T00:00:00Z", frequency: "hourly", count: 2 })
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid request body");
+  });
+
+  it("rejects an invalid start date", async () => {
+    const res = await POST(
+      postReq({ start: "not-a-date", frequency: "daily", count: 2 })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-positive interval", async () => {
+    const res = await POST(
+      postReq({
+        start: "2024-01-01T00:00:00Z",
+        frequency: "daily",
+        interval: 0,
+        count: 2,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects `until` before `start`", async () => {
+    const res = await POST(
+      postReq({
+        start: "2024-01-10T00:00:00Z",
+        frequency: "daily",
+        until: "2024-01-01T00:00:00Z",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a malformed JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/recurring-dates",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{ not json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid JSON body");
+  });
+});

--- a/app/api/routes-f/recurring-dates/route.ts
+++ b/app/api/routes-f/recurring-dates/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export type Frequency = "daily" | "weekly" | "monthly" | "yearly";
+
+/** Hard cap on the number of dates returned, regardless of `count`/`until`. */
+export const MAX_DATES = 1000;
+
+export interface RecurrenceRule {
+  start: Date;
+  frequency: Frequency;
+  interval: number;
+  count?: number;
+  until?: Date;
+}
+
+export interface RecurrenceResult {
+  dates: string[];
+  count: number;
+}
+
+/**
+ * Add whole calendar months to a UTC instant, clamping the day-of-month to the
+ * last valid day of the target month (Jan 31 + 1 month → Feb 28/29). The day is
+ * always taken from the original `start`, so anchoring is preserved across the
+ * series: Jan 31 yields Feb 29, Mar 31, Apr 30, ... rather than drifting.
+ */
+function addMonths(start: Date, months: number): Date {
+  const year = start.getUTCFullYear();
+  const monthIndex = start.getUTCMonth() + months;
+  const targetYear = year + Math.floor(monthIndex / 12);
+  const targetMonth = ((monthIndex % 12) + 12) % 12;
+
+  const daysInTargetMonth = new Date(
+    Date.UTC(targetYear, targetMonth + 1, 0)
+  ).getUTCDate();
+  const day = Math.min(start.getUTCDate(), daysInTargetMonth);
+
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      day,
+      start.getUTCHours(),
+      start.getUTCMinutes(),
+      start.getUTCSeconds(),
+      start.getUTCMilliseconds()
+    )
+  );
+}
+
+/**
+ * Compute the n-th occurrence (0-based; occurrence 0 is `start` itself) for a
+ * recurrence rule. Each occurrence is derived from `start` directly rather than
+ * from the previous one, which avoids accumulated drift and keeps month/year
+ * day-of-month anchoring correct.
+ */
+function occurrence(
+  start: Date,
+  n: number,
+  frequency: Frequency,
+  interval: number
+): Date {
+  const step = n * interval;
+  switch (frequency) {
+    case "daily":
+      return new Date(start.getTime() + step * 86_400_000);
+    case "weekly":
+      return new Date(start.getTime() + step * 7 * 86_400_000);
+    case "monthly":
+      return addMonths(start, step);
+    case "yearly":
+      return addMonths(start, step * 12);
+  }
+}
+
+/**
+ * Expand a recurrence rule into an ordered list of ISO-8601 instants. The
+ * series always begins at `start`. Generation stops at whichever limit is
+ * reached first: `count` occurrences, the last occurrence on or before `until`,
+ * or the {@link MAX_DATES} hard cap.
+ */
+export function generateSeries(rule: RecurrenceRule): RecurrenceResult {
+  const { start, frequency, interval, count, until } = rule;
+
+  const limit = count !== undefined ? Math.min(count, MAX_DATES) : MAX_DATES;
+  const untilTime = until?.getTime();
+
+  const dates: string[] = [];
+  for (let n = 0; dates.length < limit; n++) {
+    const occ = occurrence(start, n, frequency, interval);
+    if (untilTime !== undefined && occ.getTime() > untilTime) {
+      break;
+    }
+    dates.push(occ.toISOString());
+  }
+
+  return { dates, count: dates.length };
+}
+
+const isoDate = z
+  .string()
+  .refine(
+    value => !Number.isNaN(new Date(value).getTime()),
+    "must be a valid ISO date"
+  );
+
+const schema = z
+  .object({
+    start: isoDate,
+    frequency: z.enum(["daily", "weekly", "monthly", "yearly"]),
+    interval: z.number().int().positive().optional().default(1),
+    count: z.number().int().positive().optional(),
+    until: isoDate.optional(),
+  })
+  .refine(
+    rule =>
+      rule.until === undefined ||
+      new Date(rule.until).getTime() >= new Date(rule.start).getTime(),
+    { message: "until must be on or after start", path: ["until"] }
+  );
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const result = await validateBody(request, schema);
+  if (result instanceof NextResponse) {
+    return result;
+  }
+
+  const { start, frequency, interval, count, until } = result.data;
+
+  return NextResponse.json(
+    generateSeries({
+      start: new Date(start),
+      frequency,
+      interval,
+      count,
+      until: until ? new Date(until) : undefined,
+    })
+  );
+}


### PR DESCRIPTION
## Summary
Implements the recurring date series generator (#788).

`POST /api/routes-f/recurring-dates` with `{ start, frequency, interval?, count?, until? }` → `{ dates, count }`

## Approach
- Supports `daily | weekly | monthly | yearly` frequencies with an optional positive `interval` (default 1).
- Each occurrence is computed **directly from `start`** (not incrementally), which avoids drift and keeps day-of-month anchoring correct.
- **Month-end rollover**: the day is clamped to the target month's last valid day but anchored to the original start day — Jan 31 monthly → Feb 29, **Mar 31**, Apr 30, May 31; Feb 29 yearly → Feb 28 on non-leap years and Feb 29 again on the next leap year.
- **Hard cap of 1000 dates** regardless of `count`/`until`; generation stops at whichever of count, `until` (inclusive), or the cap comes first. The loop is bounded by the cap so unbounded rules still terminate.
- Validates the frequency enum, positive-integer interval, valid ISO `start`/`until`, and `until ≥ start`.

## Tests
Cover each frequency, interval handling, Jan-31 month-end rollover, Feb-29 yearly clamp/restore, `until` inclusivity, count/until/cap precedence, the unbounded cap, and the route's validation 400s.

## Scope
All files live under `app/api/routes-f/recurring-dates/`; the only import is the existing in-folder `_lib/validate` helper, matching the merged `fiscal-quarter`/`deep-merge` routes.

Closes #788