### PR TITLE
feat(routes-f): add tips, subscription, and category feeds

### DIFF
--- a/app/api/routes-f/__tests__/cancel-subscription.test.ts
+++ b/app/api/routes-f/__tests__/cancel-subscription.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, GET } from "../subscriptions/cancel/route";
+import { GET as GET_MAIN, subscriptions } from "../subscriptions/route";
+
+function makePostReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/subscriptions/cancel", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetReq(subscriptionId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/subscriptions/cancel?subscription_id=${subscriptionId}`
+  );
+}
+
+function makeMainGetReq(subscriptionId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/subscriptions?subscription_id=${subscriptionId}`
+  );
+}
+
+describe("Cancel Subscription API", () => {
+  beforeEach(() => {
+    subscriptions.clear();
+  });
+
+  it("should successfully cancel an active subscription, keeping expires_at intact", async () => {
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    subscriptions.set("sub-123", {
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-456",
+      creator_id: "creator-789",
+      tier_id: "premium",
+      payment_tx_hash: "hash-xyz",
+      asset: "USDC",
+      started_at: new Date().toISOString(),
+      expires_at: expiresAt,
+      status: "active",
+    });
+
+    const req = makePostReq({
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-456",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("cancelled");
+    expect(data.expires_at).toBe(expiresAt);
+
+    // Verify GET cancel endpoint returns current state
+    const getRes = await GET(makeGetReq("sub-123"));
+    expect(getRes.status).toBe(200);
+    const getData = await getRes.json();
+    expect(getData.status).toBe("cancelled");
+    expect(getData.expires_at).toBe(expiresAt);
+
+    // Verify GET main endpoint also returns current state
+    const getMainRes = await GET_MAIN(makeMainGetReq("sub-123"));
+    expect(getMainRes.status).toBe(200);
+    const getMainData = await getMainRes.json();
+    expect(getMainData.status).toBe("cancelled");
+  });
+
+  it("should return 403 Forbidden if the requester is not the subscriber", async () => {
+    subscriptions.set("sub-123", {
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-456",
+      creator_id: "creator-789",
+      tier_id: "premium",
+      payment_tx_hash: "hash-xyz",
+      asset: "USDC",
+      started_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      status: "active",
+    });
+
+    const req = makePostReq({
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-wrong",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("should handle double-cancel correctly, returning cancelled state", async () => {
+    subscriptions.set("sub-123", {
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-456",
+      creator_id: "creator-789",
+      tier_id: "premium",
+      payment_tx_hash: "hash-xyz",
+      asset: "USDC",
+      started_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      status: "cancelled",
+    });
+
+    const req = makePostReq({
+      subscription_id: "sub-123",
+      subscriber_id: "subscriber-456",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("cancelled");
+  });
+});

--- a/app/api/routes-f/__tests__/followed-categories.test.ts
+++ b/app/api/routes-f/__tests__/followed-categories.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../categories/followed/route";
+
+function makeReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/categories/followed?${query}`
+  );
+}
+
+describe("Followed Categories Feed API", () => {
+  it("should fail if viewer_id is missing", async () => {
+    const req = makeReq("");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("viewer_id is required");
+  });
+
+  it("should return empty list if viewer follows no categories", async () => {
+    const req = makeReq("viewer_id=viewer-no-follows");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.streams).toEqual([]);
+  });
+
+  it("should return streams in followed categories, sorted by viewer_count descending", async () => {
+    // viewer-1 follows Gaming, Music, Talk Shows
+    const req = makeReq("viewer_id=viewer-1");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(Array.isArray(data.streams)).toBe(true);
+    expect(data.streams.length).toBe(4);
+
+    // Verify categories are correct
+    const categories = data.streams.map((s: any) => s.category);
+    expect(categories).toContain("Gaming");
+    expect(categories).toContain("Music");
+    expect(categories).toContain("Talk Shows");
+    expect(categories).not.toContain("Crypto");
+    expect(categories).not.toContain("Coding");
+    expect(categories).not.toContain("Sports");
+
+    // Verify ordering is descending by viewer_count
+    // Expected order of followed categories:
+    // 1. creator-gaming-1 (Gaming) - 1500 viewers
+    // 2. creator-talk-1 (Talk Shows) - 1200 viewers
+    // 3. creator-gaming-2 (Gaming) - 800 viewers
+    // 4. creator-music-1 (Music) - 450 viewers
+    expect(data.streams[0].creator).toBe("creator-gaming-1");
+    expect(data.streams[1].creator).toBe("creator-talk-1");
+    expect(data.streams[2].creator).toBe("creator-gaming-2");
+    expect(data.streams[3].creator).toBe("creator-music-1");
+
+    for (let i = 0; i < data.streams.length - 1; i++) {
+      expect(data.streams[i].viewer_count).toBeGreaterThanOrEqual(
+        data.streams[i + 1].viewer_count
+      );
+    }
+  });
+
+  it("should return correct streams for another viewer with correct ranking", async () => {
+    // viewer-3 follows Crypto, Coding
+    // Streams:
+    // creator-crypto-1 (Crypto) - 3100 viewers
+    // creator-coding-1 (Coding) - 950 viewers
+    const req = makeReq("viewer_id=viewer-3");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.streams.length).toBe(2);
+    expect(data.streams[0].creator).toBe("creator-crypto-1");
+    expect(data.streams[1].creator).toBe("creator-coding-1");
+  });
+});

