### PR TITLE
feat(routes-f): swift/bic validator, closed captions, mod team, and category tests

### DIFF
--- a/app/api/routes-f/__tests__/categories.test.ts
+++ b/app/api/routes-f/__tests__/categories.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET as GETList, POST } from "../categories/route";
+import { GET as GETBySlug, PATCH, DELETE } from "../categories/[slug]/route";
+
+// ---------------------------------------------------------------------------
+// Mock @vercel/postgres
+// ---------------------------------------------------------------------------
+const mockSql = jest.fn();
+
+jest.mock("@vercel/postgres", () => ({
+  sql: new Proxy(
+    function (...args: unknown[]) {
+      return mockSql(...args);
+    },
+    {
+      get(_target, prop) {
+        // Handle tagged-template usage: sql`...`
+        if (prop === Symbol.toPrimitive || prop === "toString") return undefined;
+        return mockSql;
+      },
+      apply(_target, _thisArg, args) {
+        return mockSql(...args);
+      },
+    }
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock @/lib/auth/verify-session
+// ---------------------------------------------------------------------------
+const mockVerifySession = jest.fn();
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: (...args: unknown[]) => mockVerifySession(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeReq(
+  url: string,
+  init?: { method?: string; body?: unknown; headers?: Record<string, string> }
+) {
+  return new NextRequest(url, {
+    method: init?.method ?? "GET",
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+function makeParams(slug: string) {
+  return { params: Promise.resolve({ slug }) };
+}
+
+// Produce a tagged-template-compatible mock: sql`...` returns a resolved Promise
+function sqlResult(rows: Record<string, unknown>[], rowCount?: number) {
+  return Promise.resolve({ rows, rowCount: rowCount ?? rows.length });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("/api/routes-f/categories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── GET list ──────────────────────────────────────────────────────────────
+  describe("GET /api/routes-f/categories", () => {
+    it("returns 200 with a categories array", async () => {
+      // ensureCategoriesTable (CREATE TABLE) + ensureCategoriesTable (CREATE INDEX) + SELECT
+      mockSql
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE INDEX
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              slug: "gaming",
+              name: "Gaming",
+              thumbnail_url: null,
+              created_at: "2024-01-01T00:00:00Z",
+              updated_at: "2024-01-01T00:00:00Z",
+              stream_count: 3,
+              viewer_count: 900,
+            },
+          ],
+          rowCount: 1,
+        });
+
+      const req = makeReq("http://localhost/api/routes-f/categories");
+      const res = await GETList();
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toHaveProperty("categories");
+      expect(Array.isArray(data.categories)).toBe(true);
+      expect(data.categories[0].slug).toBe("gaming");
+    });
+  });
+
+  // ── POST create ───────────────────────────────────────────────────────────
+  describe("POST /api/routes-f/categories", () => {
+    it("returns 201 when admin creates a category", async () => {
+      // verifySession returns ok
+      mockVerifySession.mockResolvedValue({
+        ok: true,
+        userId: "admin-user-id",
+        response: undefined,
+      });
+
+      mockSql
+        // requireAdmin SELECT users
+        .mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 })
+        // ensureCategoriesTable CREATE TABLE
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        // ensureCategoriesTable CREATE INDEX
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        // INSERT
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              slug: "gaming",
+              name: "Gaming",
+              thumbnail_url: null,
+              created_at: "2024-01-01T00:00:00Z",
+              updated_at: "2024-01-01T00:00:00Z",
+            },
+          ],
+          rowCount: 1,
+        });
+
+      const req = makeReq("http://localhost/api/routes-f/categories", {
+        method: "POST",
+        body: { title: "Gaming" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(201);
+
+      const data = await res.json();
+      expect(data.slug).toBe("gaming");
+      expect(data.name).toBe("Gaming");
+    });
+
+    it("returns 403 for non-admin user", async () => {
+      mockVerifySession.mockResolvedValue({
+        ok: true,
+        userId: "regular-user-id",
+        response: undefined,
+      });
+
+      // requireAdmin SELECT users returns no rows → not an admin
+      mockSql.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const req = makeReq("http://localhost/api/routes-f/categories", {
+        method: "POST",
+        body: { title: "Sports" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(403);
+
+      const data = await res.json();
+      expect(data.error).toBe("Forbidden");
+    });
+  });
+
+  // ── GET by slug ───────────────────────────────────────────────────────────
+  describe("GET /api/routes-f/categories/[slug]", () => {
+    it("returns 404 for an unknown slug", async () => {
+      mockSql
+        // ensureCategoriesTable CREATE TABLE
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        // SELECT category by slug → not found
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const req = makeReq(
+        "http://localhost/api/routes-f/categories/does-not-exist"
+      );
+      const res = await GETBySlug(req, makeParams("does-not-exist"));
+      expect(res.status).toBe(404);
+
+      const data = await res.json();
+      expect(data.error).toBe("Category not found");
+    });
+  });
+
+  // ── PATCH ─────────────────────────────────────────────────────────────────
+  describe("PATCH /api/routes-f/categories/[slug]", () => {
+    it("admin updates category and returns updated category", async () => {
+      mockVerifySession.mockResolvedValue({
+        ok: true,
+        userId: "admin-user-id",
+        response: undefined,
+      });
+
+      mockSql
+        // requireAdmin SELECT users
+        .mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 })
+        // ensureCategoriesTable CREATE TABLE
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        // SELECT existing category
+        .mockResolvedValueOnce({
+          rows: [
+            { slug: "gaming", name: "Gaming", thumbnail_url: null },
+          ],
+          rowCount: 1,
+        })
+        // UPDATE
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              slug: "gaming-updated",
+              name: "Gaming Updated",
+              thumbnail_url: null,
+              created_at: "2024-01-01T00:00:00Z",
+              updated_at: "2024-06-01T00:00:00Z",
+            },
+          ],
+          rowCount: 1,
+        });
+
+      const req = makeReq(
+        "http://localhost/api/routes-f/categories/gaming",
+        {
+          method: "PATCH",
+          body: { title: "Gaming Updated" },
+        }
+      );
+      const res = await PATCH(req, makeParams("gaming"));
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.name).toBe("Gaming Updated");
+    });
+  });
+
+  // ── DELETE ────────────────────────────────────────────────────────────────
+  describe("DELETE /api/routes-f/categories/[slug]", () => {
+    it("admin deletes category and returns success message", async () => {
+      mockVerifySession.mockResolvedValue({
+        ok: true,
+        userId: "admin-user-id",
+        response: undefined,
+      });
+
+      mockSql
+        // requireAdmin SELECT users
+        .mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 })
+        // ensureCategoriesTable CREATE TABLE
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        // DELETE
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const req = makeReq(
+        "http://localhost/api/routes-f/categories/gaming",
+        { method: "DELETE" }
+      );
+      const res = await DELETE(req, makeParams("gaming"));
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.message).toBe("Category removed");
+    });
+  });
+});

