### PR TITLE
feat(routes-f): subscription and chat features

### DIFF
--- a/app/api/routes-f/__tests__/chat-emote-mode.test.ts
+++ b/app/api/routes-f/__tests__/chat-emote-mode.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../chat-emote-mode/check/route";
+
+function makeCheckReq(message: string) {
+  return new NextRequest("http://localhost/api/routes-f/chat-emote-mode/check", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+}
+
+describe("/api/routes-f/chat-emote-mode/check", () => {
+  it("accepts all-emoji message", async () => {
+    const req = makeCheckReq("😀 🎉 👍");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(true);
+    expect(data.would_be_blocked).toBe(false);
+  });
+
+  it("blocks plain text", async () => {
+    const req = makeCheckReq("hello world");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(false);
+    expect(data.would_be_blocked).toBe(true);
+  });
+
+  it("blocks mixed emoji and text", async () => {
+    const req = makeCheckReq("hello 😀 world");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(false);
+    expect(data.would_be_blocked).toBe(true);
+  });
+
+  it("accepts emoji with whitespace", async () => {
+    const req = makeCheckReq("   😀   🎉   👍   ");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(true);
+    expect(data.would_be_blocked).toBe(false);
+  });
+
+  it("rejects empty message", async () => {
+    const req = makeCheckReq("   ");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(false);
+  });
+
+  it("rejects missing message field", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/chat-emote-mode/check", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("handles unicode emoji correctly", async () => {
+    const req = makeCheckReq("❤️ 🚀 🌟");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.is_emote_only).toBe(true);
+  });
+});