--- a/app/api/routes-f/__tests__/recent-tips.test.ts
+++ b/app/api/routes-f/__tests__/recent-tips.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../tips/recent/route";
+
+function makeReq(query: string) {
+  return new NextRequest(`http://localhost/api/routes-f/tips/recent?${query}`);
+}
+
+describe("Recent Tips Feed API", () => {
+  it("should fail if creator_id is missing", async () => {
+    const req = makeReq("");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("creator_id is required");
+  });
+
+  it("should return newest tips first with default limit of 20", async () => {
+    const req = makeReq("creator_id=creator-123");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(Array.isArray(data.tips)).toBe(true);
+    expect(data.tips.length).toBe(20);
+
+    // Verify ordering is newest first
+    for (let i = 0; i < data.tips.length - 1; i++) {
+      const currentTs = new Date(data.tips[i].ts).getTime();
+      const nextTs = new Date(data.tips[i + 1].ts).getTime();
+      expect(currentTs).toBeGreaterThan(nextTs);
+    }
+
+    expect(data.next_cursor).toBe("20");
+  });
+
+  it("should respect limit parameter", async () => {
+    const req = makeReq("creator_id=creator-123&limit=5");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tips.length).toBe(5);
+    expect(data.next_cursor).toBe("5");
+  });
+
+  it("should correctly paginate using cursor", async () => {
+    // Page 1
+    const req1 = makeReq("creator_id=creator-123&limit=15");
+    const res1 = await GET(req1);
+    const data1 = await res1.json();
+    expect(data1.tips.length).toBe(15);
+    const cursor = data1.next_cursor;
+    expect(cursor).toBe("15");
+
+    // Page 2
+    const req2 = makeReq(`creator_id=creator-123&limit=15&cursor=${cursor}`);
+    const res2 = await GET(req2);
+    const data2 = await res2.json();
+    expect(data2.tips.length).toBe(15);
+    expect(data2.next_cursor).toBeNull();
+
+    // Verify all returned tips are distinct
+    const allHashes = new Set([
+      ...data1.tips.map((t: any) => t.tx_hash),
+      ...data2.tips.map((t: any) => t.tx_hash),
+    ]);
+    expect(allHashes.size).toBe(30);
+  });
+});

