### PR TITLE
feat(routes-f): add tip refund, heatmap, playback source, and resume …

### DIFF
--- a/app/api/routes-f/__tests__/playback-source.test.ts
+++ b/app/api/routes-f/__tests__/playback-source.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST, store } from "../playback-source/route";
+
+function makePost(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/playback-source", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/playback-source");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+describe("Playback Source Selection API", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  });
+
+  describe("POST /api/routes-f/playback-source", () => {
+    it("returns 400 for missing fields", async () => {
+      const res = await POST(makePost({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("stores a quality selection", async () => {
+      const res = await POST(makePost({ viewer_id: "v1", playback_id: "pb-1", quality_label: "720p" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.stored).toBe(true);
+      expect(store["v1"].label).toBe("720p");
+      expect(store["v1"].resolution).toBe("1280x720");
+    });
+
+    it("overwrites a previous selection", async () => {
+      await POST(makePost({ viewer_id: "v1", playback_id: "pb-1", quality_label: "720p" }));
+      await POST(makePost({ viewer_id: "v1", playback_id: "pb-2", quality_label: "1080p" }));
+      expect(store["v1"].label).toBe("1080p");
+      expect(store["v1"].resolution).toBe("1920x1080");
+      expect(store["v1"].playback_id).toBe("pb-2");
+    });
+  });
+
+  describe("GET /api/routes-f/playback-source", () => {
+    it("returns 400 for missing viewer_id", async () => {
+      const res = await GET(makeGet({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns null when no selection exists", async () => {
+      const res = await GET(makeGet({ viewer_id: "v-unknown" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.last_quality).toBeNull();
+    });
+
+    it("returns the last stored quality", async () => {
+      await POST(makePost({ viewer_id: "v2", playback_id: "pb-1", quality_label: "480p" }));
+      const res = await GET(makeGet({ viewer_id: "v2" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.last_quality.label).toBe("480p");
+      expect(body.last_quality.resolution).toBe("854x480");
+    });
+
+    it("retrieves overwritten quality correctly", async () => {
+      await POST(makePost({ viewer_id: "v3", playback_id: "pb-1", quality_label: "360p" }));
+      await POST(makePost({ viewer_id: "v3", playback_id: "pb-1", quality_label: "1080p" }));
+      const res = await GET(makeGet({ viewer_id: "v3" }));
+      const body = await res.json();
+      expect(body.last_quality.label).toBe("1080p");
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/resume-position.test.ts
+++ b/app/api/routes-f/__tests__/resume-position.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST, store } from "../resume-position/route";
+
+function makePost(body: object) {
+  return new NextRequest("http://localhost/api/routes-f/resume-position", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/resume-position");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+describe("Resume Position API", () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  });
+
+  describe("POST /api/routes-f/resume-position", () => {
+    it("returns 400 for missing fields", async () => {
+      const res = await POST(makePost({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("saves a position", async () => {
+      const res = await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 300, duration_seconds: 1200 }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.saved).toBe(true);
+    });
+
+    it("marks completed=false when below 95%", async () => {
+      await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 940, duration_seconds: 1000 }));
+      expect(store["v1:vod-1"].completed).toBe(false);
+    });
+
+    it("marks completed=true at exactly 95%", async () => {
+      await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 950, duration_seconds: 1000 }));
+      expect(store["v1:vod-1"].completed).toBe(true);
+    });
+
+    it("marks completed=true above 95%", async () => {
+      await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 990, duration_seconds: 1000 }));
+      expect(store["v1:vod-1"].completed).toBe(true);
+    });
+
+    it("overwrites a previous position", async () => {
+      await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 300, duration_seconds: 1200 }));
+      await POST(makePost({ viewer_id: "v1", vod_id: "vod-1", position_seconds: 600, duration_seconds: 1200 }));
+      expect(store["v1:vod-1"].position_seconds).toBe(600);
+    });
+  });
+
+  describe("GET /api/routes-f/resume-position", () => {
+    it("returns 400 for missing params", async () => {
+      const res = await GET(makeGet({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns default 0/false when no record exists", async () => {
+      const res = await GET(makeGet({ viewer_id: "v-none", vod_id: "vod-x" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.position_seconds).toBe(0);
+      expect(body.completed).toBe(false);
+    });
+
+    it("returns saved position and completed flag", async () => {
+      await POST(makePost({ viewer_id: "v2", vod_id: "vod-2", position_seconds: 500, duration_seconds: 600 }));
+      const res = await GET(makeGet({ viewer_id: "v2", vod_id: "vod-2" }));
+      const body = await res.json();
+      expect(body.position_seconds).toBe(500);
+      expect(body.completed).toBe(false);
+    });
+
+    it("returns completed=true when position >= 95%", async () => {
+      await POST(makePost({ viewer_id: "v3", vod_id: "vod-3", position_seconds: 1140, duration_seconds: 1200 }));
+      const res = await GET(makeGet({ viewer_id: "v3", vod_id: "vod-3" }));
+      const body = await res.json();
+      expect(body.completed).toBe(true);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/tip-heatmap.test.ts
+++ b/app/api/routes-f/__tests__/tip-heatmap.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, buildHeatmap } from "../tip-heatmap/route";
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/tip-heatmap");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+describe("Tip Heatmap API", () => {
+  describe("GET /api/routes-f/tip-heatmap", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeGet({}));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("creator_id is required");
+    });
+
+    it("returns a 7x24 matrix", async () => {
+      const res = await GET(makeGet({ creator_id: "creator-1" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.heatmap).toHaveLength(7);
+      body.heatmap.forEach((row: number[]) => expect(row).toHaveLength(24));
+    });
+
+    it("returns the creator timezone in the response", async () => {
+      const res = await GET(makeGet({ creator_id: "creator-1" }));
+      const body = await res.json();
+      expect(body.timezone).toBe("America/New_York");
+    });
+
+    it("uses UTC for unknown creator", async () => {
+      const res = await GET(makeGet({ creator_id: "unknown-creator" }));
+      const body = await res.json();
+      expect(body.timezone).toBe("UTC");
+    });
+  });
+
+  describe("buildHeatmap bucket math", () => {
+    it("places a known UTC tip into the correct NY bucket", () => {
+      // 2024-01-15T20:00:00Z = Monday 15:00 in America/New_York (EST = UTC-5)
+      const tips = [{ creator_id: "c1", amount_usdc: 5.0, ts: "2024-01-15T20:00:00Z" }];
+      const matrix = buildHeatmap(tips, "c1", "America/New_York");
+      expect(matrix[1][15]).toBe(5.0);
+    });
+
+    it("places a known UTC tip into the correct London bucket", () => {
+      // 2024-06-15T14:00:00Z = Saturday 15:00 in Europe/London (BST = UTC+1)
+      const tips = [{ creator_id: "c2", amount_usdc: 3.0, ts: "2024-06-15T14:00:00Z" }];
+      const matrix = buildHeatmap(tips, "c2", "Europe/London");
+      expect(matrix[6][15]).toBe(3.0);
+    });
+
+    it("accumulates multiple tips in the same bucket", () => {
+      const tips = [
+        { creator_id: "c1", amount_usdc: 2.0, ts: "2024-01-15T20:00:00Z" },
+        { creator_id: "c1", amount_usdc: 3.5, ts: "2024-01-15T20:30:00Z" },
+      ];
+      const matrix = buildHeatmap(tips, "c1", "America/New_York");
+      expect(matrix[1][15]).toBeCloseTo(5.5);
+    });
+
+    it("ignores tips from other creators", () => {
+      const tips = [{ creator_id: "other", amount_usdc: 99.0, ts: "2024-01-15T20:00:00Z" }];
+      const matrix = buildHeatmap(tips, "c1", "America/New_York");
+      const total = matrix.flat().reduce((a, b) => a + b, 0);
+      expect(total).toBe(0);
+    });
+  });
+});

--- a/app/api/routes-f/__tests__/tip-refund.test.ts
+++ b/app/api/routes-f/__tests__/tip-refund.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST as postRequest, refundRequests } from "../tip-refund/route";
+import { POST as postResolve } from "../tip-refund/resolve/route";
+
+function makePost(url: string, body: object) {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE = "http://localhost/api/routes-f/tip-refund";
+const RESOLVE = "http://localhost/api/routes-f/tip-refund/resolve";
+
+describe("Tip Refund API", () => {
+  beforeEach(() => {
+    refundRequests.length = 0;
+  });
+
+  describe("POST /api/routes-f/tip-refund", () => {
+    it("returns 400 for missing fields", async () => {
+      const res = await postRequest(makePost(BASE, {}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for unknown tip", async () => {
+      const res = await postRequest(makePost(BASE, { tip_id: "bad-tip", tipper_id: "viewer-1", reason: "wrong amount" }));
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for tip older than 24h", async () => {
+      const res = await postRequest(makePost(BASE, { tip_id: "tip-003", tipper_id: "viewer-3", reason: "expired" }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/24 hours/);
+    });
+
+    it("returns 403 if tipper_id does not match", async () => {
+      const res = await postRequest(makePost(BASE, { tip_id: "tip-001", tipper_id: "wrong-viewer", reason: "test" }));
+      expect(res.status).toBe(403);
+    });
+
+    it("creates a pending refund request", async () => {
+      const res = await postRequest(makePost(BASE, { tip_id: "tip-001", tipper_id: "viewer-1", reason: "sent too much" }));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.status).toBe("pending");
+      expect(body.request_id).toBeDefined();
+    });
+  });
+
+  describe("POST /api/routes-f/tip-refund/resolve", () => {
+    it("returns 400 for missing fields", async () => {
+      const res = await postResolve(makePost(RESOLVE, {}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for unknown request_id", async () => {
+      const res = await postResolve(makePost(RESOLVE, { request_id: "req-9999", decision: "approve", creator_id: "creator-1" }));
+      expect(res.status).toBe(404);
+    });
+
+    it("approves a refund request", async () => {
+      await postRequest(makePost(BASE, { tip_id: "tip-001", tipper_id: "viewer-1", reason: "test" }));
+      const reqId = refundRequests[0].request_id;
+      const res = await postResolve(makePost(RESOLVE, { request_id: reqId, decision: "approve", creator_id: "creator-1", note: "ok" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.decision).toBe("approve");
+      expect(body.note).toBe("ok");
+    });
+
+    it("denies a refund request", async () => {
+      await postRequest(makePost(BASE, { tip_id: "tip-002", tipper_id: "viewer-2", reason: "test" }));
+      const reqId = refundRequests[0].request_id;
+      const res = await postResolve(makePost(RESOLVE, { request_id: reqId, decision: "deny", creator_id: "creator-1" }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.decision).toBe("deny");
+    });
+
+    it("returns 409 if already resolved", async () => {
+      await postRequest(makePost(BASE, { tip_id: "tip-001", tipper_id: "viewer-1", reason: "test" }));
+      const reqId = refundRequests[0].request_id;
+      await postResolve(makePost(RESOLVE, { request_id: reqId, decision: "approve", creator_id: "creator-1" }));
+      const res = await postResolve(makePost(RESOLVE, { request_id: reqId, decision: "deny", creator_id: "creator-1" }));
+      expect(res.status).toBe(409);
+    });
+  });
+});

--- a/app/api/routes-f/playback-source/__tests__/route.test.ts
+++ b/app/api/routes-f/playback-source/__tests__/route.test.ts
@@ -1,0 +1,2 @@
+// Tests moved to app/api/routes-f/__tests__/playback-source.test.ts
+export {};

--- a/app/api/routes-f/playback-source/route.ts
+++ b/app/api/routes-f/playback-source/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export interface QualitySelection {
+  viewer_id: string;
+  playback_id: string;
+  label: string;
+  resolution: string;
+  stored_at: string;
+}
+
+const QUALITY_RESOLUTIONS: Record<string, string> = {
+  "1080p": "1920x1080",
+  "720p": "1280x720",
+  "480p": "854x480",
+  "360p": "640x360",
+  "160p": "284x160",
+  auto: "adaptive",
+};
+
+export const store: Record<string, QualitySelection> = {};
+
+const postSchema = z.object({
+  viewer_id: z.string().min(1),
+  playback_id: z.string().min(1),
+  quality_label: z.string().min(1),
+});
+
+const getSchema = z.object({
+  viewer_id: z.string().min(1),
+});
+
+/**
+ * POST /api/routes-f/playback-source
+ * Record a viewer's manual quality selection
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = postSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { viewer_id, playback_id, quality_label } = parsed.data;
+  const resolution = QUALITY_RESOLUTIONS[quality_label] ?? "unknown";
+
+  store[viewer_id] = { viewer_id, playback_id, label: quality_label, resolution, stored_at: new Date().toISOString() };
+
+  return NextResponse.json({ stored: true });
+}
+
+/**
+ * GET /api/routes-f/playback-source?viewer_id=...
+ * Return the viewer's last quality selection
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = getSchema.safeParse(params);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "viewer_id is required" }, { status: 400 });
+  }
+
+  const entry = store[parsed.data.viewer_id];
+  if (!entry) {
+    return NextResponse.json({ last_quality: null });
+  }
+
+  return NextResponse.json({ last_quality: { label: entry.label, resolution: entry.resolution } });
+}

--- a/app/api/routes-f/resume-position/__tests__/route.test.ts
+++ b/app/api/routes-f/resume-position/__tests__/route.test.ts
@@ -1,0 +1,2 @@
+// Tests moved to app/api/routes-f/__tests__/resume-position.test.ts
+export {};

--- a/app/api/routes-f/resume-position/route.ts
+++ b/app/api/routes-f/resume-position/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const COMPLETION_THRESHOLD = 0.95;
+
+export interface PositionRecord {
+  viewer_id: string;
+  vod_id: string;
+  position_seconds: number;
+  duration_seconds: number;
+  completed: boolean;
+  saved_at: string;
+}
+
+export const store: Record<string, PositionRecord> = {};
+
+const postSchema = z.object({
+  viewer_id: z.string().min(1),
+  vod_id: z.string().min(1),
+  position_seconds: z.number().nonnegative(),
+  duration_seconds: z.number().positive(),
+});
+
+const getSchema = z.object({
+  viewer_id: z.string().min(1),
+  vod_id: z.string().min(1),
+});
+
+/**
+ * POST /api/routes-f/resume-position
+ * Save a viewer's playback position on a VOD
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = postSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { viewer_id, vod_id, position_seconds, duration_seconds } = parsed.data;
+  const completed = position_seconds / duration_seconds >= COMPLETION_THRESHOLD;
+
+  store[`${viewer_id}:${vod_id}`] = { viewer_id, vod_id, position_seconds, duration_seconds, completed, saved_at: new Date().toISOString() };
+
+  return NextResponse.json({ saved: true });
+}
+
+/**
+ * GET /api/routes-f/resume-position?viewer_id=...&vod_id=...
+ * Return the viewer's last position and completion status
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const params = Object.fromEntries(new URL(req.url).searchParams.entries());
+  const parsed = getSchema.safeParse(params);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "viewer_id and vod_id are required" }, { status: 400 });
+  }
+
+  const { viewer_id, vod_id } = parsed.data;
+  const entry = store[`${viewer_id}:${vod_id}`];
+
+  if (!entry) {
+    return NextResponse.json({ position_seconds: 0, completed: false });
+  }
+
+  return NextResponse.json({ position_seconds: entry.position_seconds, completed: entry.completed });
+}

--- a/app/api/routes-f/tip-heatmap/__tests__/route.test.ts
+++ b/app/api/routes-f/tip-heatmap/__tests__/route.test.ts
@@ -1,0 +1,2 @@
+// Tests moved to app/api/routes-f/__tests__/tip-heatmap.test.ts
+export {};

--- a/app/api/routes-f/tip-heatmap/route.ts
+++ b/app/api/routes-f/tip-heatmap/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export interface SeedTip {
+  creator_id: string;
+  amount_usdc: number;
+  ts: string; // ISO 8601
+}
+
+function buildSeedTips(): SeedTip[] {
+  const tips: SeedTip[] = [];
+  const now = Date.now();
+  const creators = ["creator-1", "creator-2"];
+  for (let i = 0; i < 200; i++) {
+    tips.push({
+      creator_id: creators[i % 2],
+      amount_usdc: Number((1 + (i % 20) * 0.5).toFixed(2)),
+      ts: new Date(now - i * 3600 * 1000).toISOString(),
+    });
+  }
+  return tips;
+}
+
+export const SEED_TIPS: SeedTip[] = buildSeedTips();
+
+// Known creator timezones
+const CREATOR_TIMEZONES: Record<string, string> = {
+  "creator-1": "America/New_York",
+  "creator-2": "Europe/London",
+};
+
+export function buildHeatmap(
+  tips: SeedTip[],
+  creator_id: string,
+  timezone: string
+): number[][] {
+  // matrix[day][hour] — day 0=Sunday
+  const matrix: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0));
+
+  for (const tip of tips) {
+    if (tip.creator_id !== creator_id) {
+      continue;
+    }
+
+    const date = new Date(tip.ts);
+    // Use Intl to get local day-of-week and hour in creator's timezone
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      weekday: "short",
+      hour: "numeric",
+      hour12: false,
+    }).formatToParts(date);
+
+    const weekdayMap: Record<string, number> = {
+      Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+    };
+
+    const weekdayStr = parts.find((p) => p.type === "weekday")?.value ?? "Sun";
+    const hourStr = parts.find((p) => p.type === "hour")?.value ?? "0";
+
+    const day = weekdayMap[weekdayStr] ?? 0;
+    const hour = parseInt(hourStr, 10) % 24;
+
+    matrix[day][hour] = Number((matrix[day][hour] + tip.amount_usdc).toFixed(2));
+  }
+
+  return matrix;
+}
+
+/**
+ * GET /api/routes-f/tip-heatmap?creator_id=...
+ * Returns a 7x24 matrix of USDC tip totals bucketed by day-of-week and hour-of-day
+ * in the creator's local timezone.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creator_id = searchParams.get("creator_id");
+
+  if (!creator_id) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+
+  const timezone = CREATOR_TIMEZONES[creator_id] ?? "UTC";
+  const matrix = buildHeatmap(SEED_TIPS, creator_id, timezone);
+
+  return NextResponse.json({ creator_id, timezone, heatmap: matrix });
+}

--- a/app/api/routes-f/tip-refund/__tests__/route.test.ts
+++ b/app/api/routes-f/tip-refund/__tests__/route.test.ts
@@ -1,0 +1,2 @@
+// Tests moved to app/api/routes-f/__tests__/tip-refund.test.ts
+export {};

--- a/app/api/routes-f/tip-refund/resolve/route.ts
+++ b/app/api/routes-f/tip-refund/resolve/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { refundRequests, RefundRequest } from "../route";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type ResolvedRequest = RefundRequest & {
+  resolved_status?: string;
+  resolved_by?: string;
+  note?: string | null;
+  resolved_at?: string;
+};
+
+const resolveSchema = z.object({
+  request_id: z.string().min(1),
+  decision: z.enum(["approve", "deny"]),
+  creator_id: z.string().min(1),
+  note: z.string().optional(),
+});
+
+/**
+ * POST /api/routes-f/tip-refund/resolve
+ * Creator approves or denies a refund request
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = resolveSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { request_id, decision, creator_id, note } = parsed.data;
+
+  const request = refundRequests.find((r) => r.request_id === request_id) as ResolvedRequest | undefined;
+  if (!request) {
+    return NextResponse.json({ error: "Refund request not found" }, { status: 404 });
+  }
+
+  if (request.resolved_status) {
+    return NextResponse.json({ error: "Refund request already resolved" }, { status: 409 });
+  }
+
+  request.resolved_status = decision;
+  request.resolved_by = creator_id;
+  request.note = note ?? null;
+  request.resolved_at = new Date().toISOString();
+
+  return NextResponse.json({ request_id, decision, note: note ?? null });
+}

--- a/app/api/routes-f/tip-refund/route.ts
+++ b/app/api/routes-f/tip-refund/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const REFUND_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export interface TipRecord {
+  tip_id: string;
+  tipper_id: string;
+  amount_usdc: number;
+  ts: string;
+}
+
+export interface RefundRequest {
+  request_id: string;
+  tip_id: string;
+  tipper_id: string;
+  reason: string;
+  status: "pending";
+  created_at: string;
+}
+
+export const SEED_TIPS: Record<string, TipRecord> = {
+  "tip-001": { tip_id: "tip-001", tipper_id: "viewer-1", amount_usdc: 5.0, ts: new Date(Date.now() - 2 * 3600 * 1000).toISOString() },
+  "tip-002": { tip_id: "tip-002", tipper_id: "viewer-2", amount_usdc: 10.0, ts: new Date(Date.now() - 12 * 3600 * 1000).toISOString() },
+  "tip-003": { tip_id: "tip-003", tipper_id: "viewer-3", amount_usdc: 2.5, ts: new Date(Date.now() - 30 * 3600 * 1000).toISOString() },
+};
+
+export const refundRequests: RefundRequest[] = [];
+
+let requestCounter = 1;
+
+const requestSchema = z.object({
+  tip_id: z.string().min(1),
+  tipper_id: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+/**
+ * POST /api/routes-f/tip-refund
+ * Submit a refund request for a recent tip
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request body", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { tip_id, tipper_id, reason } = parsed.data;
+
+  const tip = SEED_TIPS[tip_id];
+  if (!tip) {
+    return NextResponse.json({ error: "Tip not found" }, { status: 404 });
+  }
+
+  const age = Date.now() - new Date(tip.ts).getTime();
+  if (age > REFUND_WINDOW_MS) {
+    return NextResponse.json(
+      { error: "Tip is older than 24 hours and is not eligible for refund" },
+      { status: 400 }
+    );
+  }
+
+  if (tip.tipper_id !== tipper_id) {
+    return NextResponse.json({ error: "Tipper ID does not match" }, { status: 403 });
+  }
+
+
+  const request_id = `req-${String(requestCounter++).padStart(4, "0")}`;
+  const entry: RefundRequest = {
+    request_id,
+    tip_id,
+    tipper_id,
+    reason,
+    status: "pending",
+    created_at: new Date().toISOString(),
+  };
+  refundRequests.push(entry);
+
+  return NextResponse.json({ request_id, status: "pending" }, { status: 201 });
+}


### PR DESCRIPTION


feat(routes-f): add 4 new route handlers — tip refund, tip heatmap, playback source selection, and resume position

Resolves #1048, 
Closes : #1023, 
Closes : #1030, 
Closes : #1031

All files are scoped to `app/api/routes-f/` per the task constraints. No modifications to `lib/`, `utils/`, `types/`, `components/`, or any other shared directories.

## Changes

### 1. Tip Refund Request (#1048)
- `POST /api/routes-f/tip-refund` — Submits a refund request. Validates tip age (rejects >24h with 400), verifies tipper ownership (403 mismatch), returns `{ request_id, status: "pending" }` on success.
- `POST /api/routes-f/tip-refund/resolve` — Creator approves or denies a pending request. Returns 409 if already resolved.

### 2. Tip Heatmap by Hour (#1023)
- `GET /api/routes-f/tip-heatmap?creator_id=...` — Returns a 7x24 matrix of USDC totals bucketed by day-of-week and hour-of-day.
- Seed tip data is bundled in-module. Bucketing uses each creator's local timezone (e.g. `America/New_York`, `Europe/London`) via `Intl.DateTimeFormat`.

### 3. Viewer Playback Source Selection (#1030)
- `POST /api/routes-f/playback-source` — Records a viewer's manual quality selection (`viewer_id`, `playback_id`, `quality_label`), maps to known resolutions.
- `GET /api/routes-f/playback-source?viewer_id=...` — Returns `{ last_quality: { label, resolution } }`.

### 4. Resume from Last Position (#1031)
- `POST /api/routes-f/resume-position` — Saves viewer VOD position (`viewer_id`, `vod_id`, `position_seconds`, `duration_seconds`). Automatically flags `completed: true` when position >= 95% of duration.
- `GET /api/routes-f/resume-position?viewer_id=...&vod_id=...` — Returns `{ position_seconds, completed }`.

## Tests
- `app/api/routes-f/__tests__/tip-refund.test.ts` — 10 tests covering request creation, 24h expiry, tipper mismatch, approval, denial, and duplicate resolution.
- `app/api/routes-f/__tests__/tip-heatmap.test.ts` — 8 tests covering matrix shape, timezone lookup, and bucket math against known UTC timestamps.
- `app/api/routes-f/__tests__/playback-source.test.ts` — 7 tests covering store, overwrite, and retrieval.
- `app/api/routes-f/__tests__/resume-position.test.ts` — 10 tests covering save, resume, completion threshold, and overwrite.

All tests pass.