### PR TITLE
feat(routes-f): implement four stream-related api endpoints

### DIFF
--- a/app/api/routes-f/chat-blocklist/__tests__/route.test.ts
+++ b/app/api/routes-f/chat-blocklist/__tests__/route.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET } from "../route";
+
+function makeReq(method: string, body?: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/chat-blocklist", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/routes-f/chat-blocklist", () => {
+  it("adds words to blocklist", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator123",
+        add: ["spam", "scam"],
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.words).toContain("spam");
+    expect(body.words).toContain("scam");
+  });
+
+  it("removes words from blocklist", async () => {
+    // First add words
+    await POST(
+      makeReq("POST", {
+        creator_id: "creator456",
+        add: ["spam", "scam", "bot"],
+      })
+    );
+
+    // Then remove one
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator456",
+        remove: ["spam"],
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.words).not.toContain("spam");
+    expect(body.words).toContain("scam");
+    expect(body.words).toContain("bot");
+  });
+
+  it("handles case-insensitive storage and dedup", async () => {
+    await POST(
+      makeReq("POST", {
+        creator_id: "creator789",
+        add: ["Spam", "SPAM", "spam", "Scam"],
+      })
+    );
+
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator789",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.words).toHaveLength(2);
+    expect(body.words).toContain("spam");
+    expect(body.words).toContain("scam");
+  });
+
+  it("enforces cap at 200 entries", async () => {
+    const wordsToAdd = Array.from({ length: 201 }, (_, i) => `word${i}`);
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator999",
+        add: wordsToAdd,
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("allows adding up to 200 entries", async () => {
+    const wordsToAdd = Array.from({ length: 200 }, (_, i) => `word${i}`);
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator200",
+        add: wordsToAdd,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.words).toHaveLength(200);
+  });
+
+  it("rejects missing creator_id", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        add: ["spam"],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-array add parameter", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator123",
+        add: "not-an-array",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-array remove parameter", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        creator_id: "creator123",
+        remove: "not-an-array",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/chat-blocklist", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/routes-f/chat-blocklist", () => {
+  beforeEach(async () => {
+    // Setup: add words to blocklist
+    await POST(
+      makeReq("POST", {
+        creator_id: "getcreator",
+        add: ["spam", "scam", "bot"],
+      })
+    );
+  });
+
+  it("returns blocklist for creator", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/chat-blocklist?creator_id=getcreator"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.words).toContain("spam");
+    expect(body.words).toContain("scam");
+    expect(body.words).toContain("bot");
+  });
+
+  it("returns empty array for creator with no blocklist", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/chat-blocklist?creator_id=noblocklist"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.words).toHaveLength(0);
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/chat-blocklist");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/chat-blocklist/route.ts
+++ b/app/api/routes-f/chat-blocklist/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store for blocklists, keyed by creator_id
+const blocklistStore = new Map<string, Set<string>>();
+
+const MAX_ENTRIES = 200;
+
+function normalizeWord(word: string): string {
+  return word.trim().toLowerCase();
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const blocklist = blocklistStore.get(creatorId) || new Set<string>();
+  const words = Array.from(blocklist);
+
+  return NextResponse.json({ words });
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    creator_id?: unknown;
+    add?: unknown;
+    remove?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, add, remove } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  // Get or create blocklist for this creator
+  let blocklist = blocklistStore.get(creator_id);
+  if (!blocklist) {
+    blocklist = new Set<string>();
+    blocklistStore.set(creator_id, blocklist);
+  }
+
+  // Process additions
+  if (add !== undefined) {
+    if (!Array.isArray(add)) {
+      return NextResponse.json(
+        { error: "add must be an array of strings" },
+        { status: 400 }
+      );
+    }
+
+    for (const item of add) {
+      if (typeof item !== "string") {
+        return NextResponse.json(
+          { error: "add must be an array of strings" },
+          { status: 400 }
+        );
+      }
+
+      const normalized = normalizeWord(item);
+      if (normalized) {
+        // Check cap before adding
+        if (blocklist.size >= MAX_ENTRIES && !blocklist.has(normalized)) {
+          return NextResponse.json(
+            { error: `Blocklist cap reached (max ${MAX_ENTRIES} entries)` },
+            { status: 400 }
+          );
+        }
+        blocklist.add(normalized);
+      }
+    }
+  }
+
+  // Process removals
+  if (remove !== undefined) {
+    if (!Array.isArray(remove)) {
+      return NextResponse.json(
+        { error: "remove must be an array of strings" },
+        { status: 400 }
+      );
+    }
+
+    for (const item of remove) {
+      if (typeof item !== "string") {
+        return NextResponse.json(
+          { error: "remove must be an array of strings" },
+          { status: 400 }
+        );
+      }
+
+      const normalized = normalizeWord(item);
+      if (normalized) {
+        blocklist.delete(normalized);
+      }
+    }
+  }
+
+  // Return updated blocklist
+  const words = Array.from(blocklist);
+  return NextResponse.json({ words });
+}

--- a/app/api/routes-f/stream-schedule/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-schedule/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET, DELETE } from "../route";
+
+function makeReq(method: string, body?: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/stream-schedule", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/routes-f/stream-schedule", () => {
+  it("schedules stream end successfully", async () => {
+    const futureDate = new Date(Date.now() + 3600000).toISOString(); // 1 hour from now
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        end_at: futureDate,
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.stream_id).toBe("stream123");
+    expect(body.end_at).toBe(futureDate);
+    expect(body.scheduled).toBe(true);
+    expect(body.fires_in_seconds).toBeGreaterThan(0);
+  });
+
+  it("rejects past time with 400", async () => {
+    const pastDate = new Date(Date.now() - 3600000).toISOString(); // 1 hour ago
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        end_at: pastDate,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid ISO date with 400", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        end_at: "not-a-date",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing stream_id", async () => {
+    const futureDate = new Date(Date.now() + 3600000).toISOString();
+    const res = await POST(
+      makeReq("POST", {
+        end_at: futureDate,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing end_at", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-schedule", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/routes-f/stream-schedule", () => {
+  beforeEach(async () => {
+    // Setup: create a schedule
+    const futureDate = new Date(Date.now() + 3600000).toISOString();
+    await POST(
+      makeReq("POST", {
+        stream_id: "getstream",
+        end_at: futureDate,
+      })
+    );
+  });
+
+  it("returns schedule for existing stream", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-schedule?stream_id=getstream"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.stream_id).toBe("getstream");
+    expect(body.scheduled).toBe(true);
+  });
+
+  it("returns 404 for non-existent stream", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-schedule?stream_id=nonexistent"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when stream_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-schedule");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/routes-f/stream-schedule", () => {
+  beforeEach(async () => {
+    // Setup: create a schedule
+    const futureDate = new Date(Date.now() + 3600000).toISOString();
+    await POST(
+      makeReq("POST", {
+        stream_id: "deletestream",
+        end_at: futureDate,
+      })
+    );
+  });
+
+  it("cancels schedule successfully", async () => {
+    const res = await DELETE(
+      makeReq("DELETE", { stream_id: "deletestream" })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 404 when deleting non-existent stream", async () => {
+    const res = await DELETE(
+      makeReq("DELETE", { stream_id: "nonexistent" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects missing stream_id", async () => {
+    const res = await DELETE(makeReq("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-schedule", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/stream-schedule/route.ts
+++ b/app/api/routes-f/stream-schedule/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store for scheduled stream ends
+const scheduleStore = new Map<
+  string,
+  {
+    stream_id: string;
+    end_at: string;
+    scheduled: boolean;
+    fires_in_seconds: number;
+  }
+>();
+
+function isValidISODate(dateString: string): boolean {
+  const date = new Date(dateString);
+  return !isNaN(date.getTime()) && date.toISOString() === dateString;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const streamId = searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const schedule = scheduleStore.get(streamId);
+
+  if (!schedule) {
+    return NextResponse.json(
+      { error: "No schedule found for stream" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(schedule);
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    stream_id?: unknown;
+    end_at?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id, end_at } = body;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (!end_at || typeof end_at !== "string") {
+    return NextResponse.json(
+      { error: "end_at is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidISODate(end_at)) {
+    return NextResponse.json(
+      { error: "end_at must be a valid ISO 8601 date string" },
+      { status: 400 }
+    );
+  }
+
+  const endTime = new Date(end_at);
+  const now = new Date();
+
+  if (endTime <= now) {
+    return NextResponse.json(
+      { error: "end_at must be in the future" },
+      { status: 400 }
+    );
+  }
+
+  const firesInSeconds = Math.floor((endTime.getTime() - now.getTime()) / 1000);
+
+  const schedule = {
+    stream_id,
+    end_at,
+    scheduled: true,
+    fires_in_seconds: firesInSeconds,
+  };
+
+  scheduleStore.set(stream_id, schedule);
+
+  return NextResponse.json(schedule, { status: 201 });
+}
+
+export async function DELETE(req: NextRequest) {
+  let body: { stream_id?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id } = body;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const existed = scheduleStore.delete(stream_id);
+
+  if (!existed) {
+    return NextResponse.json(
+      { error: "No schedule found for stream" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/routes-f/stream-snapshot/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-snapshot/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET } from "../route";
+
+function makeReq(method: string, body?: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/stream-snapshot", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/routes-f/stream-snapshot", () => {
+  it("creates snapshot with provided timestamp", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        playback_id: "playback456",
+        timestamp: 123,
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.snapshot_url).toBe(
+      "https://image.mux.com/playback456/thumbnail.jpg?time=123"
+    );
+    expect(body.captured_at).toBeDefined();
+  });
+
+  it("creates snapshot with default timestamp", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        playback_id: "playback456",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.snapshot_url).toMatch(
+      /^https:\/\/image\.mux\.com\/playback456\/thumbnail\.jpg\?time=\d+$/
+    );
+    expect(body.captured_at).toBeDefined();
+  });
+
+  it("rejects non-numeric timestamp with 400", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        playback_id: "playback456",
+        timestamp: "not-a-number",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing stream_id", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        playback_id: "playback456",
+        timestamp: 123,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing playback_id", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        stream_id: "stream123",
+        timestamp: 123,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-snapshot", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/routes-f/stream-snapshot", () => {
+  beforeEach(async () => {
+    // Setup: create multiple snapshots
+    await POST(
+      makeReq("POST", {
+        stream_id: "getstream",
+        playback_id: "playback1",
+        timestamp: 100,
+      })
+    );
+    await POST(
+      makeReq("POST", {
+        stream_id: "getstream",
+        playback_id: "playback2",
+        timestamp: 200,
+      })
+    );
+    await POST(
+      makeReq("POST", {
+        stream_id: "getstream",
+        playback_id: "playback3",
+        timestamp: 300,
+      })
+    );
+  });
+
+  it("returns last 10 snapshots for stream", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-snapshot?stream_id=getstream"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.snapshots).toHaveLength(3);
+    expect(body.snapshots[0].stream_id).toBe("getstream");
+    expect(body.snapshots[0].playback_id).toBe("playback1");
+  });
+
+  it("returns empty array for stream with no snapshots", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-snapshot?stream_id=nosnapshots"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.snapshots).toHaveLength(0);
+  });
+
+  it("returns 400 when stream_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-snapshot");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns only last 10 snapshots when more exist", async () => {
+    // Create 15 snapshots
+    for (let i = 0; i < 15; i++) {
+      await POST(
+        makeReq("POST", {
+          stream_id: "manystream",
+          playback_id: `playback${i}`,
+          timestamp: i * 100,
+        })
+      );
+    }
+
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-snapshot?stream_id=manystream"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.snapshots).toHaveLength(10);
+  });
+});

--- a/app/api/routes-f/stream-snapshot/route.ts
+++ b/app/api/routes-f/stream-snapshot/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface Snapshot {
+  stream_id: string;
+  playback_id: string;
+  timestamp: number;
+  snapshot_url: string;
+  captured_at: string;
+}
+
+// In-memory store for snapshots, keyed by stream_id
+const snapshotStore = new Map<string, Snapshot[]>();
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const streamId = searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const snapshots = snapshotStore.get(streamId) || [];
+
+  // Return last 10 snapshots
+  const last10 = snapshots.slice(-10);
+
+  return NextResponse.json({ snapshots: last10 });
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    stream_id?: unknown;
+    playback_id?: unknown;
+    timestamp?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id, playback_id, timestamp } = body;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (!playback_id || typeof playback_id !== "string") {
+    return NextResponse.json(
+      { error: "playback_id is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  // Validate timestamp if provided
+  let ts: number;
+  if (timestamp !== undefined) {
+    if (typeof timestamp !== "number") {
+      return NextResponse.json(
+        { error: "timestamp must be a number" },
+        { status: 400 }
+      );
+    }
+    ts = timestamp;
+  } else {
+    ts = Math.floor(Date.now() / 1000);
+  }
+
+  // Build the Mux thumbnail URL
+  const snapshotUrl = `https://image.mux.com/${playback_id}/thumbnail.jpg?time=${ts}`;
+
+  const snapshot: Snapshot = {
+    stream_id,
+    playback_id,
+    timestamp: ts,
+    snapshot_url: snapshotUrl,
+    captured_at: new Date().toISOString(),
+  };
+
+  // Store snapshot
+  const existing = snapshotStore.get(stream_id) || [];
+  existing.push(snapshot);
+  snapshotStore.set(stream_id, existing);
+
+  return NextResponse.json(
+    {
+      snapshot_url: snapshotUrl,
+      captured_at: snapshot.captured_at,
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/routes-f/stream-warmup/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-warmup/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET, DELETE } from "../route";
+
+function makeReq(method: string, body?: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/stream-warmup", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/routes-f/stream-warmup", () => {
+  it("creates warmup state successfully", async () => {
+    const res = await POST(
+      makeReq("POST", {
+        username: "testuser",
+        warmup_message: "Starting soon!",
+        teaser_image_url: "https://example.com/teaser.jpg",
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.warmup_active).toBe(true);
+    expect(body.started_at).toBeDefined();
+    expect(body.warmup_message).toBe("Starting soon!");
+    expect(body.teaser_image_url).toBe("https://example.com/teaser.jpg");
+  });
+
+  it("creates warmup state with minimal fields", async () => {
+    const res = await POST(makeReq("POST", { username: "minimaluser" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.warmup_active).toBe(true);
+    expect(body.started_at).toBeDefined();
+    expect(body.warmup_message).toBeUndefined();
+    expect(body.teaser_image_url).toBeUndefined();
+  });
+
+  it("rejects missing username", async () => {
+    const res = await POST(
+      makeReq("POST", { warmup_message: "test" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-warmup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/routes-f/stream-warmup", () => {
+  beforeEach(async () => {
+    // Setup: create a warmup state
+    await POST(makeReq("POST", { username: "getuser", warmup_message: "Test" }));
+  });
+
+  it("returns warmup state for existing user", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-warmup?username=getuser"
+    );
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.warmup_active).toBe(true);
+    expect(body.warmup_message).toBe("Test");
+  });
+
+  it("returns 404 for non-existent user", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/stream-warmup?username=nonexistent"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when username is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-warmup");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/routes-f/stream-warmup", () => {
+  beforeEach(async () => {
+    // Setup: create a warmup state
+    await POST(makeReq("POST", { username: "deleteuser" }));
+  });
+
+  it("clears warmup state successfully", async () => {
+    const res = await DELETE(makeReq("DELETE", { username: "deleteuser" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 404 when deleting non-existent user", async () => {
+    const res = await DELETE(
+      makeReq("DELETE", { username: "nonexistent" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects missing username", async () => {
+    const res = await DELETE(makeReq("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-warmup", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: "invalid json",
+    });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/stream-warmup/route.ts
+++ b/app/api/routes-f/stream-warmup/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store keyed by username
+const warmupStore = new Map<
+  string,
+  {
+    warmup_active: boolean;
+    started_at: string;
+    warmup_message?: string;
+    teaser_image_url?: string;
+  }
+>();
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const username = searchParams.get("username");
+
+  if (!username) {
+    return NextResponse.json(
+      { error: "username is required" },
+      { status: 400 }
+    );
+  }
+
+  const warmup = warmupStore.get(username);
+
+  if (!warmup) {
+    return NextResponse.json(
+      { error: "Warmup state not found for user" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(warmup);
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    username?: unknown;
+    warmup_message?: unknown;
+    teaser_image_url?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { username, warmup_message, teaser_image_url } = body;
+
+  if (!username || typeof username !== "string") {
+    return NextResponse.json(
+      { error: "username is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (warmup_message !== undefined && typeof warmup_message !== "string") {
+    return NextResponse.json(
+      { error: "warmup_message must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (teaser_image_url !== undefined && typeof teaser_image_url !== "string") {
+    return NextResponse.json(
+      { error: "teaser_image_url must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const warmupState = {
+    warmup_active: true,
+    started_at: new Date().toISOString(),
+    ...(warmup_message && { warmup_message }),
+    ...(teaser_image_url && { teaser_image_url }),
+  };
+
+  warmupStore.set(username, warmupState);
+
+  return NextResponse.json(warmupState, { status: 201 });
+}
+
+export async function DELETE(req: NextRequest) {
+  let body: { username?: unknown };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { username } = body;
+
+  if (!username || typeof username !== "string") {
+    return NextResponse.json(
+      { error: "username is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const existed = warmupStore.delete(username);
+
+  if (!existed) {
+    return NextResponse.json(
+      { error: "Warmup state not found for user" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/routes-f/stream/markers/[id]/route.ts
+++ b/app/api/routes-f/stream/markers/[id]/route.ts
@@ -8,12 +8,12 @@ import { verifySession } from "@/lib/auth/verify-session";
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await verifySession(req);
   if (!session.ok) return session.response;
 
-  const { id } = params;
+  const { id } = await params;
 
   if (!id) {
     return NextResponse.json(


### PR DESCRIPTION
**Title:** feat(routes-f): implement four stream-related api endpoints

**Description:**

This PR implements four new API endpoints for StreamFi's streaming platform, all scoped to [app/api/routes-f/](cci:9://file:///Users/ew/waves5/streamfi-frontend/app/api/routes-f:0:0-0:0) as required. Each endpoint uses in-memory storage and includes comprehensive test coverage.

## Implemented Endpoints

### 1. Stream Warmup Mode (#958)
- **POST** `/api/routes-f/stream-warmup` - Creates warmup state with optional `warmup_message` and `teaser_image_url`
- **GET** `/api/routes-f/stream-warmup?username=` - Retrieves current warmup state by username
- **DELETE** `/api/routes-f/stream-warmup` - Clears warmup state
- In-memory store keyed by username
- Tests cover lifecycle and missing-user 404 scenarios

### 2. Scheduled Stream End (#961)
- **POST** `/api/routes-f/stream-schedule` - Schedules automatic end time with ISO timestamp validation
- **GET** `/api/routes-f/stream-schedule?stream_id=` - Returns pending schedules
- **DELETE** `/api/routes-f/stream-schedule` - Cancels the schedule
- Validates `end_at` is in the future
- In-memory store
- Tests cover scheduling, cancellation, and past-time rejection

### 3. Live Thumbnail Snapshot Capture (#960)
- **POST** `/api/routes-f/stream-snapshot` - Captures snapshot URL using Mux format
  - Builds URL as `https://image.mux.com/{playback_id}/thumbnail.jpg?time={timestamp}`
  - Rejects non-numeric timestamps with 400
- **GET** `/api/routes-f/stream-snapshot?stream_id=` - Returns last 10 snapshots
- In-memory store
- Tests verify URL format and history retrieval

### 4. Chat Word Blocklist (#970)
- **GET** `/api/routes-f/chat-blocklist?creator_id=` - Returns blocklist as `{ words: string[] }`
- **POST** `/api/routes-f/chat-blocklist` - Adds/removes words via `add` and `remove` arrays
- Case-insensitive storage with automatic deduplication
- Cap at 200 entries enforced
- Tests cover add, remove, dedup, and cap scenarios

## Additional Changes

- Fixed TypeScript error in `app/api/routes-f/stream/markers/[id]/route.ts` for Next.js 16 compatibility (params now require `await`)

## Test Results

All tests passing:
- stream-warmup: 11 tests passed
- stream-schedule: 13 tests passed  
- stream-snapshot: 10 tests passed
- chat-blocklist: 12 tests passed

Closes #958
Closes #960
Closes #961
Closes #970 

---

You can create the PR at: https://github.com/anonfedora/streamfi-frontend/pull/new/feat/routes-f-stream-features