### PR TITLE
feat(routes-f): category switch, pinned msg, timeout, min tip

### DIFF
--- a/app/api/routes-f/__tests__/creator-min-tip.test.ts
+++ b/app/api/routes-f/__tests__/creator-min-tip.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../creator-min-tip/route";
+import { POST as CHECK } from "../creator-min-tip/check/route";
+import { minTipStore } from "../creator-min-tip/store";
+
+function getReq(creatorId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/creator-min-tip?creator_id=${creatorId}`
+  );
+}
+
+function putReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/creator-min-tip",
+    {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function checkReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/creator-min-tip/check",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("/api/routes-f/creator-min-tip", () => {
+  beforeEach(() => {
+    minTipStore.clear();
+  });
+
+  describe("GET — retrieve minimum tips", () => {
+    it("returns defaults (0, 0) for unknown creator", async () => {
+      const res = await GET(getReq("creator-new"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.min_xlm).toBe(0);
+      expect(data.min_usdc).toBe(0);
+    });
+
+    it("returns configured values after PUT", async () => {
+      await PUT(
+        putReq({ creator_id: "c1", min_xlm: 5, min_usdc: 2 })
+      );
+
+      const res = await GET(getReq("c1"));
+      const data = await res.json();
+      expect(data.min_xlm).toBe(5);
+      expect(data.min_usdc).toBe(2);
+    });
+
+    it("rejects missing creator_id", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/creator-min-tip"
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("PUT — set minimum tips", () => {
+    it("sets both min_xlm and min_usdc", async () => {
+      const res = await PUT(
+        putReq({ creator_id: "c1", min_xlm: 10, min_usdc: 5 })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.min_xlm).toBe(10);
+      expect(data.min_usdc).toBe(5);
+    });
+
+    it("allows setting only min_xlm", async () => {
+      const res = await PUT(putReq({ creator_id: "c1", min_xlm: 3 }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.min_xlm).toBe(3);
+      expect(data.min_usdc).toBe(0);
+    });
+
+    it("allows setting only min_usdc", async () => {
+      const res = await PUT(putReq({ creator_id: "c1", min_usdc: 1 }));
+      const data = await res.json();
+      expect(data.min_xlm).toBe(0);
+      expect(data.min_usdc).toBe(1);
+    });
+
+    it("rejects negative min_xlm", async () => {
+      const res = await PUT(
+        putReq({ creator_id: "c1", min_xlm: -1 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects negative min_usdc", async () => {
+      const res = await PUT(
+        putReq({ creator_id: "c1", min_usdc: -5 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing creator_id", async () => {
+      const res = await PUT(putReq({ min_xlm: 5 }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /check — verify tip allowed", () => {
+    it("allows a tip above the minimum", async () => {
+      await PUT(putReq({ creator_id: "c1", min_xlm: 5 }));
+
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "XLM", amount: 10 })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.allowed).toBe(true);
+      expect(data.reason).toBeUndefined();
+    });
+
+    it("rejects a tip below the minimum with reason", async () => {
+      await PUT(putReq({ creator_id: "c1", min_xlm: 5 }));
+
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "XLM", amount: 2 })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.allowed).toBe(false);
+      expect(data.reason).toMatch(/Minimum XLM/);
+    });
+
+    it("allows exact minimum amount", async () => {
+      await PUT(putReq({ creator_id: "c1", min_usdc: 10 }));
+
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "USDC", amount: 10 })
+      );
+      const data = await res.json();
+      expect(data.allowed).toBe(true);
+    });
+
+    it("rejects USDC tip below minimum", async () => {
+      await PUT(putReq({ creator_id: "c1", min_usdc: 10 }));
+
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "USDC", amount: 5 })
+      );
+      const data = await res.json();
+      expect(data.allowed).toBe(false);
+      expect(data.reason).toMatch(/Minimum USDC/);
+    });
+
+    it("rejects unsupported asset", async () => {
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "BTC", amount: 1 })
+      );
+      const data = await res.json();
+      expect(data.allowed).toBe(false);
+      expect(data.reason).toMatch(/Unsupported asset/);
+    });
+
+    it("allows any amount when no minimum is configured", async () => {
+      const res = await CHECK(
+        checkReq({ creator_id: "c-new", asset: "XLM", amount: 0.001 })
+      );
+      const data = await res.json();
+      expect(data.allowed).toBe(true);
+    });
+
+    it("rejects missing creator_id", async () => {
+      const res = await CHECK(
+        checkReq({ asset: "XLM", amount: 5 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing asset", async () => {
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", amount: 5 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing amount", async () => {
+      const res = await CHECK(
+        checkReq({ creator_id: "c1", asset: "XLM" })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/stream-category-switch.test.ts
+++ b/app/api/routes-f/__tests__/stream-category-switch.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET } from "../stream/category-switch/route";
+import { categoryTimelines } from "../stream/category-switch/store";
+
+function postReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/stream/category-switch",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function getReq(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stream/category-switch?stream_id=${streamId}`
+  );
+}
+
+describe("/api/routes-f/stream/category-switch", () => {
+  beforeEach(() => {
+    categoryTimelines.clear();
+  });
+
+  describe("POST — switch category", () => {
+    it("switches to a valid category and returns previous + new", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", category: "gaming" })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.previous_category).toBe("none");
+      expect(data.new_category).toBe("gaming");
+      expect(data.switched_at).toBeDefined();
+    });
+
+    it("tracks successive category switches", async () => {
+      await POST(postReq({ stream_id: "s1", category: "gaming" }));
+      const res = await POST(
+        postReq({ stream_id: "s1", category: "music" })
+      );
+      const data = await res.json();
+      expect(data.previous_category).toBe("gaming");
+      expect(data.new_category).toBe("music");
+    });
+
+    it("rejects an unknown category", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", category: "underwater-basket-weaving" })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/Unknown category/);
+    });
+
+    it("rejects missing stream_id", async () => {
+      const res = await POST(postReq({ category: "gaming" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing category", async () => {
+      const res = await POST(postReq({ stream_id: "s1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid JSON body", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/stream/category-switch",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "not json",
+        }
+      );
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET — category timeline", () => {
+    it("returns empty timeline for a fresh stream", async () => {
+      const res = await GET(getReq("s1"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.timeline).toEqual([]);
+    });
+
+    it("returns full timeline after multiple switches", async () => {
+      await POST(postReq({ stream_id: "s1", category: "gaming" }));
+      await POST(postReq({ stream_id: "s1", category: "music" }));
+      await POST(postReq({ stream_id: "s1", category: "irl" }));
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.stream_id).toBe("s1");
+      expect(data.timeline).toHaveLength(3);
+      expect(data.timeline[0].category).toBe("gaming");
+      expect(data.timeline[1].category).toBe("music");
+      expect(data.timeline[2].category).toBe("irl");
+    });
+
+    it("rejects missing stream_id", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/stream/category-switch"
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/stream-chat-timeout.test.ts
+++ b/app/api/routes-f/__tests__/stream-chat-timeout.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET, DELETE } from "../stream/chat-timeout/route";
+import { timeoutStore } from "../stream/chat-timeout/store";
+
+function postReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/stream/chat-timeout",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function getReq(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stream/chat-timeout?stream_id=${streamId}`
+  );
+}
+
+function deleteReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/stream/chat-timeout",
+    {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("/api/routes-f/stream/chat-timeout", () => {
+  beforeEach(() => {
+    timeoutStore.clear();
+  });
+
+  describe("POST — apply timeout", () => {
+    it("applies a timeout and returns expires_at", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          user_id: "u1",
+          seconds: 300,
+          reason: "spamming",
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.expires_at).toBeDefined();
+      const expiresAt = new Date(data.expires_at).getTime();
+      expect(expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it("allows optional reason to be omitted", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", user_id: "u1", seconds: 60 })
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects seconds below 1", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", user_id: "u1", seconds: 0 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects seconds above 86400", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", user_id: "u1", seconds: 86401 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects non-integer seconds", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", user_id: "u1", seconds: 1.5 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing stream_id", async () => {
+      const res = await POST(
+        postReq({ user_id: "u1", seconds: 60 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing user_id", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", seconds: 60 })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing seconds", async () => {
+      const res = await POST(
+        postReq({ stream_id: "s1", user_id: "u1" })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET — list active timeouts", () => {
+    it("returns empty list when no timeouts", async () => {
+      const res = await GET(getReq("s1"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.timeouts).toEqual([]);
+    });
+
+    it("returns active timeouts with seconds_remaining", async () => {
+      await POST(
+        postReq({
+          stream_id: "s1",
+          user_id: "u1",
+          seconds: 600,
+          reason: "spam",
+        })
+      );
+      await POST(
+        postReq({ stream_id: "s1", user_id: "u2", seconds: 300 })
+      );
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.stream_id).toBe("s1");
+      expect(data.timeouts).toHaveLength(2);
+      expect(data.timeouts[0].seconds_remaining).toBeGreaterThan(0);
+    });
+
+    it("filters out expired timeouts automatically", async () => {
+      // Manually insert an already-expired entry
+      timeoutStore.set("s1:u-expired", {
+        stream_id: "s1",
+        user_id: "u-expired",
+        expires_at: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.timeouts).toHaveLength(0);
+    });
+
+    it("rejects missing stream_id", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/stream/chat-timeout"
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE — lift timeout", () => {
+    it("lifts an active timeout", async () => {
+      await POST(
+        postReq({ stream_id: "s1", user_id: "u1", seconds: 300 })
+      );
+
+      const res = await DELETE(
+        deleteReq({ stream_id: "s1", user_id: "u1" })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.lifted).toBe(true);
+
+      // Verify it's gone
+      const getRes = await GET(getReq("s1"));
+      const getData = await getRes.json();
+      expect(getData.timeouts).toHaveLength(0);
+    });
+
+    it("returns lifted=false when no timeout exists", async () => {
+      const res = await DELETE(
+        deleteReq({ stream_id: "s1", user_id: "u-none" })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.lifted).toBe(false);
+    });
+
+    it("rejects missing stream_id", async () => {
+      const res = await DELETE(deleteReq({ user_id: "u1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing user_id", async () => {
+      const res = await DELETE(deleteReq({ stream_id: "s1" }));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/stream-pinned-message.test.ts
+++ b/app/api/routes-f/__tests__/stream-pinned-message.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, DELETE, GET } from "../stream/pinned-message/route";
+import { pinnedMessages } from "../stream/pinned-message/store";
+
+function postReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/stream/pinned-message",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function getReq(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stream/pinned-message?stream_id=${streamId}`
+  );
+}
+
+function deleteReq(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stream/pinned-message?stream_id=${streamId}`,
+    { method: "DELETE" }
+  );
+}
+
+describe("/api/routes-f/stream/pinned-message", () => {
+  beforeEach(() => {
+    pinnedMessages.clear();
+  });
+
+  describe("POST — pin a message", () => {
+    it("pins a message and returns pinned_at", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "Hello everyone!",
+          pinned_by: "mod-1",
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.pinned_at).toBeDefined();
+      expect(data.expires_at).toBeUndefined();
+    });
+
+    it("returns expires_at when provided", async () => {
+      const expiresAt = new Date(Date.now() + 60000).toISOString();
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "Limited pin",
+          pinned_by: "mod-1",
+          expires_at: expiresAt,
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.expires_at).toBe(expiresAt);
+    });
+
+    it("replaces the previous pin (only most recent is active)", async () => {
+      await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "First pin",
+          pinned_by: "mod-1",
+        })
+      );
+      await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-2",
+          message_text: "Second pin",
+          pinned_by: "mod-2",
+        })
+      );
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.pin.message_id).toBe("msg-2");
+      expect(data.pin.message_text).toBe("Second pin");
+    });
+
+    it("rejects missing stream_id", async () => {
+      const res = await POST(
+        postReq({
+          message_id: "m1",
+          message_text: "t",
+          pinned_by: "u1",
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing message_id", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_text: "t",
+          pinned_by: "u1",
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing message_text", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "m1",
+          pinned_by: "u1",
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing pinned_by", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "m1",
+          message_text: "t",
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid expires_at", async () => {
+      const res = await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "m1",
+          message_text: "t",
+          pinned_by: "u1",
+          expires_at: "not-a-date",
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE — unpin", () => {
+    it("unpins the current message", async () => {
+      await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "Pin",
+          pinned_by: "mod-1",
+        })
+      );
+
+      const delRes = await DELETE(deleteReq("s1"));
+      expect(delRes.status).toBe(200);
+      expect((await delRes.json()).unpinned).toBe(true);
+
+      const getRes = await GET(getReq("s1"));
+      const data = await getRes.json();
+      expect(data.pin).toBeNull();
+    });
+
+    it("rejects missing stream_id", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/stream/pinned-message",
+        { method: "DELETE" }
+      );
+      const res = await DELETE(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET — get current pin", () => {
+    it("returns null when no pin exists", async () => {
+      const res = await GET(getReq("s1"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.pin).toBeNull();
+    });
+
+    it("returns the current pin", async () => {
+      await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "Pinned!",
+          pinned_by: "mod-1",
+        })
+      );
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.pin.message_id).toBe("msg-1");
+      expect(data.pin.message_text).toBe("Pinned!");
+      expect(data.pin.pinned_by).toBe("mod-1");
+      expect(data.pin.pinned_at).toBeDefined();
+    });
+
+    it("auto-clears an expired pin", async () => {
+      const pastDate = new Date(Date.now() - 1000).toISOString();
+      await POST(
+        postReq({
+          stream_id: "s1",
+          message_id: "msg-1",
+          message_text: "Expired",
+          pinned_by: "mod-1",
+          expires_at: pastDate,
+        })
+      );
+
+      const res = await GET(getReq("s1"));
+      const data = await res.json();
+      expect(data.pin).toBeNull();
+    });
+
+    it("rejects missing stream_id", async () => {
+      const req = new NextRequest(
+        "http://localhost/api/routes-f/stream/pinned-message"
+      );
+      const res = await GET(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/creator-min-tip/check/route.ts
+++ b/app/api/routes-f/creator-min-tip/check/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkTip } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { creator_id, asset, amount } = body;
+
+  if (typeof creator_id !== "string" || !creator_id.trim()) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof asset !== "string" || !asset.trim()) {
+    return NextResponse.json(
+      { error: "asset is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof amount !== "number" || amount < 0) {
+    return NextResponse.json(
+      { error: "amount must be a number >= 0." },
+      { status: 400 }
+    );
+  }
+
+  const result = checkTip(creator_id, asset, amount);
+  return NextResponse.json(result);
+}

--- a/app/api/routes-f/creator-min-tip/route.ts
+++ b/app/api/routes-f/creator-min-tip/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMinTip, setMinTip } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const config = getMinTip(creatorId);
+  return NextResponse.json({
+    min_xlm: config.min_xlm,
+    min_usdc: config.min_usdc,
+  });
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { creator_id, min_xlm, min_usdc } = body;
+
+  if (typeof creator_id !== "string" || !creator_id.trim()) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+
+  if (min_xlm !== undefined) {
+    if (typeof min_xlm !== "number" || min_xlm < 0) {
+      return NextResponse.json(
+        { error: "min_xlm must be a number >= 0." },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (min_usdc !== undefined) {
+    if (typeof min_usdc !== "number" || min_usdc < 0) {
+      return NextResponse.json(
+        { error: "min_usdc must be a number >= 0." },
+        { status: 400 }
+      );
+    }
+  }
+
+  const updated = setMinTip(
+    creator_id as string,
+    min_xlm as number | undefined,
+    min_usdc as number | undefined
+  );
+  return NextResponse.json({
+    min_xlm: updated.min_xlm,
+    min_usdc: updated.min_usdc,
+  });
+}

--- a/app/api/routes-f/creator-min-tip/store.ts
+++ b/app/api/routes-f/creator-min-tip/store.ts
@@ -1,0 +1,52 @@
+import type { MinTipConfig } from "./types";
+
+export const minTipStore = new Map<string, MinTipConfig>();
+
+export function getMinTip(creator_id: string): MinTipConfig {
+  return minTipStore.get(creator_id) ?? { creator_id, min_xlm: 0, min_usdc: 0 };
+}
+
+export function setMinTip(
+  creator_id: string,
+  min_xlm?: number,
+  min_usdc?: number
+): MinTipConfig {
+  const current = getMinTip(creator_id);
+  const updated: MinTipConfig = {
+    creator_id,
+    min_xlm: min_xlm ?? current.min_xlm,
+    min_usdc: min_usdc ?? current.min_usdc,
+  };
+  minTipStore.set(creator_id, updated);
+  return updated;
+}
+
+export function checkTip(
+  creator_id: string,
+  asset: string,
+  amount: number
+): { allowed: boolean; reason?: string } {
+  const config = getMinTip(creator_id);
+
+  if (asset === "XLM") {
+    if (amount < config.min_xlm) {
+      return {
+        allowed: false,
+        reason: `Minimum XLM tip is ${config.min_xlm}. You sent ${amount}.`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (asset === "USDC") {
+    if (amount < config.min_usdc) {
+      return {
+        allowed: false,
+        reason: `Minimum USDC tip is ${config.min_usdc}. You sent ${amount}.`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  return { allowed: false, reason: `Unsupported asset: "${asset}". Use XLM or USDC.` };
+}

--- a/app/api/routes-f/creator-min-tip/types.ts
+++ b/app/api/routes-f/creator-min-tip/types.ts
@@ -1,0 +1,10 @@
+export interface MinTipConfig {
+  creator_id: string;
+  min_xlm: number;
+  min_usdc: number;
+}
+
+export interface CheckTipResult {
+  allowed: boolean;
+  reason?: string;
+}

--- a/app/api/routes-f/stream/category-switch/categories.ts
+++ b/app/api/routes-f/stream/category-switch/categories.ts
@@ -1,0 +1,22 @@
+export const VALID_CATEGORIES = [
+  "gaming",
+  "music",
+  "irl",
+  "art",
+  "just-chatting",
+  "sports",
+  "education",
+  "technology",
+  "cooking",
+  "fitness",
+  "crypto",
+  "nft",
+  "defi",
+  "other",
+] as const;
+
+export type Category = (typeof VALID_CATEGORIES)[number];
+
+export function isValidCategory(value: string): value is Category {
+  return VALID_CATEGORIES.includes(value as Category);
+}

--- a/app/api/routes-f/stream/category-switch/route.ts
+++ b/app/api/routes-f/stream/category-switch/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isValidCategory, VALID_CATEGORIES } from "./categories";
+import { addCategorySwitch, getTimeline } from "./store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { stream_id, category } = body;
+
+  if (typeof stream_id !== "string" || !stream_id.trim()) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+
+  if (typeof category !== "string" || !category.trim()) {
+    return NextResponse.json(
+      { error: "category is required." },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidCategory(category)) {
+    return NextResponse.json(
+      {
+        error: `Unknown category: "${category}". Valid categories: ${VALID_CATEGORIES.join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  const result = addCategorySwitch(stream_id, category);
+  return NextResponse.json(result);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const timeline = getTimeline(streamId);
+  return NextResponse.json({ stream_id: streamId, timeline });
+}

--- a/app/api/routes-f/stream/category-switch/store.ts
+++ b/app/api/routes-f/stream/category-switch/store.ts
@@ -1,0 +1,28 @@
+import type { CategoryTimelineEntry } from "./types";
+
+export const categoryTimelines = new Map<string, CategoryTimelineEntry[]>();
+
+export function getCurrentCategory(streamId: string): string | undefined {
+  const timeline = categoryTimelines.get(streamId);
+  if (!timeline || timeline.length === 0) return undefined;
+  return timeline[timeline.length - 1].category;
+}
+
+export function addCategorySwitch(
+  streamId: string,
+  category: string
+): { previous_category: string; new_category: string; switched_at: string } {
+  const previous = getCurrentCategory(streamId) ?? "none";
+  const switched_at = new Date().toISOString();
+  const entry: CategoryTimelineEntry = { category, switched_at };
+
+  const timeline = categoryTimelines.get(streamId) ?? [];
+  timeline.push(entry);
+  categoryTimelines.set(streamId, timeline);
+
+  return { previous_category: previous, new_category: category, switched_at };
+}
+
+export function getTimeline(streamId: string): CategoryTimelineEntry[] {
+  return categoryTimelines.get(streamId) ?? [];
+}

--- a/app/api/routes-f/stream/category-switch/types.ts
+++ b/app/api/routes-f/stream/category-switch/types.ts
@@ -1,0 +1,15 @@
+export interface CategorySwitchRequest {
+  stream_id: string;
+  category: string;
+}
+
+export interface CategorySwitchResponse {
+  previous_category: string;
+  new_category: string;
+  switched_at: string;
+}
+
+export interface CategoryTimelineEntry {
+  category: string;
+  switched_at: string;
+}

--- a/app/api/routes-f/stream/chat-timeout/route.ts
+++ b/app/api/routes-f/stream/chat-timeout/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { applyTimeout, liftTimeout, listActiveTimeouts } from "./store";
+
+const MIN_SECONDS = 1;
+const MAX_SECONDS = 86_400;
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { stream_id, user_id, seconds, reason } = body;
+
+  if (typeof stream_id !== "string" || !stream_id.trim()) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof user_id !== "string" || !user_id.trim()) {
+    return NextResponse.json(
+      { error: "user_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof seconds !== "number" || !Number.isInteger(seconds)) {
+    return NextResponse.json(
+      { error: "seconds must be an integer." },
+      { status: 400 }
+    );
+  }
+  if (seconds < MIN_SECONDS || seconds > MAX_SECONDS) {
+    return NextResponse.json(
+      {
+        error: `seconds must be between ${MIN_SECONDS} and ${MAX_SECONDS}.`,
+      },
+      { status: 400 }
+    );
+  }
+  if (reason !== undefined && typeof reason !== "string") {
+    return NextResponse.json(
+      { error: "reason must be a string." },
+      { status: 400 }
+    );
+  }
+
+  const result = applyTimeout(
+    stream_id as string,
+    user_id as string,
+    seconds as number,
+    reason as string | undefined
+  );
+  return NextResponse.json(result);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const timeouts = listActiveTimeouts(streamId);
+  return NextResponse.json({ stream_id: streamId, timeouts });
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { stream_id, user_id } = body;
+
+  if (typeof stream_id !== "string" || !stream_id.trim()) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof user_id !== "string" || !user_id.trim()) {
+    return NextResponse.json(
+      { error: "user_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const lifted = liftTimeout(stream_id, user_id);
+  return NextResponse.json({ lifted });
+}

--- a/app/api/routes-f/stream/chat-timeout/store.ts
+++ b/app/api/routes-f/stream/chat-timeout/store.ts
@@ -1,0 +1,50 @@
+import type { TimeoutEntry, TimeoutListItem } from "./types";
+
+// Key: "stream_id:user_id"
+export const timeoutStore = new Map<string, TimeoutEntry>();
+
+function key(stream_id: string, user_id: string): string {
+  return `${stream_id}:${user_id}`;
+}
+
+export function applyTimeout(
+  stream_id: string,
+  user_id: string,
+  seconds: number,
+  reason?: string
+): { expires_at: string } {
+  const expires_at = new Date(Date.now() + seconds * 1000).toISOString();
+  const entry: TimeoutEntry = { stream_id, user_id, reason, expires_at };
+  timeoutStore.set(key(stream_id, user_id), entry);
+  return { expires_at };
+}
+
+export function liftTimeout(stream_id: string, user_id: string): boolean {
+  return timeoutStore.delete(key(stream_id, user_id));
+}
+
+export function listActiveTimeouts(stream_id: string): TimeoutListItem[] {
+  const now = Date.now();
+  const results: TimeoutListItem[] = [];
+
+  for (const [k, entry] of timeoutStore) {
+    if (entry.stream_id !== stream_id) continue;
+
+    const expiresMs = new Date(entry.expires_at).getTime();
+    const remaining = Math.ceil((expiresMs - now) / 1000);
+
+    if (remaining <= 0) {
+      timeoutStore.delete(k);
+      continue;
+    }
+
+    results.push({
+      user_id: entry.user_id,
+      reason: entry.reason,
+      expires_at: entry.expires_at,
+      seconds_remaining: remaining,
+    });
+  }
+
+  return results;
+}

--- a/app/api/routes-f/stream/chat-timeout/types.ts
+++ b/app/api/routes-f/stream/chat-timeout/types.ts
@@ -1,0 +1,13 @@
+export interface TimeoutEntry {
+  stream_id: string;
+  user_id: string;
+  reason?: string;
+  expires_at: string;
+}
+
+export interface TimeoutListItem {
+  user_id: string;
+  reason?: string;
+  expires_at: string;
+  seconds_remaining: number;
+}

--- a/app/api/routes-f/stream/pinned-message/route.ts
+++ b/app/api/routes-f/stream/pinned-message/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pinMessage, unpinMessage, getPinnedMessage } from "./store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { stream_id, message_id, message_text, pinned_by, expires_at } = body;
+
+  if (typeof stream_id !== "string" || !stream_id.trim()) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof message_id !== "string" || !message_id.trim()) {
+    return NextResponse.json(
+      { error: "message_id is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof message_text !== "string" || !message_text.trim()) {
+    return NextResponse.json(
+      { error: "message_text is required." },
+      { status: 400 }
+    );
+  }
+  if (typeof pinned_by !== "string" || !pinned_by.trim()) {
+    return NextResponse.json(
+      { error: "pinned_by is required." },
+      { status: 400 }
+    );
+  }
+
+  let expiresAtStr: string | undefined;
+  if (expires_at !== undefined) {
+    if (typeof expires_at !== "string") {
+      return NextResponse.json(
+        { error: "expires_at must be a valid ISO date string." },
+        { status: 400 }
+      );
+    }
+    const d = new Date(expires_at);
+    if (isNaN(d.getTime())) {
+      return NextResponse.json(
+        { error: "expires_at must be a valid ISO date string." },
+        { status: 400 }
+      );
+    }
+    expiresAtStr = expires_at;
+  }
+
+  const pin = pinMessage(
+    stream_id as string,
+    message_id as string,
+    message_text as string,
+    pinned_by as string,
+    expiresAtStr
+  );
+
+  return NextResponse.json({
+    pinned_at: pin.pinned_at,
+    ...(pin.expires_at ? { expires_at: pin.expires_at } : {}),
+  });
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+
+  unpinMessage(streamId);
+  return NextResponse.json({ unpinned: true });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const pin = getPinnedMessage(streamId);
+  return NextResponse.json({ pin });
+}

--- a/app/api/routes-f/stream/pinned-message/store.ts
+++ b/app/api/routes-f/stream/pinned-message/store.ts
@@ -1,0 +1,38 @@
+import type { PinnedMessage } from "./types";
+
+export const pinnedMessages = new Map<string, PinnedMessage>();
+
+export function pinMessage(
+  stream_id: string,
+  message_id: string,
+  message_text: string,
+  pinned_by: string,
+  expires_at?: string
+): PinnedMessage {
+  const pin: PinnedMessage = {
+    stream_id,
+    message_id,
+    message_text,
+    pinned_by,
+    pinned_at: new Date().toISOString(),
+    expires_at,
+  };
+  pinnedMessages.set(stream_id, pin);
+  return pin;
+}
+
+export function unpinMessage(stream_id: string): boolean {
+  return pinnedMessages.delete(stream_id);
+}
+
+export function getPinnedMessage(stream_id: string): PinnedMessage | null {
+  const pin = pinnedMessages.get(stream_id);
+  if (!pin) return null;
+
+  if (pin.expires_at && new Date(pin.expires_at).getTime() <= Date.now()) {
+    pinnedMessages.delete(stream_id);
+    return null;
+  }
+
+  return pin;
+}

--- a/app/api/routes-f/stream/pinned-message/types.ts
+++ b/app/api/routes-f/stream/pinned-message/types.ts
@@ -1,0 +1,13 @@
+export interface PinnedMessage {
+  stream_id: string;
+  message_id: string;
+  message_text: string;
+  pinned_by: string;
+  pinned_at: string;
+  expires_at?: string;
+}
+
+export interface PinResponse {
+  pinned_at: string;
+  expires_at?: string;
+}


### PR DESCRIPTION
## Summary

Closes #964
Closes #966
Closes #971
Closes #981

Four new stream/creator API routes, all scoped to `app/api/routes-f/` per issue constraints. Each uses in-memory stores and follows existing route patterns.

---

### #964 — Mid-Stream Category Switch (`/api/routes-f/stream/category-switch`)

- **POST** `{ stream_id, category }` → `{ previous_category, new_category, switched_at }`
- **GET** `?stream_id=` → full category timeline
- Bundled category list for validation (gaming, music, irl, crypto, etc.)
- Rejects unknown categories with descriptive error

### #966 — Pinned Chat Message (`/api/routes-f/stream/pinned-message`)

- **POST** `{ stream_id, message_id, message_text, pinned_by, expires_at? }` → `{ pinned_at, expires_at? }`
- **DELETE** `?stream_id=` → unpins
- **GET** `?stream_id=` → current pin or `null`
- Only the most recent pin is active (new pin replaces old)
- Optional `expires_at` auto-clears on read

### #971 — Chat User Timeout (`/api/routes-f/stream/chat-timeout`)

- **POST** `{ stream_id, user_id, seconds, reason? }` → `{ expires_at }`
- **GET** `?stream_id=` → list active timeouts with `seconds_remaining`
- **DELETE** `{ stream_id, user_id }` → lifts timeout
- Validates `seconds` in `[1, 86400]`
- Expired timeouts are automatically pruned on list

### #981 — Creator Minimum Tip Amount (`/api/routes-f/creator-min-tip`)

- **GET** `?creator_id=` → `{ min_xlm, min_usdc }` (defaults to 0)
- **PUT** `{ creator_id, min_xlm?, min_usdc? }` → updated config
- **POST** `/check` `{ creator_id, asset, amount }` → `{ allowed, reason? }`
- Validates minimums >= 0, supports XLM and USDC assets
- Below-minimum tips return `allowed: false` with reason

## Test plan

- [x] 57 tests pass across 4 test suites
- [x] All files scoped to `app/api/routes-f/` — no imports from outside
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Next.js build passes
- [x] Each route covers: happy path, edge cases, all validation errors
- [x] In-memory stores cleared between tests via `beforeEach`