### PR TITLE
feat(routes-f): add mute/unmute creator route

### DIFF
--- a/app/api/routes-f/mute-creator/__tests__/route.test.ts
+++ b/app/api/routes-f/mute-creator/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { GET, POST, DELETE } from "../route";
+import { __resetMuteStore } from "../_lib/store";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/mute-creator";
+
+function req(method: string, body?: object, search?: string) {
+  const url = search ? `${BASE}?${search}` : BASE;
+  return new NextRequest(url, {
+    method,
+    ...(body
+      ? { body: JSON.stringify(body), headers: { "Content-Type": "application/json" } }
+      : {}),
+  });
+}
+
+beforeEach(() => {
+  __resetMuteStore();
+});
+
+describe("POST /mute-creator — mute", () => {
+  it("mutes a creator and returns muted_at", async () => {
+    const res = await POST(req("POST", { follower_id: "user-1", creator_id: "creator-1" }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(typeof body.muted_at).toBe("string");
+    expect(new Date(body.muted_at).getTime()).not.toBeNaN();
+  });
+
+  it("returns 409 when already muted", async () => {
+    await POST(req("POST", { follower_id: "user-1", creator_id: "creator-1" }));
+    const res = await POST(req("POST", { follower_id: "user-1", creator_id: "creator-1" }));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/already muted/i);
+  });
+
+  it("returns 400 when a user tries to mute themselves", async () => {
+    const res = await POST(req("POST", { follower_id: "user-1", creator_id: "user-1" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/cannot mute themselves/i);
+  });
+
+  it("returns 400 when follower_id is missing", async () => {
+    const res = await POST(req("POST", { creator_id: "creator-1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await POST(req("POST", { follower_id: "user-1" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /mute-creator — unmute", () => {
+  it("unmutes a previously muted creator", async () => {
+    await POST(req("POST", { follower_id: "user-1", creator_id: "creator-1" }));
+    const res = await DELETE(req("DELETE", { follower_id: "user-1", creator_id: "creator-1" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).message).toMatch(/unmuted/i);
+  });
+
+  it("returns 404 when the mute record does not exist", async () => {
+    const res = await DELETE(req("DELETE", { follower_id: "user-1", creator_id: "ghost-creator" }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/not found/i);
+  });
+});
+
+describe("GET /mute-creator — list muted creators", () => {
+  it("returns an empty list when no creators are muted", async () => {
+    const res = await GET(req("GET", undefined, "follower_id=user-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.muted).toHaveLength(0);
+    expect(body.count).toBe(0);
+  });
+
+  it("lists all muted creators for the given follower", async () => {
+    await POST(req("POST", { follower_id: "user-1", creator_id: "creator-a" }));
+    await POST(req("POST", { follower_id: "user-1", creator_id: "creator-b" }));
+    await POST(req("POST", { follower_id: "user-2", creator_id: "creator-a" }));
+
+    const res = await GET(req("GET", undefined, "follower_id=user-1"));
+    const body = await res.json();
+
+    expect(body.count).toBe(2);
+    expect(body.muted.map((r: { creator_id: string }) => r.creator_id).sort()).toEqual([
+      "creator-a",
+      "creator-b",
+    ]);
+  });
+
+  it("does not include creators muted after an unmute", async () => {
+    await POST(req("POST", { follower_id: "user-1", creator_id: "creator-a" }));
+    await DELETE(req("DELETE", { follower_id: "user-1", creator_id: "creator-a" }));
+
+    const res = await GET(req("GET", undefined, "follower_id=user-1"));
+    expect((await res.json()).count).toBe(0);
+  });
+
+  it("returns 400 when follower_id query param is missing", async () => {
+    const res = await GET(req("GET"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/mute-creator/_lib/store.ts
+++ b/app/api/routes-f/mute-creator/_lib/store.ts
@@ -1,0 +1,53 @@
+import type { MuteRecord } from "./types";
+
+// Keyed by `${follower_id}:${creator_id}` for O(1) lookups
+const mutes = new Map<string, MuteRecord>();
+
+function muteKey(followerId: string, creatorId: string): string {
+  return `${followerId}:${creatorId}`;
+}
+
+export function muteCreator(
+  followerId: string,
+  creatorId: string,
+): { ok: true; record: MuteRecord } | { ok: false; error: string; status: number } {
+  if (followerId === creatorId) {
+    return { ok: false, error: "A user cannot mute themselves.", status: 400 };
+  }
+
+  const key = muteKey(followerId, creatorId);
+  if (mutes.has(key)) {
+    return { ok: false, error: "Creator is already muted.", status: 409 };
+  }
+
+  const record: MuteRecord = {
+    follower_id: followerId,
+    creator_id: creatorId,
+    muted_at: new Date().toISOString(),
+  };
+
+  mutes.set(key, record);
+  return { ok: true, record };
+}
+
+export function unmuteCreator(
+  followerId: string,
+  creatorId: string,
+): { ok: true } | { ok: false; error: string; status: number } {
+  const key = muteKey(followerId, creatorId);
+  if (!mutes.has(key)) {
+    return { ok: false, error: "Mute record not found.", status: 404 };
+  }
+  mutes.delete(key);
+  return { ok: true };
+}
+
+export function listMutedCreators(followerId: string): MuteRecord[] {
+  return Array.from(mutes.values())
+    .filter((r) => r.follower_id === followerId)
+    .sort((a, b) => a.muted_at.localeCompare(b.muted_at));
+}
+
+export function __resetMuteStore(): void {
+  mutes.clear();
+}

--- a/app/api/routes-f/mute-creator/_lib/types.ts
+++ b/app/api/routes-f/mute-creator/_lib/types.ts
@@ -1,0 +1,5 @@
+export interface MuteRecord {
+  follower_id: string;
+  creator_id: string;
+  muted_at: string;
+}

--- a/app/api/routes-f/mute-creator/route.ts
+++ b/app/api/routes-f/mute-creator/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { muteCreator, unmuteCreator, listMutedCreators } from "./_lib/store";
+
+// GET /api/routes-f/mute-creator?follower_id=<id>
+export async function GET(req: NextRequest) {
+  const followerId = req.nextUrl.searchParams.get("follower_id");
+
+  if (!followerId || followerId.trim().length === 0) {
+    return NextResponse.json(
+      { error: "follower_id query parameter is required." },
+      { status: 400 },
+    );
+  }
+
+  const muted = listMutedCreators(followerId.trim());
+  return NextResponse.json({ muted, count: muted.length });
+}
+
+// POST /api/routes-f/mute-creator
+// Body: { follower_id, creator_id }
+export async function POST(req: NextRequest) {
+  let body: { follower_id?: unknown; creator_id?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { follower_id, creator_id } = body;
+
+  if (typeof follower_id !== "string" || follower_id.trim().length === 0) {
+    return NextResponse.json(
+      { error: "follower_id is required and must be a non-empty string." },
+      { status: 400 },
+    );
+  }
+
+  if (typeof creator_id !== "string" || creator_id.trim().length === 0) {
+    return NextResponse.json(
+      { error: "creator_id is required and must be a non-empty string." },
+      { status: 400 },
+    );
+  }
+
+  const result = muteCreator(follower_id.trim(), creator_id.trim());
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ muted_at: result.record.muted_at }, { status: 201 });
+}
+
+// DELETE /api/routes-f/mute-creator
+// Body: { follower_id, creator_id }
+export async function DELETE(req: NextRequest) {
+  let body: { follower_id?: unknown; creator_id?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { follower_id, creator_id } = body;
+
+  if (typeof follower_id !== "string" || follower_id.trim().length === 0) {
+    return NextResponse.json(
+      { error: "follower_id is required and must be a non-empty string." },
+      { status: 400 },
+    );
+  }
+
+  if (typeof creator_id !== "string" || creator_id.trim().length === 0) {
+    return NextResponse.json(
+      { error: "creator_id is required and must be a non-empty string." },
+      { status: 400 },
+    );
+  }
+
+  const result = unmuteCreator(follower_id.trim(), creator_id.trim());
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ message: "Creator unmuted successfully." });
+}


### PR DESCRIPTION
Closes #982
Closes #987
Closes #991
Closes #993

## What was done

Added `app/api/routes-f/mute-creator/` implementing the full mute/unmute creator feature as specified in #991. All files are scoped entirely within `routes-f/` with no imports from or modifications to the rest of the app.

### `_lib/types.ts`

Defines `MuteRecord`:
```ts
{ follower_id: string; creator_id: string; muted_at: string }
```

### `_lib/store.ts`

In-memory `Map` store keyed by a composite `follower_id:creator_id` string for O(1) lookups on mute and unmute operations.

- `muteCreator(followerId, creatorId)` — creates a mute record; returns `409` if already muted, `400` if a user attempts to mute themselves
- `unmuteCreator(followerId, creatorId)` — removes the mute record; returns `404` if no mute exists
- `listMutedCreators(followerId)` — returns all muted creators for a follower sorted by `muted_at` ascending
- `__resetMuteStore()` — clears the store between tests

### `route.ts`

Three Next.js route handlers:

| Method | Body / Query | Success | Error cases |
|--------|-------------|---------|-------------|
| `POST` | `{ follower_id, creator_id }` | `201 { muted_at }` | `400` missing fields / self-mute, `409` duplicate |
| `DELETE` | `{ follower_id, creator_id }` | `200 { message }` | `400` missing fields, `404` not muted |
| `GET` | `?follower_id=<id>` | `200 { muted[], count }` | `400` missing param |

### `__tests__/route.test.ts`

9 tests covering all acceptance criteria:

- Mute success → `201` with valid ISO `muted_at`
- Duplicate mute → `409` with "already muted" message
- Self-mute → `400` with descriptive error
- Missing `follower_id` / `creator_id` → `400`
- Unmute success → `200` with confirmation message
- Unmute non-existent record → `404`
- Empty list when nothing is muted → `{ count: 0 }`
- Multi-creator list scoped to requesting follower only
- List reflects unmutes (removed entry not returned)