--- a/app/api/routes-f/__tests__/subscriber-roster.test.ts
+++ b/app/api/routes-f/__tests__/subscriber-roster.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../subscriber-roster/route";
+
+function makeReq(creatorId: string) {
+  const req = new NextRequest("http://localhost/api/routes-f/subscriber-roster", {
+    method: "GET",
+  });
+  req.nextUrl.searchParams.set("creator_id", creatorId);
+  return req;
+}
+
+describe("/api/routes-f/subscriber-roster", () => {
+  it("returns subscriber list with tier breakdown", async () => {
+    const req = makeReq("creator123");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data).toHaveProperty("subscribers");
+    expect(data).toHaveProperty("by_tier");
+    expect(data).toHaveProperty("monthly_recurring_revenue_usdc");
+    expect(Array.isArray(data.subscribers)).toBe(true);
+  });
+
+  it("computes MRR correctly", async () => {
+    const req = makeReq("creator123");
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(typeof data.monthly_recurring_revenue_usdc).toBe("number");
+    expect(data.monthly_recurring_revenue_usdc).toBeGreaterThanOrEqual(0);
+  });
+
+  it("sorts subscribers by started_at descending", async () => {
+    const req = makeReq("creator123");
+    const res = await GET(req);
+    const data = await res.json();
+
+    if (data.subscribers.length > 1) {
+      for (let i = 0; i < data.subscribers.length - 1; i++) {
+        const current = new Date(data.subscribers[i].started_at);
+        const next = new Date(data.subscribers[i + 1].started_at);
+        expect(current.getTime()).toBeGreaterThanOrEqual(next.getTime());
+      }
+    }
+  });
+
+  it("rejects missing creator_id", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/subscriber-roster");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/__tests__/subscription-tiers.test.ts
+++ b/app/api/routes-f/__tests__/subscription-tiers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST } from "../subscription-tiers/route";
+
+function makeReq(body?: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/subscription-tiers", {
+    method: body ? "POST" : "GET",
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeAuthReq(body: unknown) {
+  const req = new NextRequest("http://localhost/api/routes-f/subscription-tiers", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: "session=mock-token",
+    },
+    body: JSON.stringify(body),
+  });
+  return req;
+}
+
+describe("/api/routes-f/subscription-tiers", () => {
+  describe("POST", () => {
+    it("creates a tier with valid fields", async () => {
+      const req = makeAuthReq({
+        name: "Basic",
+        price_usdc: 5,
+        duration_days: 30,
+        perks: ["badge"],
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(201);
+
+      const data = await res.json();
+      expect(data).toHaveProperty("id");
+      expect(data.name).toBe("Basic");
+      expect(data.price_usdc).toBe(5);
+    });
+
+    it("rejects tier with missing name", async () => {
+      const req = makeAuthReq({
+        price_usdc: 5,
+        duration_days: 30,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects tier with zero price", async () => {
+      const req = makeAuthReq({
+        name: "Free",
+        price_usdc: 0,
+        duration_days: 30,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects tier with negative duration", async () => {
+      const req = makeAuthReq({
+        name: "Bad",
+        price_usdc: 5,
+        duration_days: -1,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("caps at 5 tiers per creator", async () => {
+      for (let i = 0; i < 5; i++) {
+        const req = makeAuthReq({
+          name: `Tier ${i}`,
+          price_usdc: i + 1,
+          duration_days: 30,
+        });
+        const res = await POST(req);
+        expect(res.status).toBe(201);
+      }
+
+      const sixthReq = makeAuthReq({
+        name: "Tier 6",
+        price_usdc: 6,
+        duration_days: 30,
+      });
+      const sixthRes = await POST(sixthReq);
+      expect(sixthRes.status).toBe(400);
+
+      const data = await sixthRes.json();
+      expect(data.error).toContain("Cannot exceed 5");
+    });
+  });
+
+  describe("GET", () => {
+    it("lists tiers for creator", async () => {
+      const req = makeReq();
+      req.nextUrl.searchParams.set("creator_id", "user123");
+
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toHaveProperty("tiers");
+      expect(Array.isArray(data.tiers)).toBe(true);
+    });
+
+    it("rejects missing creator_id", async () => {
+      const req = makeReq();
+      const res = await GET(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/tips-anonymous.test.ts
+++ b/app/api/routes-f/__tests__/tips-anonymous.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../tips/route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/tips", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/tips", () => {
+  describe("POST", () => {
+    it("toggles anonymous flag on a tip", async () => {
+      const req = makeReq({
+        tip_id: "tip123",
+        anonymous: true,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toHaveProperty("updated");
+      expect(data.updated).toBe(true);
+      expect(data.tip).toHaveProperty("anonymous");
+    });
+
+    it("accepts boolean toggle to false", async () => {
+      const req = makeReq({
+        tip_id: "tip456",
+        anonymous: false,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.updated).toBe(true);
+      expect(data.tip.anonymous).toBe(false);
+    });
+
+    it("rejects missing tip_id", async () => {
+      const req = makeReq({
+        anonymous: true,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing anonymous field", async () => {
+      const req = makeReq({
+        tip_id: "tip789",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects non-boolean anonymous", async () => {
+      const req = makeReq({
+        tip_id: "tip789",
+        anonymous: "yes",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for non-existent tip", async () => {
+      const req = makeReq({
+        tip_id: "nonexistent",
+        anonymous: true,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/app/api/routes-f/chat-emote-mode/[stream_id]/route.ts
+++ b/app/api/routes-f/chat-emote-mode/[stream_id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * DELETE /api/routes-f/chat-emote-mode/[stream_id]
+ * Disable emote-only mode for a stream
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ stream_id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { stream_id } = await params;
+
+  try {
+    const { rows: streamRows } = await sql`
+      SELECT creator_id FROM streams WHERE id = ${stream_id}
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json(
+        { error: "Stream not found" },
+        { status: 404 }
+      );
+    }
+
+    if (streamRows[0].creator_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`
+      UPDATE emote_mode_settings
+      SET enabled = false, updated_at = CURRENT_TIMESTAMP
+      WHERE stream_id = ${stream_id}
+    `;
+
+    return NextResponse.json({ enabled: false, stream_id });
+  } catch (error) {
+    console.error("[Chat Emote Mode API] Error disabling mode:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/chat-emote-mode/check/route.ts
+++ b/app/api/routes-f/chat-emote-mode/check/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "../../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const checkMessageSchema = z.object({
+  message: z.string(),
+});
+
+function isEmoteOnly(message: string): boolean {
+  const trimmed = message.trim();
+  if (trimmed.length === 0) return false;
+
+  for (const char of trimmed) {
+    const code = char.codePointAt(0);
+    if (!code) continue;
+
+    if (code < 0x1F000) {
+      if (!/[\p{Emoji}]/u.test(char)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * POST /api/routes-f/chat-emote-mode/check
+ * Check if a message would be blocked by emote-only mode
+ */
+export async function POST(req: NextRequest) {
+  const bodyResult = await validateBody(req, checkMessageSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { message } = bodyResult.data;
+  const isEmote = isEmoteOnly(message);
+
+  return NextResponse.json({
+    is_emote_only: isEmote,
+    would_be_blocked: !isEmote,
+  });
+}

--- a/app/api/routes-f/chat-emote-mode/route.ts
+++ b/app/api/routes-f/chat-emote-mode/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const enableEmoteModeSchema = z.object({
+  stream_id: z.string(),
+});
+
+function isEmoteOnly(message: string): boolean {
+  const trimmed = message.trim();
+  if (trimmed.length === 0) return false;
+
+  for (const char of trimmed) {
+    const code = char.codePointAt(0);
+    if (!code) continue;
+
+    if (code < 0x1F000) {
+      if (!/[\p{Emoji}]/u.test(char)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * POST /api/routes-f/chat-emote-mode
+ * Enable emote-only mode for a stream
+ */
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, enableEmoteModeSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { stream_id } = bodyResult.data;
+
+  try {
+    const { rows: streamRows } = await sql`
+      SELECT creator_id FROM streams WHERE id = ${stream_id}
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json(
+        { error: "Stream not found" },
+        { status: 404 }
+      );
+    }
+
+    if (streamRows[0].creator_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`
+      INSERT INTO emote_mode_settings (stream_id, enabled, created_at)
+      VALUES (${stream_id}, true, CURRENT_TIMESTAMP)
+      ON CONFLICT (stream_id)
+      DO UPDATE SET enabled = true, updated_at = CURRENT_TIMESTAMP
+    `;
+
+    return NextResponse.json({ enabled: true, stream_id });
+  } catch (error) {
+    console.error("[Chat Emote Mode API] Error enabling mode:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+export { isEmoteOnly };

--- a/app/api/routes-f/subscriber-roster/route.ts
+++ b/app/api/routes-f/subscriber-roster/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { validateQuery } from "../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/routes-f/subscriber-roster?creator_id=...
+ * Get subscriber roster for a creator with tier breakdown and MRR
+ */
+export async function GET(req: NextRequest) {
+  const queryResult = validateQuery(
+    req.nextUrl.searchParams,
+    z.object({ creator_id: z.string() })
+  );
+
+  if (queryResult instanceof NextResponse) {
+    return queryResult;
+  }
+
+  const { creator_id } = queryResult.data;
+
+  try {
+    const { rows: subscribers } = await sql`
+      SELECT
+        id,
+        user_id,
+        subscription_tier_id,
+        started_at,
+        end_date,
+        active
+      FROM subscriptions
+      WHERE creator_id = ${creator_id} AND active = true
+      ORDER BY started_at DESC
+    `;
+
+    const { rows: tierRows } = await sql`
+      SELECT id, price_usdc FROM subscription_tiers
+      WHERE creator_id = ${creator_id} AND active = true
+    `;
+
+    const tierMap = new Map(tierRows.map((t: any) => [t.id, t.price_usdc]));
+
+    const byTier: Record<string, number> = {};
+    let totalMrrUsdc = 0;
+
+    for (const sub of subscribers) {
+      const tierId = sub.subscription_tier_id;
+      byTier[tierId] = (byTier[tierId] || 0) + 1;
+
+      const tierPrice = tierMap.get(tierId) || 0;
+      totalMrrUsdc += tierPrice;
+    }
+
+    const monthlyRecurringRevenue = Math.round(totalMrrUsdc * 100) / 100;
+
+    return NextResponse.json({
+      subscribers,
+      by_tier: byTier,
+      monthly_recurring_revenue_usdc: monthlyRecurringRevenue,
+    });
+  } catch (error) {
+    console.error("[Subscriber Roster API] Error fetching roster:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/subscription-tiers/[id]/route.ts
+++ b/app/api/routes-f/subscription-tiers/[id]/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "../../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const updateTierSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  price_usdc: z.number().positive().optional(),
+  duration_days: z.number().int().positive().optional(),
+  perks: z.array(z.string()).optional(),
+});
+
+/**
+ * PATCH /api/routes-f/subscription-tiers/[id]
+ * Update a subscription tier
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, updateTierSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { id } = await params;
+  const { name, price_usdc, duration_days, perks } = bodyResult.data;
+
+  try {
+    const { rows: tierRows } = await sql`
+      SELECT creator_id FROM subscription_tiers WHERE id = ${id}
+    `;
+
+    if (tierRows.length === 0) {
+      return NextResponse.json({ error: "Tier not found" }, { status: 404 });
+    }
+
+    if (tierRows[0].creator_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (
+      name === undefined &&
+      price_usdc === undefined &&
+      duration_days === undefined &&
+      perks === undefined
+    ) {
+      return NextResponse.json(
+        { error: "No fields to update" },
+        { status: 400 }
+      );
+    }
+
+    const { rows: currentRows } = await sql`
+      SELECT name, price_usdc, duration_days, perks FROM subscription_tiers WHERE id = ${id}
+    `;
+    const current = currentRows[0];
+
+    const { rows } = await sql`
+      UPDATE subscription_tiers
+      SET
+        name = ${name ?? current.name},
+        price_usdc = ${price_usdc ?? current.price_usdc},
+        duration_days = ${duration_days ?? current.duration_days},
+        perks = ${JSON.stringify(perks ?? current.perks)},
+        updated_at = CURRENT_TIMESTAMP
+      WHERE id = ${id}
+      RETURNING id, name, price_usdc, duration_days, perks, active, created_at
+    `;
+
+    return NextResponse.json(rows[0]);
+  } catch (error) {
+    console.error("[Subscription Tiers API] Error updating tier:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/routes-f/subscription-tiers/[id]
+ * Soft-delete a subscription tier
+ */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { id } = await params;
+
+  try {
+    const { rows: tierRows } = await sql`
+      SELECT creator_id FROM subscription_tiers WHERE id = ${id}
+    `;
+
+    if (tierRows.length === 0) {
+      return NextResponse.json({ error: "Tier not found" }, { status: 404 });
+    }
+
+    if (tierRows[0].creator_id !== session.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await sql`
+      UPDATE subscription_tiers
+      SET active = false, updated_at = CURRENT_TIMESTAMP
+      WHERE id = ${id}
+    `;
+
+    return NextResponse.json({ message: "Tier deleted" });
+  } catch (error) {
+    console.error("[Subscription Tiers API] Error deleting tier:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/subscription-tiers/route.ts
+++ b/app/api/routes-f/subscription-tiers/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateQuery, validateBody } from "../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const tierSchema = z.object({
+  name: z.string().min(1).max(100),
+  price_usdc: z.number().positive(),
+  duration_days: z.number().int().positive(),
+  perks: z.array(z.string()).default([]),
+});
+
+const createTierSchema = tierSchema;
+const updateTierSchema = tierSchema.partial().omit({ perks: true }).extend({
+  perks: z.array(z.string()).optional(),
+});
+
+/**
+ * GET /api/routes-f/subscription-tiers?creator_id=...
+ * List subscription tiers for a creator
+ */
+export async function GET(req: NextRequest) {
+  const queryResult = validateQuery(
+    req.nextUrl.searchParams,
+    z.object({ creator_id: z.string() })
+  );
+
+  if (queryResult instanceof NextResponse) {
+    return queryResult;
+  }
+
+  const { creator_id } = queryResult.data;
+
+  try {
+    const { rows } = await sql`
+      SELECT id, name, price_usdc, duration_days, perks, active, created_at
+      FROM subscription_tiers
+      WHERE creator_id = ${creator_id} AND active = true
+      ORDER BY created_at ASC
+    `;
+
+    return NextResponse.json({ tiers: rows });
+  } catch (error) {
+    console.error("[Subscription Tiers API] Error fetching tiers:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/routes-f/subscription-tiers
+ * Create a new subscription tier for the authenticated creator
+ */
+export async function POST(req: NextRequest) {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, createTierSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { name, price_usdc, duration_days, perks } = bodyResult.data;
+
+  try {
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*) as count
+      FROM subscription_tiers
+      WHERE creator_id = ${session.userId} AND active = true
+    `;
+
+    if (countRows[0].count >= 5) {
+      return NextResponse.json(
+        { error: "Cannot exceed 5 active tiers per creator" },
+        { status: 400 }
+      );
+    }
+
+    const { rows } = await sql`
+      INSERT INTO subscription_tiers (
+        creator_id, name, price_usdc, duration_days, perks, active, created_at
+      )
+      VALUES (
+        ${session.userId},
+        ${name},
+        ${price_usdc},
+        ${duration_days},
+        ${JSON.stringify(perks)},
+        true,
+        CURRENT_TIMESTAMP
+      )
+      RETURNING id, name, price_usdc, duration_days, perks, active, created_at
+    `;
+
+    return NextResponse.json(rows[0], { status: 201 });
+  } catch (error) {
+    console.error("[Subscription Tiers API] Error creating tier:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/routes-f/tips/route.ts
+++ b/app/api/routes-f/tips/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { validateBody } from "../_lib/validate";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const toggleAnonymousSchema = z.object({
+  tip_id: z.string(),
+  anonymous: z.boolean(),
+});
+
+/**
+ * POST /api/routes-f/tips
+ * Toggle anonymous flag on a tip
+ */
+export async function POST(req: NextRequest) {
+  const bodyResult = await validateBody(req, toggleAnonymousSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { tip_id, anonymous } = bodyResult.data;
+
+  try {
+    const { rows } = await sql`
+      UPDATE tips
+      SET anonymous = ${anonymous}, updated_at = CURRENT_TIMESTAMP
+      WHERE id = ${tip_id}
+      RETURNING id, anonymous, updated_at
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Tip not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ updated: true, tip: rows[0] });
+  } catch (error) {
+    console.error("[Tips API] Error updating tip:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## What
Add four new features to the routes-f API: subscription tier management, subscriber roster tracking, anonymous tipping, and emote-only chat mode.

## Issues Resolved
Closes #980
Closes #973
Closes #988
Closes #983

## Changes

### #983 - Subscription tier management
CRUD endpoints for creator-defined subscription tiers with name, price, duration, and perks. Includes a 5-tier limit per creator.

### #988 - Creator subscriber roster
GET endpoint returning subscriber list, tier breakdown counts, and calculated monthly recurring revenue.

### #980 - Anonymous tipping toggle
POST endpoint to toggle the anonymous flag on tips, masking the tipper's identity in overlays.

### #973 - Emote-only chat mode
Enable/disable endpoints plus a message validation endpoint to check if content meets emote-only requirements.