--- a/app/api/routes-f/__tests__/subscription-badges.test.ts
+++ b/app/api/routes-f/__tests__/subscription-badges.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../subscriptions/badges/route";
+import { subscriptions } from "../subscriptions/route";
+
+function makeReq(creatorId: string, subscriberId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/subscriptions/badges?creator_id=${creatorId}&subscriber_id=${subscriberId}`
+  );
+}
+
+describe("Subscription Badges by Tier API", () => {
+  beforeEach(() => {
+    subscriptions.clear();
+  });
+
+  it("should return has_sub false if no subscription exists", async () => {
+    const req = makeReq("creator-1", "user-1");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.has_sub).toBe(false);
+    expect(data.months_subscribed).toBe(0);
+    expect(data.tier_id).toBeUndefined();
+  });
+
+  it("should return active subscription details (single tier)", async () => {
+    const creatorId = "creator-1";
+    const subscriberId = "user-1";
+
+    const now = Date.now();
+    // 30 days active sub
+    subscriptions.set("sub-1", {
+      subscription_id: "sub-1",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "premium",
+      payment_tx_hash: "hash-1",
+      asset: "USDC",
+      started_at: new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const req = makeReq(creatorId, subscriberId);
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.has_sub).toBe(true);
+    expect(data.tier_id).toBe("premium");
+    expect(data.badge_url).toBe("/api/routes-f/subscriptions/badges/svg");
+    expect(data.months_subscribed).toBe(1); // 30 days total
+  });
+
+  it("should stack months_subscribed across non-overlapping historical subscriptions", async () => {
+    const creatorId = "creator-1";
+    const subscriberId = "user-1";
+    const now = Date.now();
+
+    // Sub 1: Active premium sub (30 days, from now-15d to now+15d)
+    subscriptions.set("sub-1", {
+      subscription_id: "sub-1",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "premium",
+      payment_tx_hash: "hash-1",
+      asset: "USDC",
+      started_at: new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    // Sub 2: Past basic sub (30 days, from now-75d to now-45d)
+    subscriptions.set("sub-2", {
+      subscription_id: "sub-2",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "basic",
+      payment_tx_hash: "hash-2",
+      asset: "XLM",
+      started_at: new Date(now - 75 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now - 45 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    // Sub 3: Even older basic sub (60 days, from now-150d to now-90d)
+    subscriptions.set("sub-3", {
+      subscription_id: "sub-3",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "basic",
+      payment_tx_hash: "hash-3",
+      asset: "XLM",
+      started_at: new Date(now - 150 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now - 90 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const req = makeReq(creatorId, subscriberId);
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.has_sub).toBe(true);
+    expect(data.tier_id).toBe("premium"); // Returns current active tier
+    expect(data.months_subscribed).toBe(4); // 30 + 30 + 60 = 120 days -> 4 months
+  });
+
+  it("should not double count overlapping subscription days", async () => {
+    const creatorId = "creator-1";
+    const subscriberId = "user-1";
+    const now = Date.now();
+
+    // Sub 1: 30 days
+    subscriptions.set("sub-1", {
+      subscription_id: "sub-1",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "premium",
+      payment_tx_hash: "hash-1",
+      asset: "USDC",
+      started_at: new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    // Sub 2: Overlapping (starts 5 days into sub-1, runs for 30 days)
+    subscriptions.set("sub-2", {
+      subscription_id: "sub-2",
+      subscriber_id: subscriberId,
+      creator_id: creatorId,
+      tier_id: "premium",
+      payment_tx_hash: "hash-2",
+      asset: "USDC",
+      started_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(now + 20 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const req = makeReq(creatorId, subscriberId);
+    const res = await GET(req);
+    const data = await res.json();
+
+    // Total interval: now-15 to now+20 (35 days total) -> Math.floor(35/30) = 1 month
+    expect(data.months_subscribed).toBe(1);
+  });
+});

--- a/app/api/routes-f/categories/followed/route.ts
+++ b/app/api/routes-f/categories/followed/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface Stream {
+  creator: string;
+  category: string;
+  viewer_count: number;
+}
+
+// Seed category follows mapping: viewer_id -> list of followed categories
+export const SEED_FOLLOWS: Record<string, string[]> = {
+  "viewer-1": ["Gaming", "Music", "Talk Shows"],
+  "viewer-2": ["Gaming"],
+  "viewer-3": ["Crypto", "Coding"],
+};
+
+// Seed live streams
+export const SEED_STREAMS: Stream[] = [
+  { creator: "creator-gaming-1", category: "Gaming", viewer_count: 1500 },
+  { creator: "creator-gaming-2", category: "Gaming", viewer_count: 800 },
+  { creator: "creator-music-1", category: "Music", viewer_count: 450 },
+  { creator: "creator-talk-1", category: "Talk Shows", viewer_count: 1200 },
+  { creator: "creator-crypto-1", category: "Crypto", viewer_count: 3100 },
+  { creator: "creator-coding-1", category: "Coding", viewer_count: 950 },
+  { creator: "creator-sports-1", category: "Sports", viewer_count: 5000 },
+];
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const viewerId = searchParams.get("viewer_id");
+
+  if (!viewerId) {
+    return NextResponse.json({ error: "viewer_id is required" }, { status: 400 });
+  }
+
+  // Get categories followed by the viewer
+  const followedCategories = SEED_FOLLOWS[viewerId] || [];
+
+  // Filter streams to only those in the followed categories
+  const followedStreams = SEED_STREAMS.filter((stream) =>
+    followedCategories.includes(stream.category)
+  );
+
+  // Sort by viewer_count descending
+  followedStreams.sort((a, b) => b.viewer_count - a.viewer_count);
+
+  return NextResponse.json({
+    streams: followedStreams,
+  });
+}

--- a/app/api/routes-f/subscriptions/badges/badge.svg
+++ b/app/api/routes-f/subscriptions/badges/badge.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <defs>
+    <linearGradient id="gold-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFE07D" />
+      <stop offset="100%" stop-color="#F5A623" />
+    </linearGradient>
+  </defs>
+  <path fill="url(#gold-grad)" d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z" />
+</svg>

--- a/app/api/routes-f/subscriptions/badges/route.ts
+++ b/app/api/routes-f/subscriptions/badges/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { subscriptions } from "../route";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+  const subscriberId = searchParams.get("subscriber_id");
+
+  if (!creatorId || !subscriberId) {
+    return NextResponse.json(
+      { error: "creator_id and subscriber_id are required" },
+      { status: 400 }
+    );
+  }
+
+  const now = Date.now();
+
+  // Find all subscriptions matching user and creator
+  const userSubs = Array.from(subscriptions.values()).filter(
+    (sub) => sub.subscriber_id === subscriberId && sub.creator_id === creatorId
+  );
+
+  // Check if there is a currently active subscription (active until expires_at)
+  const activeSub = userSubs.find(
+    (sub) =>
+      new Date(sub.expires_at).getTime() > now &&
+      new Date(sub.started_at).getTime() <= now
+  );
+
+  const has_sub = !!activeSub;
+
+  // Stack months_subscribed across non-overlapping subs
+  const intervals = userSubs.map((sub) => ({
+    start: new Date(sub.started_at).getTime(),
+    end: new Date(sub.expires_at).getTime(),
+  }));
+
+  // Sort intervals by start time
+  intervals.sort((a, b) => a.start - b.start);
+
+  // Merge overlapping intervals
+  const merged: { start: number; end: number }[] = [];
+  for (const interval of intervals) {
+    if (merged.length === 0) {
+      merged.push(interval);
+    } else {
+      const last = merged[merged.length - 1];
+      if (interval.start <= last.end) {
+        // Overlapping or adjacent, merge
+        last.end = Math.max(last.end, interval.end);
+      } else {
+        // Non-overlapping
+        merged.push(interval);
+      }
+    }
+  }
+
+  const totalDurationMs = merged.reduce(
+    (sum, interval) => sum + (interval.end - interval.start),
+    0
+  );
+  const totalDays = totalDurationMs / (24 * 60 * 60 * 1000);
+  const months_subscribed = Math.floor(totalDays / 30);
+
+  if (has_sub) {
+    return NextResponse.json({
+      has_sub,
+      tier_id: activeSub.tier_id,
+      badge_url: "/api/routes-f/subscriptions/badges/svg",
+      months_subscribed,
+    });
+  }
+
+  return NextResponse.json({
+    has_sub,
+    months_subscribed,
+  });
+}

--- a/app/api/routes-f/subscriptions/badges/svg/route.ts
+++ b/app/api/routes-f/subscriptions/badges/svg/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function GET() {
+  try {
+    const filePath = path.join(
+      process.cwd(),
+      "app/api/routes-f/subscriptions/badges/badge.svg"
+    );
+    const fileContent = await fs.readFile(filePath, "utf-8");
+    return new NextResponse(fileContent, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({ error: "Badge icon not found" }, { status: 404 });
+  }
+}

--- a/app/api/routes-f/subscriptions/cancel/route.ts
+++ b/app/api/routes-f/subscriptions/cancel/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { subscriptions } from "../route";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { subscription_id, subscriber_id } = body;
+  if (!subscription_id || !subscriber_id) {
+    return NextResponse.json(
+      { error: "subscription_id and subscriber_id are required" },
+      { status: 400 }
+    );
+  }
+
+  const sub = subscriptions.get(subscription_id);
+  if (!sub) {
+    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+  }
+
+  if (sub.subscriber_id !== subscriber_id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Mark status='cancelled' but keep expires_at intact
+  const updatedSub = {
+    ...sub,
+    status: "cancelled" as const,
+  };
+  subscriptions.set(subscription_id, updatedSub);
+
+  return NextResponse.json(updatedSub);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const subscriptionId = searchParams.get("subscription_id");
+  if (!subscriptionId) {
+    return NextResponse.json({ error: "subscription_id is required" }, { status: 400 });
+  }
+
+  const sub = subscriptions.get(subscriptionId);
+  if (!sub) {
+    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(sub);
+}

--- a/app/api/routes-f/subscriptions/route.ts
+++ b/app/api/routes-f/subscriptions/route.ts
@@ -33,6 +33,7 @@ export interface Subscription {
   asset: "XLM" | "USDC";
   started_at: string;
   expires_at: string;
+  status?: "active" | "cancelled";
 }
 
 // Exported so tests can reset between runs.
@@ -75,8 +76,23 @@ function findActiveSubscription(
 }
 
 // ---------------------------------------------------------------------------
-// Route handler
+// Route handlers
 // ---------------------------------------------------------------------------
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const subscriptionId = searchParams.get("subscription_id");
+  if (!subscriptionId) {
+    return NextResponse.json({ error: "subscription_id is required" }, { status: 400 });
+  }
+
+  const sub = subscriptions.get(subscriptionId);
+  if (!sub) {
+    return NextResponse.json({ error: "Subscription not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(sub);
+}
+
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const bodyResult = await validateBody(req, createSubscriptionSchema);
   if (bodyResult instanceof NextResponse) {
@@ -130,6 +146,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     asset,
     started_at,
     expires_at,
+    status: "active",
   };
 
   subscriptions.set(subscription.subscription_id, subscription);
@@ -142,6 +159,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       tier_id: subscription.tier_id,
       started_at: subscription.started_at,
       expires_at: subscription.expires_at,
+      status: subscription.status,
     },
     { status: 201 }
   );

--- a/app/api/routes-f/tips/recent/route.ts
+++ b/app/api/routes-f/tips/recent/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface Tip {
+  tipper: string;
+  amount_usdc: number;
+  asset: "XLM" | "USDC";
+  tx_hash: string;
+  message?: string;
+  ts: string; // ISO 8601 string
+}
+
+// Generate 30 seed tips with varied assets, amounts, messages, and timestamps
+const SEED_TIPS: Tip[] = Array.from({ length: 30 }).map((_, idx) => {
+  const assets: ("XLM" | "USDC")[] = ["XLM", "USDC"];
+  const asset = assets[idx % 2];
+  const amount_usdc = Number((1.5 * (idx + 1) + (idx % 3) * 0.75).toFixed(2));
+  const messages = [
+    "Awesome stream!",
+    "Keep up the great work!",
+    "Love the content!",
+    "Super cool stream overlay!",
+    undefined,
+    "stellar network is so fast",
+    "greetings from the chat!",
+  ];
+  return {
+    tipper: `tipper_${idx + 1}`,
+    amount_usdc,
+    asset,
+    tx_hash: `0x${idx.toString().padStart(64, "0")}`, // Unique transaction hash
+    message: messages[idx % messages.length],
+    ts: new Date(Date.now() - idx * 3600 * 1000).toISOString(), // older as index increases (already sorted newest first!)
+  };
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+  if (!creatorId) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam ? parseInt(limitParam, 10) : 20;
+  if (isNaN(limit) || limit <= 0) {
+    return NextResponse.json({ error: "Invalid limit" }, { status: 400 });
+  }
+
+  const cursorParam = searchParams.get("cursor");
+  const startIndex = cursorParam ? parseInt(cursorParam, 10) : 0;
+  if (isNaN(startIndex) || startIndex < 0) {
+    return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+  }
+
+  const paginatedTips = SEED_TIPS.slice(startIndex, startIndex + limit);
+  const nextCursor =
+    startIndex + limit < SEED_TIPS.length ? (startIndex + limit).toString() : null;
+
+  return NextResponse.json({
+    tips: paginatedTips,
+    next_cursor: nextCursor,
+  });
+}


### PR DESCRIPTION
<!-- Do not delete this PR template. Just edit it to include the required information -->

# Description

<!-- If your PR fixes an open issue, use Closes #999 to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Github Issue Example: Closes #31 -->

Closes #976 
Closes #989 
Closes #985
Closes #994

# Changes proposed

## What were you told to do?

<!-- Write the title of the issue/feature you are working on -->

Implement the following features inside the scoped `app/api/routes-f/` directory:
1. **#976 feat(routes-f): recent tips feed** - Live feed of the most recent tips for a creator supporting cursor pagination and returning a list of tips.
2. **#989 feat(routes-f): subscription badges by tier** - Return subscriber details and stack months subscribed across non-overlapping subscriptions, bundling a default badge SVG.
3. **#985 feat(routes-f): cancel subscription** - Allow a subscriber to cancel auto-renew on a subscription (making it status='cancelled' but active until expires_at), return 403 if unauthorized, and support fetching state.
4. **#994 feat(routes-f): followed categories feed** - Aggregate the live streams in categories followed by a viewer, sorted by viewer count descending.

## What did you do?

<!-- Talk about the things you did eg. files changes, dependencies installed e.t.c -->

- Created [app/api/routes-f/tips/recent/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/tips/recent/route.ts) with index-based cursor pagination and 30 seed tips.
- Created [app/api/routes-f/subscriptions/badges/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/subscriptions/badges/route.ts) to calculate stacked subscriber months across non-overlapping sub intervals.
- Bundled default badge icon in [app/api/routes-f/subscriptions/badges/badge.svg](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/subscriptions/badges/badge.svg) and served it from [app/api/routes-f/subscriptions/badges/svg/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/subscriptions/badges/svg/route.ts).
- Modified the existing [app/api/routes-f/subscriptions/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/subscriptions/route.ts) to include subscription status fields and support retrieval via GET.
- Created [app/api/routes-f/subscriptions/cancel/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/subscriptions/cancel/route.ts) to process subscription cancellation and state checks.
- Created [app/api/routes-f/categories/followed/route.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/categories/followed/route.ts) to return live streams in categories followed by a viewer sorted by viewer count.
- Added comprehensive unit tests in:
  - [app/api/routes-f/__tests__/recent-tips.test.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/__tests__/recent-tips.test.ts)
  - [app/api/routes-f/__tests__/subscription-badges.test.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/__tests__/subscription-badges.test.ts)
  - [app/api/routes-f/__tests__/cancel-subscription.test.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/__tests__/cancel-subscription.test.ts)
  - [app/api/routes-f/__tests__/followed-categories.test.ts](file:///home/c-shells/Desktop/oss/testers/streamfi-frontend/app/api/routes-f/__tests__/followed-categories.test.ts)

# Check List (Check all the applicable boxes)

🚨Please review the [contribution guideline](../CONTRIBUTING.md) for this repository.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Correct; marked as *not* done

[] - Not Correct; syntax error
[ x] - Not Correct; space between the brackets
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the _main branch_ (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->

### Unit Test Execution Output
```bash
PASS app/api/routes-f/__tests__/cancel-subscription.test.ts
PASS app/api/routes-f/__tests__/subscription-badges.test.ts
PASS app/api/routes-f/__tests__/recent-tips.test.ts
PASS app/api/routes-f/__tests__/followed-categories.test.ts
Test Suites: 4 passed, 4 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        0.364 s