--- a/app/api/routes-f/closed-captions/route.test.ts
+++ b/app/api/routes-f/closed-captions/route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT, viewerPrefsStore } from "./route";
+
+function makeGetReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/closed-captions?${query}`
+  );
+}
+
+function makePutReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/closed-captions", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/closed-captions", () => {
+  beforeEach(() => {
+    viewerPrefsStore.clear();
+  });
+
+  it("GET with playback_id returns tracks array", async () => {
+    const req = makeGetReq("playback_id=playback-001");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(Array.isArray(data.tracks)).toBe(true);
+    expect(data.tracks.length).toBe(2);
+    expect(data.tracks[0].lang).toBe("en");
+    expect(data.tracks[1].lang).toBe("es");
+  });
+
+  it("GET with unknown playback_id returns empty tracks", async () => {
+    const req = makeGetReq("playback_id=unknown-999");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.tracks).toEqual([]);
+  });
+
+  it("GET with viewer_id returns captions_enabled and preferred_lang", async () => {
+    // No prior prefs → defaults
+    const req = makeGetReq("viewer_id=viewer-42");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(typeof data.captions_enabled).toBe("boolean");
+    expect(data.captions_enabled).toBe(false);
+    expect(data.preferred_lang).toBeNull();
+  });
+
+  it("PUT updates viewer prefs and returns them", async () => {
+    const req = makePutReq({
+      viewer_id: "viewer-42",
+      captions_enabled: true,
+      preferred_lang: "es",
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.captions_enabled).toBe(true);
+    expect(data.preferred_lang).toBe("es");
+  });
+
+  it("GET after PUT reflects the updated prefs", async () => {
+    // PUT first
+    const putReq = makePutReq({
+      viewer_id: "viewer-42",
+      captions_enabled: true,
+      preferred_lang: "fr",
+    });
+    await PUT(putReq);
+
+    // Now GET
+    const getReq = makeGetReq("viewer_id=viewer-42");
+    const res = await GET(getReq);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.captions_enabled).toBe(true);
+    expect(data.preferred_lang).toBe("fr");
+  });
+});

--- a/app/api/routes-f/closed-captions/route.ts
+++ b/app/api/routes-f/closed-captions/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SEED_TRACKS, CaptionTrack } from "./seed-tracks";
+
+/**
+ * Closed Captions endpoint
+ *
+ * GET ?playback_id=...   → { tracks: [{ lang, label, url }] }
+ * GET ?viewer_id=...     → { captions_enabled: boolean, preferred_lang: string | null }
+ * PUT { viewer_id, captions_enabled, preferred_lang } → updated prefs
+ *
+ * Viewer prefs are stored in an in-memory map (no DB).
+ */
+
+interface ViewerPrefs {
+  captions_enabled: boolean;
+  preferred_lang: string | null;
+}
+
+// In-memory store: viewer_id → prefs
+export const viewerPrefsStore = new Map<string, ViewerPrefs>();
+
+// Build a lookup from playback_id → tracks
+const tracksByPlaybackId = new Map<string, CaptionTrack[]>();
+for (const entry of SEED_TRACKS) {
+  tracksByPlaybackId.set(entry.playback_id, entry.tracks);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = req.nextUrl;
+
+  const playbackId = searchParams.get("playback_id");
+  if (playbackId !== null) {
+    const tracks = tracksByPlaybackId.get(playbackId) ?? [];
+    return NextResponse.json({ tracks });
+  }
+
+  const viewerId = searchParams.get("viewer_id");
+  if (viewerId !== null) {
+    const prefs = viewerPrefsStore.get(viewerId) ?? {
+      captions_enabled: false,
+      preferred_lang: null,
+    };
+    return NextResponse.json(prefs);
+  }
+
+  return NextResponse.json(
+    { error: "playback_id or viewer_id query parameter is required" },
+    { status: 400 }
+  );
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    typeof (body as Record<string, unknown>).viewer_id !== "string" ||
+    typeof (body as Record<string, unknown>).captions_enabled !== "boolean"
+  ) {
+    return NextResponse.json(
+      { error: "viewer_id (string) and captions_enabled (boolean) are required" },
+      { status: 400 }
+    );
+  }
+
+  const {
+    viewer_id,
+    captions_enabled,
+    preferred_lang = null,
+  } = body as {
+    viewer_id: string;
+    captions_enabled: boolean;
+    preferred_lang?: string | null;
+  };
+
+  if (preferred_lang !== null && typeof preferred_lang !== "string") {
+    return NextResponse.json(
+      { error: "preferred_lang must be a string or null" },
+      { status: 400 }
+    );
+  }
+
+  const prefs: ViewerPrefs = {
+    captions_enabled,
+    preferred_lang: preferred_lang ?? null,
+  };
+
+  viewerPrefsStore.set(viewer_id, prefs);
+
+  return NextResponse.json(prefs);
+}

--- a/app/api/routes-f/closed-captions/seed-tracks.ts
+++ b/app/api/routes-f/closed-captions/seed-tracks.ts
@@ -1,0 +1,32 @@
+/**
+ * Seed caption tracks for the closed-captions endpoint.
+ * Self-contained inside app/api/routes-f/ — do not import from outside.
+ */
+export interface CaptionTrack {
+  lang: string;
+  label: string;
+  url: string;
+}
+
+export interface PlaybackTracks {
+  playback_id: string;
+  tracks: CaptionTrack[];
+}
+
+export const SEED_TRACKS: PlaybackTracks[] = [
+  {
+    playback_id: "playback-001",
+    tracks: [
+      { lang: "en", label: "English", url: "/captions/en.vtt" },
+      { lang: "es", label: "Spanish", url: "/captions/es.vtt" },
+    ],
+  },
+  {
+    playback_id: "playback-002",
+    tracks: [
+      { lang: "en", label: "English", url: "/captions/en-002.vtt" },
+      { lang: "fr", label: "French", url: "/captions/fr-002.vtt" },
+      { lang: "de", label: "German", url: "/captions/de-002.vtt" },
+    ],
+  },
+];

--- a/app/api/routes-f/mod-team/route.test.ts
+++ b/app/api/routes-f/mod-team/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE, modStore } from "./route";
+
+function makeGetReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/mod-team?${query}`
+  );
+}
+
+function makePostReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/mod-team", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/mod-team", {
+    method: "DELETE",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/mod-team", () => {
+  beforeEach(() => {
+    modStore.clear();
+  });
+
+  it("GET returns moderators for a creator", async () => {
+    // Seed a mod directly
+    modStore.set("creator-1:viewer-1", {
+      creator_id: "creator-1",
+      viewer_id: "viewer-1",
+      role: "mod",
+      added_at: new Date().toISOString(),
+    });
+
+    const req = makeGetReq("creator_id=creator-1");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(Array.isArray(data.moderators)).toBe(true);
+    expect(data.moderators.length).toBe(1);
+    expect(data.moderators[0].viewer_id).toBe("viewer-1");
+    expect(data.moderators[0].role).toBe("mod");
+  });
+
+  it("POST assigns a moderator", async () => {
+    const req = makePostReq({
+      creator_id: "creator-1",
+      viewer_id: "viewer-2",
+      role: "mod",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    const data = await res.json();
+    expect(data.creator_id).toBe("creator-1");
+    expect(data.viewer_id).toBe("viewer-2");
+    expect(data.role).toBe("mod");
+    expect(typeof data.added_at).toBe("string");
+  });
+
+  it("POST with existing mod updates role (upsert)", async () => {
+    // First assign as mod
+    await POST(
+      makePostReq({ creator_id: "creator-1", viewer_id: "viewer-3", role: "mod" })
+    );
+
+    // Promote to sr_mod
+    const req = makePostReq({
+      creator_id: "creator-1",
+      viewer_id: "viewer-3",
+      role: "sr_mod",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.role).toBe("sr_mod");
+
+    // Only one entry in store for this pair
+    const getReq = makeGetReq("creator_id=creator-1");
+    const getRes = await GET(getReq);
+    const getData = await getRes.json();
+    expect(getData.moderators.filter((m: { viewer_id: string }) => m.viewer_id === "viewer-3").length).toBe(1);
+  });
+
+  it("DELETE removes moderator", async () => {
+    // Seed a mod
+    modStore.set("creator-1:viewer-4", {
+      creator_id: "creator-1",
+      viewer_id: "viewer-4",
+      role: "mod",
+      added_at: new Date().toISOString(),
+    });
+
+    const req = makeDeleteReq({ creator_id: "creator-1", viewer_id: "viewer-4" });
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.message).toBe("Moderator removed");
+
+    // Confirm removal
+    const getReq = makeGetReq("creator_id=creator-1");
+    const getRes = await GET(getReq);
+    const getData = await getRes.json();
+    expect(getData.moderators.length).toBe(0);
+  });
+
+  it("POST returns 400 when cap of 20 is reached", async () => {
+    // Add exactly 20 mods
+    for (let i = 0; i < 20; i++) {
+      modStore.set(`creator-1:viewer-cap-${i}`, {
+        creator_id: "creator-1",
+        viewer_id: `viewer-cap-${i}`,
+        role: "mod",
+        added_at: new Date().toISOString(),
+      });
+    }
+
+    // The 21st should fail
+    const req = makePostReq({
+      creator_id: "creator-1",
+      viewer_id: "viewer-overflow",
+      role: "mod",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error).toMatch(/Cannot exceed 20/);
+  });
+});

--- a/app/api/routes-f/mod-team/route.ts
+++ b/app/api/routes-f/mod-team/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Channel Mod Team Management
+ *
+ * GET  ?creator_id=...                              → list of mods for creator
+ * POST { creator_id, viewer_id, role }              → add / update mod (upsert)
+ * DELETE { creator_id, viewer_id }                  → remove mod
+ *
+ * Cap: max 20 mods per creator. POST returns 400 if limit reached for new mods.
+ * Uses in-memory store — no DB.
+ */
+
+type ModRole = "mod" | "sr_mod" | "owner";
+
+interface Mod {
+  creator_id: string;
+  viewer_id: string;
+  role: ModRole;
+  added_at: string;
+}
+
+const MOD_CAP = 20;
+
+// In-memory store: "creator_id:viewer_id" → Mod
+export const modStore = new Map<string, Mod>();
+
+function storeKey(creator_id: string, viewer_id: string): string {
+  return `${creator_id}:${viewer_id}`;
+}
+
+function modsForCreator(creator_id: string): Mod[] {
+  const result: Mod[] = [];
+  for (const mod of modStore.values()) {
+    if (mod.creator_id === creator_id) {
+      result.push(mod);
+    }
+  }
+  return result;
+}
+
+const VALID_ROLES = new Set<string>(["mod", "sr_mod", "owner"]);
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = req.nextUrl;
+  const creator_id = searchParams.get("creator_id");
+
+  if (!creator_id) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ moderators: modsForCreator(creator_id) });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const {
+    creator_id,
+    viewer_id,
+    role,
+  } = (body ?? {}) as Record<string, unknown>;
+
+  if (
+    typeof creator_id !== "string" ||
+    !creator_id ||
+    typeof viewer_id !== "string" ||
+    !viewer_id ||
+    typeof role !== "string" ||
+    !VALID_ROLES.has(role)
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "creator_id (string), viewer_id (string), and role ('mod' | 'sr_mod' | 'owner') are required",
+      },
+      { status: 400 }
+    );
+  }
+
+  const key = storeKey(creator_id, viewer_id);
+  const isExisting = modStore.has(key);
+
+  if (!isExisting) {
+    // New mod — check cap
+    const existing = modsForCreator(creator_id);
+    if (existing.length >= MOD_CAP) {
+      return NextResponse.json(
+        { error: `Cannot exceed ${MOD_CAP} moderators per creator` },
+        { status: 400 }
+      );
+    }
+  }
+
+  const mod: Mod = {
+    creator_id,
+    viewer_id,
+    role: role as ModRole,
+    added_at: isExisting
+      ? (modStore.get(key)!.added_at)
+      : new Date().toISOString(),
+  };
+
+  modStore.set(key, mod);
+
+  return NextResponse.json(mod, { status: isExisting ? 200 : 201 });
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, viewer_id } = (body ?? {}) as Record<string, unknown>;
+
+  if (
+    typeof creator_id !== "string" ||
+    !creator_id ||
+    typeof viewer_id !== "string" ||
+    !viewer_id
+  ) {
+    return NextResponse.json(
+      { error: "creator_id and viewer_id are required" },
+      { status: 400 }
+    );
+  }
+
+  const key = storeKey(creator_id, viewer_id);
+  if (!modStore.has(key)) {
+    return NextResponse.json({ error: "Moderator not found" }, { status: 404 });
+  }
+
+  modStore.delete(key);
+
+  return NextResponse.json({ message: "Moderator removed" });
+}

