### PR TITLE
feat(routes-f): clip auto-tag, VOD playlist, rerun loop, stream cover

### DIFF
--- a/app/api/routes-f/clip-auto-tags/__tests__/route.test.ts
+++ b/app/api/routes-f/clip-auto-tags/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/clip-auto-tags", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/routes-f/clip-auto-tags", () => {
+  it("returns gaming tags for a gaming title", async () => {
+    const res = await POST(
+      makePostReq({ title: "Epic Valorant Ranked Grind" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags).toContain("gaming");
+  });
+
+  it("returns music tags for a music title", async () => {
+    const res = await POST(
+      makePostReq({ title: "Live DJ Set - Techno Beats" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags).toContain("music");
+  });
+
+  it("returns irl tags for an IRL title", async () => {
+    const res = await POST(
+      makePostReq({ title: "Daily Vlog - Travel Food Adventure" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags).toContain("irl");
+  });
+
+  it("returns crypto tags when description contains crypto keywords", async () => {
+    const res = await POST(
+      makePostReq({
+        title: "Stream Updates",
+        description: "Discussing Bitcoin, Ethereum and Stellar XLM staking",
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tags).toContain("crypto");
+  });
+
+  it("returns at most 5 tags", async () => {
+    const res = await POST(
+      makePostReq({
+        title: "gaming music art tech chat crypto",
+        description: "irl sports competitive coding painting beats",
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tags.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns empty tags array for unrecognized title", async () => {
+    const res = await POST(makePostReq({ title: "xyzzy flurble" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tags).toEqual([]);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const res = await POST(makePostReq({ description: "something" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is empty string", async () => {
+    const res = await POST(makePostReq({ title: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when description is not a string", async () => {
+    const res = await POST(makePostReq({ title: "test", description: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const res = await POST(
+      new NextRequest("http://localhost/api/routes-f/clip-auto-tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/clip-auto-tags/route.ts
+++ b/app/api/routes-f/clip-auto-tags/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ClipAutoTagsRequest, ClipAutoTagsResponse } from "./types";
+import { TAG_KEYWORDS } from "./tag-map";
+
+const MAX_TAGS = 5;
+
+function generateTags(title: string, description?: string): string[] {
+  const text = `${title} ${description ?? ""}`.toLowerCase();
+  const words = text.split(/\s+/);
+
+  const scores: Record<string, number> = {};
+
+  for (const [tag, keywords] of Object.entries(TAG_KEYWORDS)) {
+    let score = 0;
+    for (const keyword of keywords) {
+      if (keyword.includes(" ")) {
+        if (text.includes(keyword)) {
+          score += 2;
+        }
+      } else {
+        for (const word of words) {
+          if (word === keyword || word.startsWith(keyword)) {
+            score += 1;
+          }
+        }
+      }
+    }
+    if (score > 0) {
+      scores[tag] = score;
+    }
+  }
+
+  return Object.entries(scores)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_TAGS)
+    .map(([tag]) => tag);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: ClipAutoTagsRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { title, description } = body;
+
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.json(
+      { error: "title is required and must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  if (description !== undefined && typeof description !== "string") {
+    return NextResponse.json(
+      { error: "description must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const tags = generateTags(title.trim(), description?.trim());
+
+  return NextResponse.json({ tags } as ClipAutoTagsResponse);
+}

--- a/app/api/routes-f/clip-auto-tags/tag-map.ts
+++ b/app/api/routes-f/clip-auto-tags/tag-map.ts
@@ -1,0 +1,58 @@
+export const TAG_KEYWORDS: Record<string, string[]> = {
+  gaming: [
+    "game", "gaming", "play", "player", "fps", "rpg", "mmo", "moba",
+    "battle", "boss", "raid", "level", "rank", "competitive", "esports",
+    "stream", "twitch", "controller", "keyboard", "mouse", "gpu", "pc",
+    "console", "playstation", "xbox", "nintendo", "steam", "valorant",
+    "fortnite", "league", "minecraft", "apex", "cod", "overwatch",
+    "destiny", "diablo", "wow", "ffxiv", "genshin", "roblox",
+  ],
+  music: [
+    "music", "song", "track", "album", "artist", "band", "concert",
+    "live", "performance", "dj", "remix", "beat", "rap", "hip hop",
+    "rock", "pop", "edm", "techno", "bass", "guitar", "piano",
+    "vocal", "sing", "karaoke", "playlist", "vinyl", "studio",
+    "producer", "beats", "melody", "rhythm",
+  ],
+  irl: [
+    "irl", "vlog", "daily", "life", "travel", "food", "cook", "cooking",
+    "restaurant", "eat", "mukbang", "outdoor", "adventure", "city",
+    "walk", "explore", "nature", "beach", "mountain", "camp",
+    "fitness", "gym", "workout", "yoga", "pet", "dog", "cat",
+    "unboxing", "haul", "fashion", "style",
+  ],
+  crypto: [
+    "crypto", "bitcoin", "btc", "ethereum", "eth", "solana", "sol",
+    "stellar", "xlm", "defi", "nft", "web3", "blockchain", "token",
+    "wallet", "mining", "staking", "yield", "liquidity", "swap",
+    "airdrop", "meme", "altcoin", "trading", "chart", "bull", "bear",
+    "hodl", "moon", "pump",
+  ],
+  creative: [
+    "art", "draw", "paint", "design", "creative", "illustration",
+    "digital", "photoshop", "blender", "3d", "model", "animation",
+    "manga", "comic", "sketch", "canvas", "color", "pixel",
+    "timelapse", "speedpaint", "tutorial", "howto", "diy", "craft",
+    "make", "build", "woodworking", "sew", "knit",
+  ],
+  sports: [
+    "sport", "football", "soccer", "basketball", "baseball", "tennis",
+    "golf", "mma", "ufc", "boxing", "wrestling", "f1", "racing",
+    "nfl", "nba", "mlb", "nhl", "olympics", "world cup", "championship",
+    "tournament", "league", "match", "game day", "highlight",
+    "replay", "analysis", "draft",
+  ],
+  tech: [
+    "tech", "technology", "code", "coding", "programming", "developer",
+    "software", "hardware", "ai", "machine learning", "robot",
+    "hack", "cyber", "security", "linux", "mac", "windows",
+    "phone", "iphone", "android", "app", "review", "unbox",
+    "setup", "desk", "monitor", "keyboard", "usb",
+  ],
+  just_chatting: [
+    "chat", "talk", "discussion", "debate", "q&a", "ama", "story",
+    "rant", "opinion", "news", "react", "reaction", "funny",
+    "meme", "comedy", "joke", "laugh", "chill", "hangout",
+    "podcast", "interview", "collab", "guest",
+  ],
+};

--- a/app/api/routes-f/clip-auto-tags/types.ts
+++ b/app/api/routes-f/clip-auto-tags/types.ts
@@ -1,0 +1,8 @@
+export interface ClipAutoTagsRequest {
+  title: string;
+  description?: string;
+}
+
+export interface ClipAutoTagsResponse {
+  tags: string[];
+}

--- a/app/api/routes-f/stream-cover/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-cover/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { clearAllCovers } from "../store";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/stream-cover");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/stream-cover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("stream-cover lifecycle", () => {
+  beforeEach(() => {
+    clearAllCovers();
+  });
+
+  describe("POST /api/routes-f/stream-cover", () => {
+    it("sets a cover image and returns updated_at", async () => {
+      const res = await POST(
+        makePostReq({
+          stream_id: "s1",
+          cover_url: "https://example.com/cover.jpg",
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(typeof data.updated_at).toBe("string");
+    });
+
+    it("overwrites an existing cover image", async () => {
+      await POST(
+        makePostReq({
+          stream_id: "s1",
+          cover_url: "https://example.com/cover1.jpg",
+        })
+      );
+      const res = await POST(
+        makePostReq({
+          stream_id: "s1",
+          cover_url: "https://example.com/cover2.jpg",
+        })
+      );
+      expect(res.status).toBe(200);
+
+      const getRes = await GET(makeGetReq({ stream_id: "s1" }));
+      const data = await getRes.json();
+      expect(data.cover_url).toBe("https://example.com/cover2.jpg");
+    });
+
+    it("returns 400 when stream_id is missing", async () => {
+      const res = await POST(
+        makePostReq({ cover_url: "https://example.com/cover.jpg" })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when cover_url is missing", async () => {
+      const res = await POST(makePostReq({ stream_id: "s1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid URL", async () => {
+      const res = await POST(
+        makePostReq({ stream_id: "s1", cover_url: "not-a-url" })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/valid URL/i);
+    });
+
+    it("accepts http URLs", async () => {
+      const res = await POST(
+        makePostReq({
+          stream_id: "s1",
+          cover_url: "http://example.com/cover.jpg",
+        })
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /api/routes-f/stream-cover", () => {
+    it("returns 400 when stream_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when no cover is set", async () => {
+      const res = await GET(makeGetReq({ stream_id: "s_unknown" }));
+      expect(res.status).toBe(404);
+    });
+
+    it("returns the cover image after setting it", async () => {
+      await POST(
+        makePostReq({
+          stream_id: "s1",
+          cover_url: "https://example.com/cover.jpg",
+        })
+      );
+      const res = await GET(makeGetReq({ stream_id: "s1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.stream_id).toBe("s1");
+      expect(data.cover_url).toBe("https://example.com/cover.jpg");
+      expect(typeof data.updated_at).toBe("string");
+    });
+  });
+});

--- a/app/api/routes-f/stream-cover/route.ts
+++ b/app/api/routes-f/stream-cover/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { PostCoverBody, PostCoverResponse, GetCoverResponse } from "./types";
+import { getCover, setCover } from "./store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: PostCoverBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id, cover_url } = body;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!cover_url || typeof cover_url !== "string") {
+    return NextResponse.json(
+      { error: "cover_url is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    new URL(cover_url);
+  } catch {
+    return NextResponse.json(
+      { error: "cover_url must be a valid URL" },
+      { status: 400 }
+    );
+  }
+
+  const record = setCover(stream_id, cover_url);
+  return NextResponse.json(
+    { updated_at: record.updated_at } as PostCoverResponse,
+    { status: 200 }
+  );
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const record = getCover(streamId);
+  if (!record) {
+    return NextResponse.json(
+      { error: "No cover image set for this stream" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(record as GetCoverResponse);
+}

--- a/app/api/routes-f/stream-cover/store.ts
+++ b/app/api/routes-f/stream-cover/store.ts
@@ -1,0 +1,21 @@
+import type { CoverImageRecord } from "./types";
+
+const covers = new Map<string, CoverImageRecord>();
+
+export function getCover(streamId: string): CoverImageRecord | undefined {
+  return covers.get(streamId);
+}
+
+export function setCover(streamId: string, coverUrl: string): CoverImageRecord {
+  const record: CoverImageRecord = {
+    stream_id: streamId,
+    cover_url: coverUrl,
+    updated_at: new Date().toISOString(),
+  };
+  covers.set(streamId, record);
+  return record;
+}
+
+export function clearAllCovers(): void {
+  covers.clear();
+}

--- a/app/api/routes-f/stream-cover/types.ts
+++ b/app/api/routes-f/stream-cover/types.ts
@@ -1,0 +1,20 @@
+export interface CoverImageRecord {
+  stream_id: string;
+  cover_url: string;
+  updated_at: string;
+}
+
+export interface PostCoverBody {
+  stream_id: string;
+  cover_url: string;
+}
+
+export interface PostCoverResponse {
+  updated_at: string;
+}
+
+export interface GetCoverResponse {
+  stream_id: string;
+  cover_url: string;
+  updated_at: string;
+}

--- a/app/api/routes-f/stream-rerun/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-rerun/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE } from "../route";
+import { clearAllReruns } from "../store";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/stream-rerun");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/stream-rerun", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/stream-rerun", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("stream-rerun lifecycle", () => {
+  beforeEach(() => {
+    clearAllReruns();
+  });
+
+  describe("POST /api/routes-f/stream-rerun", () => {
+    it("enables rerun for a creator", async () => {
+      const res = await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: true })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rerun_active).toBe(true);
+      expect(data.vod_id).toBe("vod_x");
+      expect(typeof data.started_at).toBe("string");
+    });
+
+    it("disables rerun for a creator", async () => {
+      await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: true })
+      );
+      const res = await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: false })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rerun_active).toBe(false);
+      expect(data.vod_id).toBeNull();
+      expect(data.started_at).toBeNull();
+    });
+
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await POST(
+        makePostReq({ vod_id: "vod_x", enabled: true })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when vod_id is missing", async () => {
+      const res = await POST(
+        makePostReq({ creator_id: "c1", enabled: true })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when enabled is not boolean", async () => {
+      const res = await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: "yes" })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/routes-f/stream-rerun", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns inactive rerun for unknown creator", async () => {
+      const res = await GET(makeGetReq({ creator_id: "unknown" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rerun_active).toBe(false);
+      expect(data.vod_id).toBeNull();
+      expect(data.started_at).toBeNull();
+    });
+
+    it("returns active rerun after setting it", async () => {
+      await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: true })
+      );
+      const res = await GET(makeGetReq({ creator_id: "c1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.rerun_active).toBe(true);
+      expect(data.vod_id).toBe("vod_x");
+    });
+  });
+
+  describe("DELETE /api/routes-f/stream-rerun", () => {
+    it("clears rerun for a creator", async () => {
+      await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: true })
+      );
+      const res = await DELETE(makeDeleteReq({ creator_id: "c1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.cleared).toBe(true);
+    });
+
+    it("returns true when clearing non-existent rerun", async () => {
+      const res = await DELETE(makeDeleteReq({ creator_id: "nobody" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.cleared).toBe(true);
+    });
+
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await DELETE(makeDeleteReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("GET returns inactive after DELETE", async () => {
+      await POST(
+        makePostReq({ creator_id: "c1", vod_id: "vod_x", enabled: true })
+      );
+      await DELETE(makeDeleteReq({ creator_id: "c1" }));
+      const res = await GET(makeGetReq({ creator_id: "c1" }));
+      const data = await res.json();
+      expect(data.rerun_active).toBe(false);
+    });
+  });
+});

--- a/app/api/routes-f/stream-rerun/route.ts
+++ b/app/api/routes-f/stream-rerun/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { PostRerunBody, GetRerunResponse } from "./types";
+import { getRerun, setRerun, clearRerun } from "./store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: PostRerunBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, vod_id, enabled } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!vod_id || typeof vod_id !== "string") {
+    return NextResponse.json(
+      { error: "vod_id is required" },
+      { status: 400 }
+    );
+  }
+  if (typeof enabled !== "boolean") {
+    return NextResponse.json(
+      { error: "enabled must be a boolean" },
+      { status: 400 }
+    );
+  }
+
+  const config = setRerun(creator_id, vod_id, enabled);
+  return NextResponse.json({
+    rerun_active: config.rerun_active,
+    vod_id: config.vod_id,
+    started_at: config.started_at,
+  } as GetRerunResponse);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const config = getRerun(creatorId);
+  if (!config) {
+    return NextResponse.json({
+      rerun_active: false,
+      vod_id: null,
+      started_at: null,
+    } as GetRerunResponse);
+  }
+
+  return NextResponse.json({
+    rerun_active: config.rerun_active,
+    vod_id: config.vod_id,
+    started_at: config.started_at,
+  } as GetRerunResponse);
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: { creator_id: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const cleared = clearRerun(creator_id);
+  return NextResponse.json({ cleared });
+}

--- a/app/api/routes-f/stream-rerun/store.ts
+++ b/app/api/routes-f/stream-rerun/store.ts
@@ -1,0 +1,31 @@
+import type { RerunConfig } from "./types";
+
+const reruns = new Map<string, RerunConfig>();
+
+export function getRerun(creatorId: string): RerunConfig | undefined {
+  return reruns.get(creatorId);
+}
+
+export function setRerun(
+  creatorId: string,
+  vodId: string,
+  enabled: boolean
+): RerunConfig {
+  const config: RerunConfig = {
+    creator_id: creatorId,
+    vod_id: enabled ? vodId : null,
+    rerun_active: enabled,
+    started_at: enabled ? new Date().toISOString() : null,
+  };
+  reruns.set(creatorId, config);
+  return config;
+}
+
+export function clearRerun(creatorId: string): boolean {
+  reruns.delete(creatorId);
+  return true;
+}
+
+export function clearAllReruns(): void {
+  reruns.clear();
+}

--- a/app/api/routes-f/stream-rerun/types.ts
+++ b/app/api/routes-f/stream-rerun/types.ts
@@ -1,0 +1,18 @@
+export interface RerunConfig {
+  creator_id: string;
+  vod_id: string | null;
+  rerun_active: boolean;
+  started_at: string | null;
+}
+
+export interface PostRerunBody {
+  creator_id: string;
+  vod_id: string;
+  enabled: boolean;
+}
+
+export interface GetRerunResponse {
+  rerun_active: boolean;
+  vod_id: string | null;
+  started_at: string | null;
+}

--- a/app/api/routes-f/vod-playlist/__tests__/route.test.ts
+++ b/app/api/routes-f/vod-playlist/__tests__/route.test.ts
@@ -1,0 +1,183 @@
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE } from "../route";
+import { POST as REORDER_POST } from "../reorder/route";
+import { clearAllPlaylists } from "../store";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/vod-playlist");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/vod-playlist", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/vod-playlist", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeReorderReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/vod-playlist/reorder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("vod-playlist lifecycle", () => {
+  beforeEach(() => {
+    clearAllPlaylists();
+  });
+
+  describe("POST /api/routes-f/vod-playlist", () => {
+    it("appends a VOD to the playlist", async () => {
+      const res = await POST(
+        makePostReq({ viewer_id: "v1", vod_id: "vod_1" })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.vod_id).toBe("vod_1");
+      expect(typeof data.added_at).toBe("string");
+    });
+
+    it("returns 400 when viewer_id is missing", async () => {
+      const res = await POST(makePostReq({ vod_id: "vod_1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when vod_id is missing", async () => {
+      const res = await POST(makePostReq({ viewer_id: "v1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 409 when VOD already in playlist", async () => {
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_1" }));
+      const res = await POST(
+        makePostReq({ viewer_id: "v1", vod_id: "vod_1" })
+      );
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 400 when playlist is full (100 items)", async () => {
+      for (let i = 0; i < 100; i++) {
+        await POST(makePostReq({ viewer_id: "v_full", vod_id: `vod_${i}` }));
+      }
+      const res = await POST(
+        makePostReq({ viewer_id: "v_full", vod_id: "vod_100" })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/routes-f/vod-playlist", () => {
+    it("returns 400 when viewer_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns empty playlist for unknown viewer", async () => {
+      const res = await GET(makeGetReq({ viewer_id: "unknown" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.items).toEqual([]);
+    });
+
+    it("returns playlist with items", async () => {
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_1" }));
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_2" }));
+      const res = await GET(makeGetReq({ viewer_id: "v1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.items).toHaveLength(2);
+      expect(data.viewer_id).toBe("v1");
+    });
+  });
+
+  describe("DELETE /api/routes-f/vod-playlist", () => {
+    it("removes a VOD from the playlist", async () => {
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_1" }));
+      const res = await DELETE(
+        makeDeleteReq({ viewer_id: "v1", vod_id: "vod_1" })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.removed).toBe(true);
+    });
+
+    it("returns 404 when VOD not in playlist", async () => {
+      const res = await DELETE(
+        makeDeleteReq({ viewer_id: "v1", vod_id: "vod_none" })
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when viewer_id is missing", async () => {
+      const res = await DELETE(makeDeleteReq({ vod_id: "vod_1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when vod_id is missing", async () => {
+      const res = await DELETE(makeDeleteReq({ viewer_id: "v1" }));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/routes-f/vod-playlist/reorder", () => {
+    it("reorders the playlist", async () => {
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_a" }));
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_b" }));
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_c" }));
+
+      const res = await REORDER_POST(
+        makeReorderReq({ viewer_id: "v1", order: ["vod_c", "vod_a", "vod_b"] })
+      );
+      expect(res.status).toBe(200);
+
+      const playlist = await GET(makeGetReq({ viewer_id: "v1" }));
+      const data = await playlist.json();
+      expect(data.items.map((i: { vod_id: string }) => i.vod_id)).toEqual([
+        "vod_c",
+        "vod_a",
+        "vod_b",
+      ]);
+    });
+
+    it("returns 400 when order is not an array", async () => {
+      const res = await REORDER_POST(
+        makeReorderReq({ viewer_id: "v1", order: "not_array" })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when order is empty", async () => {
+      const res = await REORDER_POST(
+        makeReorderReq({ viewer_id: "v1", order: [] })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when viewer has no playlist", async () => {
+      const res = await REORDER_POST(
+        makeReorderReq({ viewer_id: "unknown", order: ["vod_x"] })
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when order contains unknown vod_id", async () => {
+      await POST(makePostReq({ viewer_id: "v1", vod_id: "vod_a" }));
+      const res = await REORDER_POST(
+        makeReorderReq({ viewer_id: "v1", order: ["vod_a", "vod_z"] })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/vod-playlist/reorder/route.ts
+++ b/app/api/routes-f/vod-playlist/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ReorderBody } from "../types";
+import { reorderPlaylist } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: ReorderBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, order } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!Array.isArray(order) || order.length === 0) {
+    return NextResponse.json(
+      { error: "order must be a non-empty array of vod_ids" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    reorderPlaylist(viewer_id, order);
+    return NextResponse.json({ message: "Playlist reordered" });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (message.includes("No playlist found")) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/vod-playlist/route.ts
+++ b/app/api/routes-f/vod-playlist/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { PostPlaylistBody, DeletePlaylistBody } from "./types";
+import {
+  getPlaylist,
+  appendToPlaylist,
+  removeFromPlaylist,
+} from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const viewerId = req.nextUrl.searchParams.get("viewer_id");
+
+  if (!viewerId) {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const playlist = getPlaylist(viewerId);
+  return NextResponse.json(playlist);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: PostPlaylistBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, vod_id } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!vod_id || typeof vod_id !== "string") {
+    return NextResponse.json(
+      { error: "vod_id is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const item = appendToPlaylist(viewer_id, vod_id);
+    return NextResponse.json(item, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    const status = message.includes("full") ? 400 : 409;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: DeletePlaylistBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, vod_id } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!vod_id || typeof vod_id !== "string") {
+    return NextResponse.json(
+      { error: "vod_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const removed = removeFromPlaylist(viewer_id, vod_id);
+  if (!removed) {
+    return NextResponse.json(
+      { error: "VOD not found in playlist" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ removed: true });
+}

--- a/app/api/routes-f/vod-playlist/store.ts
+++ b/app/api/routes-f/vod-playlist/store.ts
@@ -1,0 +1,75 @@
+import type { ViewerPlaylist, PlaylistItem } from "./types";
+
+const MAX_PLAYLIST_ITEMS = 100;
+
+const playlists = new Map<string, PlaylistItem[]>();
+
+export function getPlaylist(viewerId: string): ViewerPlaylist {
+  const items = playlists.get(viewerId) ?? [];
+  return { viewer_id: viewerId, items: [...items] };
+}
+
+export function appendToPlaylist(viewerId: string, vodId: string): PlaylistItem {
+  const items = playlists.get(viewerId) ?? [];
+
+  if (items.length >= MAX_PLAYLIST_ITEMS) {
+    throw new Error("Playlist is full (max 100 items)");
+  }
+
+  const existing = items.find(i => i.vod_id === vodId);
+  if (existing) {
+    throw new Error("VOD already in playlist");
+  }
+
+  const item: PlaylistItem = {
+    vod_id: vodId,
+    added_at: new Date().toISOString(),
+  };
+  items.push(item);
+  playlists.set(viewerId, items);
+  return item;
+}
+
+export function removeFromPlaylist(viewerId: string, vodId: string): boolean {
+  const items = playlists.get(viewerId);
+  if (!items) {
+    return false;
+  }
+
+  const idx = items.findIndex(i => i.vod_id === vodId);
+  if (idx === -1) {
+    return false;
+  }
+
+  items.splice(idx, 1);
+  playlists.set(viewerId, items);
+  return true;
+}
+
+export function reorderPlaylist(viewerId: string, order: string[]): void {
+  const items = playlists.get(viewerId);
+  if (!items) {
+    throw new Error("No playlist found for viewer");
+  }
+
+  const itemMap = new Map(items.map(i => [i.vod_id, i]));
+  const reordered: PlaylistItem[] = [];
+
+  for (const vodId of order) {
+    const item = itemMap.get(vodId);
+    if (!item) {
+      throw new Error(`vod_id '${vodId}' not found in playlist`);
+    }
+    reordered.push(item);
+  }
+
+  if (reordered.length !== items.length) {
+    throw new Error("Reorder list does not contain all playlist items");
+  }
+
+  playlists.set(viewerId, reordered);
+}
+
+export function clearAllPlaylists(): void {
+  playlists.clear();
+}

--- a/app/api/routes-f/vod-playlist/types.ts
+++ b/app/api/routes-f/vod-playlist/types.ts
@@ -1,0 +1,24 @@
+export interface PlaylistItem {
+  vod_id: string;
+  added_at: string;
+}
+
+export interface ViewerPlaylist {
+  viewer_id: string;
+  items: PlaylistItem[];
+}
+
+export interface PostPlaylistBody {
+  viewer_id: string;
+  vod_id: string;
+}
+
+export interface DeletePlaylistBody {
+  viewer_id: string;
+  vod_id: string;
+}
+
+export interface ReorderBody {
+  viewer_id: string;
+  order: string[];
+}


### PR DESCRIPTION
Closes #1050, Closes #1051, Closes #1052, Closes #1053

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

This PR implements four new API routes under `app/api/routes-f/` for the StreamFi platform: a clip auto-tag generator that suggests tags from title/description, a VOD playlist manager with append/remove/reorder operations, a stream rerun loop configuration for offline creators, and a featured stream cover image setter with URL validation. All routes use in-memory stores with comprehensive test coverage.

## Motivation / Context

These four features extend the StreamFi platform's content management and viewer experience capabilities. The clip auto-tag generator helps streamers categorize content, the VOD playlist lets viewers curate watch lists, the rerun loop keeps channels active when creators are offline, and the cover image endpoint enables stream branding.

Closes #1050, Closes #1051, Closes #1052, Closes #1053