### PR TITLE
feat(routes-f): viewer watch history, tip recap, session cap, stream reminders

### DIFF
--- a/app/api/routes-f/tip-recap/__tests__/route.test.ts
+++ b/app/api/routes-f/tip-recap/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+import { sql } from "@vercel/postgres";
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/app/api/routes-f/_lib/validate", () => ({
+  validateQuery: jest.fn((params: URLSearchParams, schema: any) => {
+    const obj = Object.fromEntries(params.entries());
+    const result = schema.safeParse(obj);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid query", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+
+function makeGetRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/tip-recap");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url) as any;
+}
+
+describe("Tip Recap Card API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/routes-f/tip-recap", () => {
+    it("returns 400 for missing tip_id", async () => {
+      const res = await GET(makeGetRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid tip_id", async () => {
+      const res = await GET(makeGetRequest({ tip_id: "not-a-uuid" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for unknown tip", async () => {
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+
+      const res = await GET(makeGetRequest({ tip_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe("Tip not found");
+    });
+
+    it("returns tip recap payload for a known tip", async () => {
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            tip_id: "tip-1",
+            creator_id: "creator-1",
+            tipper_id: "tipper-1",
+            amount: "10.5",
+            asset: "XLM",
+            message: "Great stream!",
+            is_anonymous: false,
+            created_at: "2025-06-01T12:00:00Z",
+            creator_username: "alice",
+            creator_avatar: "alice.png",
+            tipper_username: "bob",
+            tipper_avatar: "bob.png",
+          },
+        ],
+      });
+
+      const res = await GET(makeGetRequest({ tip_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.tip_id).toBe("tip-1");
+      expect(body.creator.username).toBe("alice");
+      expect(body.tipper.username).toBe("bob");
+      expect(body.tipper.anonymous).toBe(false);
+      expect(body.amount).toBe("10.5");
+      expect(body.asset).toBe("XLM");
+      expect(body.message).toBe("Great stream!");
+      expect(body.image_meta).toEqual({ width: 1200, height: 630, format: "png" });
+    });
+
+    it("handles anonymous tips by hiding tipper details", async () => {
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            tip_id: "tip-2",
+            creator_id: "creator-1",
+            tipper_id: "tipper-2",
+            amount: "5.0",
+            asset: "USDC",
+            message: null,
+            is_anonymous: true,
+            created_at: "2025-06-01T12:00:00Z",
+            creator_username: "alice",
+            creator_avatar: "alice.png",
+            tipper_username: "anon",
+            tipper_avatar: "anon.png",
+          },
+        ],
+      });
+
+      const res = await GET(makeGetRequest({ tip_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.tipper.anonymous).toBe(true);
+      expect(body.tipper.user_id).toBeNull();
+      expect(body.tipper.username).toBeNull();
+      expect(body.tipper.avatar).toBeNull();
+      expect(body.message).toBeNull();
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await GET(makeGetRequest({ tip_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/app/api/routes-f/tip-recap/route.ts
+++ b/app/api/routes-f/tip-recap/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const getQuerySchema = z.object({
+  tip_id: z.string().uuid(),
+});
+
+type TipRecapPayload = {
+  tip_id: string;
+  creator: {
+    user_id: string;
+    username: string | null;
+    avatar: string | null;
+  };
+  tipper: {
+    user_id: string | null;
+    username: string | null;
+    avatar: string | null;
+    anonymous: boolean;
+  };
+  amount: string;
+  asset: string;
+  message: string | null;
+  image_meta: {
+    width: number;
+    height: number;
+    format: string;
+  };
+  created_at: string;
+};
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    getQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { tip_id } = queryResult.data;
+
+  try {
+    const { rows: tipRows } = await sql`
+      SELECT
+        t.id AS tip_id,
+        t.creator_id,
+        t.tipper_id,
+        t.amount,
+        t.asset,
+        t.message,
+        t.is_anonymous,
+        t.created_at,
+        u_creator.username  AS creator_username,
+        u_creator.avatar    AS creator_avatar,
+        u_tipper.username   AS tipper_username,
+        u_tipper.avatar     AS tipper_avatar
+      FROM tip_transactions t
+      LEFT JOIN users u_creator ON u_creator.id = t.creator_id
+      LEFT JOIN users u_tipper  ON u_tipper.id = t.tipper_id
+      WHERE t.id = ${tip_id}
+      LIMIT 1
+    `;
+
+    if (tipRows.length === 0) {
+      return NextResponse.json(
+        { error: "Tip not found" },
+        { status: 404 }
+      );
+    }
+
+    const tip = tipRows[0];
+    const isAnonymous = tip.is_anonymous === true;
+
+    const payload: TipRecapPayload = {
+      tip_id: tip.tip_id,
+      creator: {
+        user_id: tip.creator_id,
+        username: tip.creator_username,
+        avatar: tip.creator_avatar,
+      },
+      tipper: isAnonymous
+        ? {
+            user_id: null,
+            username: null,
+            avatar: null,
+            anonymous: true,
+          }
+        : {
+            user_id: tip.tipper_id,
+            username: tip.tipper_username,
+            avatar: tip.tipper_avatar,
+            anonymous: false,
+          },
+      amount: String(tip.amount),
+      asset: tip.asset ?? "XLM",
+      message: tip.message ?? null,
+      image_meta: {
+        width: 1200,
+        height: 630,
+        format: "png",
+      },
+      created_at: tip.created_at,
+    };
+
+    return NextResponse.json(payload, {
+      headers: { "Cache-Control": "public, max-age=3600" },
+    });
+  } catch (error) {
+    console.error("[routes-f tip-recap GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tip recap" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/viewer/reminders/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer/reminders/__tests__/route.test.ts
@@ -1,0 +1,222 @@
+import { sql } from "@vercel/postgres";
+import { GET, POST, DELETE } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/app/api/routes-f/_lib/validate", () => ({
+  validateQuery: jest.fn((params: URLSearchParams, schema: any) => {
+    const obj = Object.fromEntries(params.entries());
+    const result = schema.safeParse(obj);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid query", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+  validateBody: jest.fn(async (req: Request, schema: any) => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 });
+    }
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid request body", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+
+const UUID1 = "550e8400-e29b-41d4-a716-446655440000";
+const UUID2 = "550e8400-e29b-41d4-a716-446655440001";
+const UUID3 = "550e8400-e29b-41d4-a716-446655440002";
+
+function makeGetRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/viewer/reminders");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url) as any;
+}
+
+function makePostRequest(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/viewer/reminders", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+function makeDeleteRequest(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/viewer/reminders", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("Scheduled Stream Reminder API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/routes-f/viewer/reminders", () => {
+    it("returns 400 for missing viewer_id", async () => {
+      const res = await GET(makeGetRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns upcoming reminders", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "r1",
+            viewer_id: UUID1,
+            scheduled_stream_id: UUID2,
+            fires_at: "2025-06-02T18:00:00Z",
+            created_at: "2025-06-01T12:00:00Z",
+          },
+        ],
+      });
+
+      const res = await GET(makeGetRequest({ viewer_id: UUID1 }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.reminders).toHaveLength(1);
+      expect(body.reminders[0].scheduled_stream_id).toBe(UUID2);
+    });
+
+    it("returns empty list when no reminders", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+
+      const res = await GET(makeGetRequest({ viewer_id: UUID1 }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.reminders).toHaveLength(0);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await GET(makeGetRequest({ viewer_id: UUID1 }));
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("POST /api/routes-f/viewer/reminders", () => {
+    it("sets a reminder for a scheduled stream", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [{ id: UUID2, scheduled_at: "2025-06-02T18:00:00Z" }],
+      });
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "r1",
+            viewer_id: UUID1,
+            scheduled_stream_id: UUID2,
+            fires_at: "2025-06-02T18:00:00Z",
+            created_at: "2025-06-01T12:00:00Z",
+          },
+        ],
+      });
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID2,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.reminder_set).toBe(true);
+      expect(body.fires_at).toBe("2025-06-02T18:00:00Z");
+    });
+
+    it("returns 404 for unknown scheduled stream", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID3,
+      }));
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe("Scheduled stream not found");
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await POST(makePostRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID2,
+      }));
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("DELETE /api/routes-f/viewer/reminders", () => {
+    it("removes a reminder", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rowCount: 1 });
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID2,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.removed).toBe(true);
+    });
+
+    it("returns removed=false for non-existent reminder", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rowCount: 0 });
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID3,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.removed).toBe(false);
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await DELETE(makeDeleteRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        scheduled_stream_id: UUID2,
+      }));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/app/api/routes-f/viewer/reminders/route.ts
+++ b/app/api/routes-f/viewer/reminders/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const getQuerySchema = z.object({
+  viewer_id: z.string().uuid(),
+});
+
+const postBodySchema = z.object({
+  viewer_id: z.string().uuid(),
+  scheduled_stream_id: z.string().uuid(),
+});
+
+const deleteBodySchema = z.object({
+  viewer_id: z.string().uuid(),
+  scheduled_stream_id: z.string().uuid(),
+});
+
+async function ensureRemindersTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS stream_reminders (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      viewer_id UUID NOT NULL,
+      scheduled_stream_id UUID NOT NULL,
+      fires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (viewer_id, scheduled_stream_id)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_stream_reminders_viewer_fires
+    ON stream_reminders (viewer_id, fires_at DESC)
+  `;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    getQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { viewer_id } = queryResult.data;
+
+  try {
+    await ensureRemindersTable();
+
+    const { rows } = await sql`
+      SELECT
+        r.id,
+        r.viewer_id,
+        r.scheduled_stream_id,
+        r.fires_at,
+        r.created_at
+      FROM stream_reminders r
+      WHERE r.viewer_id = ${viewer_id}
+        AND r.fires_at > NOW()
+      ORDER BY r.fires_at ASC
+    `;
+
+    return NextResponse.json({ reminders: rows });
+  } catch (error) {
+    console.error("[routes-f viewer/reminders GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch reminders" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, postBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { viewer_id, scheduled_stream_id } = bodyResult.data;
+
+  try {
+    await ensureRemindersTable();
+
+    const { rows: streamRows } = await sql`
+      SELECT id, scheduled_at
+      FROM scheduled_streams
+      WHERE id = ${scheduled_stream_id}
+      LIMIT 1
+    `;
+
+    if (streamRows.length === 0) {
+      return NextResponse.json(
+        { error: "Scheduled stream not found" },
+        { status: 404 }
+      );
+    }
+
+    const firesAt = streamRows[0].scheduled_at;
+
+    const { rows } = await sql`
+      INSERT INTO stream_reminders (viewer_id, scheduled_stream_id, fires_at, created_at)
+      VALUES (${viewer_id}, ${scheduled_stream_id}, ${firesAt}, NOW())
+      ON CONFLICT (viewer_id, scheduled_stream_id)
+      DO UPDATE SET fires_at = EXCLUDED.fires_at
+      RETURNING id, viewer_id, scheduled_stream_id, fires_at, created_at
+    `;
+
+    return NextResponse.json({
+      reminder_set: true,
+      fires_at: rows[0].fires_at,
+      reminder: rows[0],
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/reminders POST]", error);
+    return NextResponse.json(
+      { error: "Failed to set reminder" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, deleteBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { viewer_id, scheduled_stream_id } = bodyResult.data;
+
+  try {
+    await ensureRemindersTable();
+
+    const { rowCount } = await sql`
+      DELETE FROM stream_reminders
+      WHERE viewer_id = ${viewer_id} AND scheduled_stream_id = ${scheduled_stream_id}
+    `;
+
+    return NextResponse.json({
+      removed: (rowCount ?? 0) > 0,
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/reminders DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to remove reminder" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/viewer/sessions/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer/sessions/__tests__/route.test.ts
@@ -1,0 +1,212 @@
+import { sql } from "@vercel/postgres";
+import { GET, POST, DELETE } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/app/api/routes-f/_lib/validate", () => ({
+  validateQuery: jest.fn((params: URLSearchParams, schema: any) => {
+    const obj = Object.fromEntries(params.entries());
+    const result = schema.safeParse(obj);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid query", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+  validateBody: jest.fn(async (req: Request, schema: any) => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 });
+    }
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid request body", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+
+const UUID1 = "550e8400-e29b-41d4-a716-446655440000";
+const UUID2 = "550e8400-e29b-41d4-a716-446655440001";
+const UUID3 = "550e8400-e29b-41d4-a716-446655440002";
+const UUID4 = "550e8400-e29b-41d4-a716-446655440003";
+
+function makeGetRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/viewer/sessions");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url) as any;
+}
+
+function makePostRequest(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/viewer/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+function makeDeleteRequest(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/viewer/sessions", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("Viewer Concurrent Sessions API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/routes-f/viewer/sessions", () => {
+    it("returns 400 for missing viewer_id", async () => {
+      const res = await GET(makeGetRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns active sessions", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          { id: "s1", viewer_id: UUID1, session_id: UUID2, playback_id: "pb-1", registered_at: "2025-06-01T12:00:00Z" },
+        ],
+      });
+
+      const res = await GET(makeGetRequest({ viewer_id: UUID1 }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.active_sessions).toHaveLength(1);
+      expect(body.limit).toBe(3);
+    });
+  });
+
+  describe("POST /api/routes-f/viewer/sessions", () => {
+    it("registers a new session", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+      sqlMock.mockResolvedValueOnce({ rows: [{ total: 0 }] });
+      sqlMock.mockResolvedValueOnce({});
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        session_id: UUID2,
+        playback_id: "pb-1",
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.active_sessions).toBe(1);
+      expect(body.limit).toBe(3);
+    });
+
+    it("returns existing session info if session already registered", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [{ id: "existing" }] });
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        session_id: UUID2,
+        playback_id: "pb-1",
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.message).toBe("Session already registered");
+    });
+
+    it("rejects with 429 when concurrent limit reached", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+      sqlMock.mockResolvedValueOnce({ rows: [{ total: 3 }] });
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        session_id: UUID4,
+        playback_id: "pb-4",
+      }));
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.error).toBe("Concurrent session limit reached");
+      expect(body.active_sessions).toBe(3);
+      expect(body.limit).toBe(3);
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await POST(makePostRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await POST(makePostRequest({
+        viewer_id: UUID1,
+        session_id: UUID2,
+        playback_id: "pb-1",
+      }));
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("DELETE /api/routes-f/viewer/sessions", () => {
+    it("removes a session", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rowCount: 1 });
+      sqlMock.mockResolvedValueOnce({ rows: [{ total: 0 }] });
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        session_id: UUID2,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.removed).toBe(true);
+      expect(body.active_sessions).toBe(0);
+    });
+
+    it("returns removed=false for non-existent session", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rowCount: 0 });
+      sqlMock.mockResolvedValueOnce({ rows: [{ total: 1 }] });
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        session_id: UUID3,
+      }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.removed).toBe(false);
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await DELETE(makeDeleteRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await DELETE(makeDeleteRequest({
+        viewer_id: UUID1,
+        session_id: UUID2,
+      }));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/app/api/routes-f/viewer/sessions/route.ts
+++ b/app/api/routes-f/viewer/sessions/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_CONCURRENT_SESSIONS = 3;
+
+const getQuerySchema = z.object({
+  viewer_id: z.string().uuid(),
+});
+
+const postBodySchema = z.object({
+  viewer_id: z.string().uuid(),
+  session_id: z.string().uuid(),
+  playback_id: z.string().min(1),
+});
+
+const deleteBodySchema = z.object({
+  viewer_id: z.string().uuid(),
+  session_id: z.string().uuid(),
+});
+
+async function ensureSessionsTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS viewer_playback_sessions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      viewer_id UUID NOT NULL,
+      session_id UUID NOT NULL,
+      playback_id TEXT NOT NULL,
+      registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (viewer_id, session_id)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_viewer_playback_sessions_viewer
+    ON viewer_playback_sessions (viewer_id)
+  `;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    getQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { viewer_id } = queryResult.data;
+
+  try {
+    await ensureSessionsTable();
+
+    const { rows } = await sql`
+      SELECT id, viewer_id, session_id, playback_id, registered_at
+      FROM viewer_playback_sessions
+      WHERE viewer_id = ${viewer_id}
+      ORDER BY registered_at DESC
+    `;
+
+    return NextResponse.json({
+      active_sessions: rows,
+      limit: MAX_CONCURRENT_SESSIONS,
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/sessions GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch active sessions" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, postBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { viewer_id, session_id, playback_id } = bodyResult.data;
+
+  try {
+    await ensureSessionsTable();
+
+    const { rows: existing } = await sql`
+      SELECT id FROM viewer_playback_sessions
+      WHERE viewer_id = ${viewer_id} AND session_id = ${session_id}
+      LIMIT 1
+    `;
+
+    if (existing.length > 0) {
+      return NextResponse.json({
+        active_sessions: existing.length,
+        limit: MAX_CONCURRENT_SESSIONS,
+        message: "Session already registered",
+      });
+    }
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS total
+      FROM viewer_playback_sessions
+      WHERE viewer_id = ${viewer_id}
+    `;
+
+    const currentCount = Number(countRows[0]?.total ?? 0);
+
+    if (currentCount >= MAX_CONCURRENT_SESSIONS) {
+      return NextResponse.json(
+        {
+          error: "Concurrent session limit reached",
+          active_sessions: currentCount,
+          limit: MAX_CONCURRENT_SESSIONS,
+        },
+        { status: 429 }
+      );
+    }
+
+    await sql`
+      INSERT INTO viewer_playback_sessions (viewer_id, session_id, playback_id, registered_at)
+      VALUES (${viewer_id}, ${session_id}, ${playback_id}, NOW())
+    `;
+
+    return NextResponse.json({
+      active_sessions: currentCount + 1,
+      limit: MAX_CONCURRENT_SESSIONS,
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/sessions POST]", error);
+    return NextResponse.json(
+      { error: "Failed to register session" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, deleteBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { viewer_id, session_id } = bodyResult.data;
+
+  try {
+    await ensureSessionsTable();
+
+    const { rowCount } = await sql`
+      DELETE FROM viewer_playback_sessions
+      WHERE viewer_id = ${viewer_id} AND session_id = ${session_id}
+    `;
+
+    const { rows: countRows } = await sql`
+      SELECT COUNT(*)::int AS total
+      FROM viewer_playback_sessions
+      WHERE viewer_id = ${viewer_id}
+    `;
+
+    return NextResponse.json({
+      removed: (rowCount ?? 0) > 0,
+      active_sessions: Number(countRows[0]?.total ?? 0),
+      limit: MAX_CONCURRENT_SESSIONS,
+    });
+  } catch (error) {
+    console.error("[routes-f viewer/sessions DELETE]", error);
+    return NextResponse.json(
+      { error: "Failed to remove session" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/viewer/watch-history/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer/watch-history/__tests__/route.test.ts
@@ -1,0 +1,205 @@
+import { sql } from "@vercel/postgres";
+import { GET, POST } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/app/api/routes-f/_lib/validate", () => ({
+  validateQuery: jest.fn((params: URLSearchParams, schema: any) => {
+    const obj = Object.fromEntries(params.entries());
+    const result = schema.safeParse(obj);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid query", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+  validateBody: jest.fn(async (req: Request, schema: any) => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 });
+    }
+    const result = schema.safeParse(body);
+    if (!result.success) {
+      return new Response(JSON.stringify({ error: "Invalid request body", details: result.error.flatten() }), { status: 400 });
+    }
+    return { data: result.data };
+  }),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+
+function makeGetRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/viewer/watch-history");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url) as any;
+}
+
+function makePostRequest(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/viewer/watch-history", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("Viewer Watch History API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("GET /api/routes-f/viewer/watch-history", () => {
+    it("returns 400 for missing viewer_id", async () => {
+      const res = await GET(makeGetRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid viewer_id", async () => {
+      const res = await GET(makeGetRequest({ viewer_id: "not-a-uuid" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns watch history entries", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "h1",
+            viewer_id: "v1",
+            target_type: "stream",
+            target_id: "t1",
+            watched_at: "2025-06-01T12:00:00Z",
+            created_at: "2025-06-01T12:00:00Z",
+            updated_at: "2025-06-01T12:00:00Z",
+          },
+          {
+            id: "h2",
+            viewer_id: "v1",
+            target_type: "vod",
+            target_id: "t2",
+            watched_at: "2025-06-01T10:00:00Z",
+            created_at: "2025-06-01T10:00:00Z",
+            updated_at: "2025-06-01T10:00:00Z",
+          },
+        ],
+      });
+
+      const res = await GET(makeGetRequest({ viewer_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.entries).toHaveLength(2);
+      expect(body.entries[0].watched_at).toBe("2025-06-01T12:00:00Z");
+    });
+
+    it("respects limit parameter", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({ rows: [] });
+
+      const res = await GET(makeGetRequest({ viewer_id: "550e8400-e29b-41d4-a716-446655440000", limit: "5" }));
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await GET(makeGetRequest({ viewer_id: "550e8400-e29b-41d4-a716-446655440000" }));
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("POST /api/routes-f/viewer/watch-history", () => {
+    it("returns 400 for missing fields", async () => {
+      const res = await POST(makePostRequest({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid target_type", async () => {
+      const res = await POST(makePostRequest({
+        viewer_id: "550e8400-e29b-41d4-a716-446655440000",
+        target_type: "invalid",
+        target_id: "550e8400-e29b-41d4-a716-446655440001",
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it("creates a new watch history entry", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "h1",
+            viewer_id: "v1",
+            target_type: "stream",
+            target_id: "t1",
+            watched_at: "2025-06-01T12:00:00Z",
+            created_at: "2025-06-01T12:00:00Z",
+            updated_at: "2025-06-01T12:00:00Z",
+          },
+        ],
+      });
+
+      const res = await POST(makePostRequest({
+        viewer_id: "550e8400-e29b-41d4-a716-446655440000",
+        target_type: "stream",
+        target_id: "550e8400-e29b-41d4-a716-446655440001",
+      }));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.entry).toBeDefined();
+      expect(body.entry.target_type).toBe("stream");
+    });
+
+    it("deduplicates by keeping latest timestamp", async () => {
+      sqlMock.mockResolvedValueOnce({});
+      sqlMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "h1",
+            viewer_id: "v1",
+            target_type: "stream",
+            target_id: "t1",
+            watched_at: "2025-06-02T12:00:00Z",
+            created_at: "2025-06-01T10:00:00Z",
+            updated_at: "2025-06-02T12:00:00Z",
+          },
+        ],
+      });
+
+      const res = await POST(makePostRequest({
+        viewer_id: "550e8400-e29b-41d4-a716-446655440000",
+        target_type: "stream",
+        target_id: "550e8400-e29b-41d4-a716-446655440001",
+      }));
+      expect(res.status).toBe(201);
+      expect(sqlMock).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.stringContaining("ON CONFLICT")])
+      );
+    });
+
+    it("returns 500 on database error", async () => {
+      sqlMock.mockRejectedValueOnce(new Error("DB error"));
+
+      const res = await POST(makePostRequest({
+        viewer_id: "550e8400-e29b-41d4-a716-446655440000",
+        target_type: "stream",
+        target_id: "550e8400-e29b-41d4-a716-446655440001",
+      }));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/app/api/routes-f/viewer/watch-history/route.ts
+++ b/app/api/routes-f/viewer/watch-history/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { z } from "zod";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 20;
+
+const getQuerySchema = z.object({
+  viewer_id: z.string().uuid(),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+});
+
+const postBodySchema = z.object({
+  viewer_id: z.string().uuid(),
+  target_type: z.enum(["stream", "vod"]),
+  target_id: z.string().uuid(),
+  watched_at: z.string().datetime().optional(),
+});
+
+async function ensureWatchHistoryTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS viewer_watch_history (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      viewer_id UUID NOT NULL,
+      target_type TEXT NOT NULL CHECK (target_type IN ('stream', 'vod')),
+      target_id UUID NOT NULL,
+      watched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (viewer_id, target_id)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_viewer_watch_history_viewer_watched
+    ON viewer_watch_history (viewer_id, watched_at DESC)
+  `;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const queryResult = validateQuery(
+    new URL(req.url).searchParams,
+    getQuerySchema
+  );
+  if (queryResult instanceof Response) {
+    return queryResult;
+  }
+
+  const { viewer_id, limit } = queryResult.data;
+
+  try {
+    await ensureWatchHistoryTable();
+
+    const { rows } = await sql`
+      SELECT
+        id,
+        viewer_id,
+        target_type,
+        target_id,
+        watched_at,
+        created_at,
+        updated_at
+      FROM viewer_watch_history
+      WHERE viewer_id = ${viewer_id}
+      ORDER BY watched_at DESC
+      LIMIT ${limit}
+    `;
+
+    return NextResponse.json({ entries: rows });
+  } catch (error) {
+    console.error("[routes-f viewer/watch-history GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch watch history" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, postBodySchema);
+  if (bodyResult instanceof Response) {
+    return bodyResult;
+  }
+
+  const { viewer_id, target_type, target_id, watched_at } = bodyResult.data;
+
+  try {
+    await ensureWatchHistoryTable();
+
+    const now = watched_at ?? new Date().toISOString();
+
+    const { rows } = await sql`
+      INSERT INTO viewer_watch_history (viewer_id, target_type, target_id, watched_at, created_at, updated_at)
+      VALUES (${viewer_id}, ${target_type}, ${target_id}, ${now}, NOW(), NOW())
+      ON CONFLICT (viewer_id, target_id)
+      DO UPDATE SET
+        watched_at = GREATEST(viewer_watch_history.watched_at, EXCLUDED.watched_at),
+        updated_at = NOW()
+      RETURNING id, viewer_id, target_type, target_id, watched_at, created_at, updated_at
+    `;
+
+    return NextResponse.json({ entry: rows[0] }, { status: 201 });
+  } catch (error) {
+    console.error("[routes-f viewer/watch-history POST]", error);
+    return NextResponse.json(
+      { error: "Failed to record watch history" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Closes #1054 , Closes #1057, Closes #1056, Closes #1058

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

Four new API route handlers under `app/api/routes-f/` implementing viewer-facing features for the StreamFi platform: watch history tracking with deduplication, tip recap card generation, concurrent playback session capping, and scheduled stream reminder signups. Each route is self-contained with its own table setup, Zod validation, and comprehensive test coverage.

## Motivation / Context

These features fill gaps in the viewer experience on StreamFi. Watch history lets viewers track what they've watched across live and VOD content. Tip recap cards provide shareable payloads for tip events. Concurrent session tracking prevents abuse by capping active playback streams per viewer at 3. Reminder signups let viewers opt into notifications for upcoming scheduled streams.

All files are scoped to `app/api/routes-f/` per the task constraints, ensuring independence and mergeability.

Closes #1054, Closes #1057, Closes #1056, Closes #1058