--- a/app/api/routes-f/swift-bic/iso-countries.ts
+++ b/app/api/routes-f/swift-bic/iso-countries.ts
@@ -1,0 +1,42 @@
+/**
+ * Inline ISO 3166-1 alpha-2 country code set.
+ * Intentionally self-contained inside app/api/routes-f/ — do not import from outside.
+ */
+export const ISO_COUNTRY_CODES = new Set<string>([
+  "AD", // Andorra
+  "AE", // United Arab Emirates
+  "AT", // Austria
+  "AU", // Australia
+  "BE", // Belgium
+  "BR", // Brazil
+  "CA", // Canada
+  "CH", // Switzerland
+  "CN", // China
+  "DE", // Germany
+  "DK", // Denmark
+  "EG", // Egypt
+  "ES", // Spain
+  "FR", // France
+  "GB", // United Kingdom
+  "GH", // Ghana
+  "HK", // Hong Kong
+  "IN", // India
+  "IT", // Italy
+  "JP", // Japan
+  "KE", // Kenya
+  "MX", // Mexico
+  "NG", // Nigeria
+  "NL", // Netherlands
+  "NO", // Norway
+  "NZ", // New Zealand
+  "PL", // Poland
+  "PT", // Portugal
+  "RU", // Russia
+  "SA", // Saudi Arabia
+  "SE", // Sweden
+  "SG", // Singapore
+  "TZ", // Tanzania
+  "US", // United States
+  "ZA", // South Africa
+  "ZW", // Zimbabwe
+]);

