### PR TITLE
fix(routes-f): repair unix-date type error breaking type-check

### DIFF
--- a/app/api/routes-f/unix-date/_lib/convert.ts
+++ b/app/api/routes-f/unix-date/_lib/convert.ts
@@ -35,7 +35,10 @@ export function convertUnixDate(input: unknown): UnixDateResponse {
     throw new Error("Request body must be an object.");
   }
 
-  const request = input as UnixDateRequest;
+  // `input` is an arbitrary record here; its fields are validated below, so
+  // assert through `unknown` rather than directly (the record type does not
+  // structurally overlap with UnixDateRequest's required fields).
+  const request = input as unknown as UnixDateRequest;
   const unit = normalizeUnit(request.unit);
 
   if (request.mode === "to_iso") {


### PR DESCRIPTION
## Problem
`app/api/routes-f/unix-date/_lib/convert.ts:38` casts a `Record<string, unknown>` directly to `UnixDateRequest`:

```ts
const request = input as UnixDateRequest;
```

TypeScript rejects this with **TS2352** because the two types don't structurally overlap (the record is missing `UnixDateRequest`'s required `mode` and `value` fields). As a result `npm run type-check` — and therefore `prebuild` and the husky pre-commit hook — fail on `dev`, which blocks every PR's build/CI.

## Fix
The function already narrows `input` to a record and then validates each field (`mode`, `value`, `unit`) at runtime, so the assertion just needs to go through `unknown`:

```ts
const request = input as unknown as UnixDateRequest;
```

No behavioural change — the downstream runtime validation is untouched.

## Verification
- `npx tsc --noEmit` passes cleanly across the repo.
- `jest unix-date` — all 8 tests pass.
- ESLint clean on the changed file.