--- a/app/api/routes-f/swift-bic/route.test.ts
+++ b/app/api/routes-f/swift-bic/route.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/swift-bic", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routes-f/swift-bic", () => {
+  it("returns valid: true with all fields for a valid 8-char BIC", async () => {
+    // DEUTDEFF — Deutsche Bank, Germany, Frankfurt, no branch
+    const req = makeReq({ bic: "DEUTDEFF" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.valid).toBe(true);
+    expect(data.bank_code).toBe("DEUT");
+    expect(data.country).toBe("DE");
+    expect(data.location_code).toBe("FF");
+    expect(data.branch).toBeNull();
+  });
+
+  it("returns valid: true with branch for a valid 11-char BIC", async () => {
+    // DEUTDEFF500 — Deutsche Bank, Germany, Frankfurt, branch 500
+    const req = makeReq({ bic: "DEUTDEFF500" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.valid).toBe(true);
+    expect(data.bank_code).toBe("DEUT");
+    expect(data.country).toBe("DE");
+    expect(data.location_code).toBe("FF");
+    expect(data.branch).toBe("500");
+  });
+
+  it("returns valid: false for wrong-length BIC", async () => {
+    // 7 chars — too short
+    const req = makeReq({ bic: "DEUTDEF" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+  });
+
+  it("returns valid: false with error for unknown country code", async () => {
+    // BANKZZFF — country code ZZ does not exist
+    const req = makeReq({ bic: "BANKZZFF" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+    expect(data.error).toBe("unknown country code");
+  });
+
+  it("returns valid: false for lowercase BIC (must be uppercase)", async () => {
+    const req = makeReq({ bic: "deutdeff" });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.valid).toBe(false);
+  });
+});

--- a/app/api/routes-f/swift-bic/route.ts
+++ b/app/api/routes-f/swift-bic/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ISO_COUNTRY_CODES } from "./iso-countries";
+
+/**
+ * BIC / SWIFT code validator
+ *
+ * Format: [A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?
+ *   chars 1-4  : bank code       (A-Z, 4 letters)
+ *   chars 5-6  : country code    (A-Z, ISO 3166-1 alpha-2)
+ *   chars 7-8  : location code   (A-Z0-9, 2 chars)
+ *   chars 9-11 : branch code     (A-Z0-9, 3 chars, optional; 'XXX' = primary)
+ */
+
+const BIC_REGEX = /^([A-Z]{4})([A-Z]{2})([A-Z0-9]{2})([A-Z0-9]{3})?$/;
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ valid: false }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("bic" in body) ||
+    typeof (body as Record<string, unknown>).bic !== "string"
+  ) {
+    return NextResponse.json({ valid: false }, { status: 400 });
+  }
+
+  const bic = (body as { bic: string }).bic;
+
+  const match = BIC_REGEX.exec(bic);
+  if (!match) {
+    return NextResponse.json({ valid: false });
+  }
+
+  const [, bankCode, countryCode, locationCode, branchCode] = match;
+
+  if (!ISO_COUNTRY_CODES.has(countryCode)) {
+    return NextResponse.json(
+      { valid: false, error: "unknown country code" },
+      { status: 200 }
+    );
+  }
+
+  return NextResponse.json({
+    valid: true,
+    bank_code: bankCode,
+    country: countryCode,
+    location_code: locationCode,
+    branch: branchCode ?? null,
+  });
+}


### PR DESCRIPTION
## Summary

Four self-contained route implementations and tests inside `app/api/routes-f/`. No files modified outside that folder.

## Changes

### #433 — Category management endpoint tests
- `app/api/routes-f/__tests__/categories.test.ts`: 6 tests covering GET list, POST create (admin/non-admin), GET by unknown slug, PATCH update, DELETE; mocks `@vercel/postgres` and `@/lib/auth/verify-session`

### #790 — SWIFT/BIC code validator
- `app/api/routes-f/swift-bic/iso-countries.ts`: inline 36-country ISO 3166-1 set
- `app/api/routes-f/swift-bic/route.ts`: POST validates 8/11-char BIC regex, parses bank/country/location/branch fields
- `app/api/routes-f/swift-bic/route.test.ts`: 5 tests (valid 8-char, valid 11-char, wrong length, unknown country, lowercase rejection)

### #1035 — Closed captions toggle and data
- `app/api/routes-f/closed-captions/seed-tracks.ts`: bundled caption track seed data
- `app/api/routes-f/closed-captions/route.ts`: GET by `playback_id` or `viewer_id`, PUT to update prefs; in-memory store
- `app/api/routes-f/closed-captions/route.test.ts`: 5 tests including GET→PUT→GET round-trip

### #1055 — Channel mod team management
- `app/api/routes-f/mod-team/route.ts`: GET/POST/DELETE with upsert semantics, 20-mod cap per creator; in-memory store
- `app/api/routes-f/mod-team/route.test.ts`: 5 tests (list, assign, upsert role, delete, cap enforcement)

closes #433
closes #790
closes #1035
closes #1055