### PR TITLE
feat(routes-f): add dvr bookmarks and channel management apis (#1033, #1036, #1038, #1039)

### DIFF
--- a/app/api/routes-f/channel/about/__tests__/route.test.ts
+++ b/app/api/routes-f/channel/about/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../route";
+import { clearAllAboutPages } from "../store";
+import { MAX_ABOUT_BYTES } from "../types";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/channel/about");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePutReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/channel/about", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("channel/about", () => {
+  beforeEach(() => {
+    clearAllAboutPages();
+  });
+
+  describe("GET", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns empty about for unknown creator", async () => {
+      const res = await GET(makeGetReq({ creator_id: "creator_new" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.about_markdown).toBe("");
+      expect(data.last_updated).toBeNull();
+    });
+
+    it("returns saved about content", async () => {
+      await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          about_markdown: "# Welcome\n\nI stream on StreamFi.",
+        })
+      );
+
+      const res = await GET(makeGetReq({ creator_id: "creator_1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.about_markdown).toContain("Welcome");
+      expect(typeof data.last_updated).toBe("string");
+    });
+  });
+
+  describe("PUT", () => {
+    it("updates about content", async () => {
+      const res = await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          about_markdown: "Tips accepted in **XLM** and **USDC**.",
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.about_markdown).toContain("USDC");
+      expect(typeof data.last_updated).toBe("string");
+    });
+
+    it("rejects content over 50KB", async () => {
+      const oversized = "x".repeat(MAX_ABOUT_BYTES + 1);
+      const res = await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          about_markdown: oversized,
+        })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("50");
+    });
+
+    it("accepts content at exactly 50KB", async () => {
+      const exact = "x".repeat(MAX_ABOUT_BYTES);
+      const res = await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          about_markdown: exact,
+        })
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await PUT(makePutReq({ about_markdown: "hello" }));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/channel/about/route.ts
+++ b/app/api/routes-f/channel/about/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { GetAboutResponse, PutAboutBody } from "./types";
+import { MAX_ABOUT_BYTES } from "./types";
+import { getAbout, upsertAbout, byteLength } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const about = getAbout(creatorId);
+  if (!about) {
+    return NextResponse.json({
+      about_markdown: "",
+      last_updated: null,
+    });
+  }
+
+  return NextResponse.json({
+    about_markdown: about.about_markdown,
+    last_updated: about.last_updated,
+  } satisfies GetAboutResponse);
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: PutAboutBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, about_markdown } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (typeof about_markdown !== "string") {
+    return NextResponse.json(
+      { error: "about_markdown is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  if (byteLength(about_markdown) > MAX_ABOUT_BYTES) {
+    return NextResponse.json(
+      { error: "about_markdown exceeds maximum size of 50KB" },
+      { status: 400 }
+    );
+  }
+
+  const updated = upsertAbout(creator_id, about_markdown);
+  return NextResponse.json({
+    about_markdown: updated.about_markdown,
+    last_updated: updated.last_updated,
+  });
+}

--- a/app/api/routes-f/channel/about/store.ts
+++ b/app/api/routes-f/channel/about/store.ts
@@ -1,0 +1,29 @@
+import type { ChannelAbout } from "./types";
+
+const aboutPages = new Map<string, ChannelAbout>();
+
+export function getAbout(creatorId: string): ChannelAbout | null {
+  return aboutPages.get(creatorId) ?? null;
+}
+
+export function upsertAbout(
+  creatorId: string,
+  aboutMarkdown: string
+): ChannelAbout {
+  const now = new Date().toISOString();
+  const record: ChannelAbout = {
+    creator_id: creatorId,
+    about_markdown: aboutMarkdown,
+    last_updated: now,
+  };
+  aboutPages.set(creatorId, record);
+  return record;
+}
+
+export function clearAllAboutPages(): void {
+  aboutPages.clear();
+}
+
+export function byteLength(content: string): number {
+  return new TextEncoder().encode(content).length;
+}

--- a/app/api/routes-f/channel/about/types.ts
+++ b/app/api/routes-f/channel/about/types.ts
@@ -1,0 +1,17 @@
+export interface ChannelAbout {
+  creator_id: string;
+  about_markdown: string;
+  last_updated: string;
+}
+
+export interface GetAboutResponse {
+  about_markdown: string;
+  last_updated: string | null;
+}
+
+export interface PutAboutBody {
+  creator_id: string;
+  about_markdown: string;
+}
+
+export const MAX_ABOUT_BYTES = 50 * 1024;

--- a/app/api/routes-f/channel/info-panels/[panel_id]/route.ts
+++ b/app/api/routes-f/channel/info-panels/[panel_id]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { PatchPanelBody } from "../types";
+import { findPanel, updatePanel, deletePanel } from "../store";
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ panel_id: string }> }
+): Promise<NextResponse> {
+  const { panel_id } = await context.params;
+
+  let body: PatchPanelBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { title, body_markdown, image_url } = body;
+
+  if (
+    title === undefined &&
+    body_markdown === undefined &&
+    image_url === undefined
+  ) {
+    return NextResponse.json(
+      { error: "At least one field to update is required" },
+      { status: 400 }
+    );
+  }
+
+  if (title !== undefined && (typeof title !== "string" || title.trim().length === 0)) {
+    return NextResponse.json(
+      { error: "title must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+  if (
+    body_markdown !== undefined &&
+    (typeof body_markdown !== "string" || body_markdown.trim().length === 0)
+  ) {
+    return NextResponse.json(
+      { error: "body_markdown must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+  if (image_url !== undefined && image_url !== null && typeof image_url !== "string") {
+    return NextResponse.json(
+      { error: "image_url must be a string or null" },
+      { status: 400 }
+    );
+  }
+
+  if (!findPanel(panel_id)) {
+    return NextResponse.json({ error: "Panel not found" }, { status: 404 });
+  }
+
+  const updated = updatePanel(panel_id, { title, body_markdown, image_url });
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: Promise<{ panel_id: string }> }
+): Promise<NextResponse> {
+  const { panel_id } = await context.params;
+
+  const removed = deletePanel(panel_id);
+  if (!removed) {
+    return NextResponse.json({ error: "Panel not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ removed: true });
+}

--- a/app/api/routes-f/channel/info-panels/__tests__/route.test.ts
+++ b/app/api/routes-f/channel/info-panels/__tests__/route.test.ts
@@ -1,0 +1,203 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { PATCH, DELETE } from "../[panel_id]/route";
+import { POST as REORDER_POST } from "../reorder/route";
+import { clearAllPanels } from "../store";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/channel/info-panels");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/channel/info-panels", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatchReq(panelId: string, body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/channel/info-panels/${panelId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeDeleteReq(panelId: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/channel/info-panels/${panelId}`,
+    { method: "DELETE" }
+  );
+}
+
+function makeReorderReq(body: unknown): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/routes-f/channel/info-panels/reorder",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("channel/info-panels", () => {
+  beforeEach(() => {
+    clearAllPanels();
+  });
+
+  describe("full lifecycle", () => {
+    it("creates, lists, updates, and deletes panels", async () => {
+      const createRes = await POST(
+        makePostReq({
+          creator_id: "creator_1",
+          title: "About",
+          body_markdown: "Welcome to my channel!",
+          image_url: "https://cdn.streamfi.io/panels/about.png",
+        })
+      );
+      expect(createRes.status).toBe(201);
+      const panel = await createRes.json();
+      expect(panel.panel_id).toMatch(/^pnl_/);
+      expect(panel.title).toBe("About");
+
+      await POST(
+        makePostReq({
+          creator_id: "creator_1",
+          title: "Schedule",
+          body_markdown: "Mon/Wed/Fri 7pm UTC",
+        })
+      );
+
+      const listRes = await GET(makeGetReq({ creator_id: "creator_1" }));
+      expect(listRes.status).toBe(200);
+      const list = await listRes.json();
+      expect(list.panels).toHaveLength(2);
+      expect(list.panels[0].title).toBe("About");
+      expect(list.panels[1].title).toBe("Schedule");
+
+      const patchRes = await PATCH(
+        makePatchReq(panel.panel_id, {
+          title: "About Me",
+          body_markdown: "Updated bio content",
+        }),
+        { params: Promise.resolve({ panel_id: panel.panel_id }) }
+      );
+      expect(patchRes.status).toBe(200);
+      const updated = await patchRes.json();
+      expect(updated.title).toBe("About Me");
+
+      const deleteRes = await DELETE(
+        makeDeleteReq(panel.panel_id),
+        { params: Promise.resolve({ panel_id: panel.panel_id }) }
+      );
+      expect(deleteRes.status).toBe(200);
+
+      const afterDelete = await GET(makeGetReq({ creator_id: "creator_1" }));
+      const remaining = await afterDelete.json();
+      expect(remaining.panels).toHaveLength(1);
+      expect(remaining.panels[0].title).toBe("Schedule");
+    });
+
+    it("returns 400 when creator_id is missing on GET", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when patching unknown panel", async () => {
+      const res = await PATCH(
+        makePatchReq("pnl_missing", { title: "X" }),
+        { params: Promise.resolve({ panel_id: "pnl_missing" }) }
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when deleting unknown panel", async () => {
+      const res = await DELETE(
+        makeDeleteReq("pnl_missing"),
+        { params: Promise.resolve({ panel_id: "pnl_missing" }) }
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /reorder", () => {
+    it("reorders panels for a creator", async () => {
+      const a = await (
+        await POST(
+          makePostReq({
+            creator_id: "creator_1",
+            title: "About",
+            body_markdown: "About content",
+          })
+        )
+      ).json();
+      const b = await (
+        await POST(
+          makePostReq({
+            creator_id: "creator_1",
+            title: "Donations",
+            body_markdown: "Tip in XLM/USDC",
+          })
+        )
+      ).json();
+      const c = await (
+        await POST(
+          makePostReq({
+            creator_id: "creator_1",
+            title: "Social",
+            body_markdown: "Follow me everywhere",
+          })
+        )
+      ).json();
+
+      const res = await REORDER_POST(
+        makeReorderReq({
+          creator_id: "creator_1",
+          order: [c.panel_id, a.panel_id, b.panel_id],
+        })
+      );
+      expect(res.status).toBe(200);
+
+      const list = await (await GET(makeGetReq({ creator_id: "creator_1" }))).json();
+      expect(list.panels.map((p: { title: string }) => p.title)).toEqual([
+        "Social",
+        "About",
+        "Donations",
+      ]);
+    });
+
+    it("returns 404 when creator has no panels", async () => {
+      const res = await REORDER_POST(
+        makeReorderReq({ creator_id: "unknown", order: ["pnl_000001"] })
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when order contains unknown panel_id", async () => {
+      const panel = await (
+        await POST(
+          makePostReq({
+            creator_id: "creator_1",
+            title: "About",
+            body_markdown: "Content",
+          })
+        )
+      ).json();
+
+      const res = await REORDER_POST(
+        makeReorderReq({
+          creator_id: "creator_1",
+          order: [panel.panel_id, "pnl_missing"],
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/channel/info-panels/reorder/route.ts
+++ b/app/api/routes-f/channel/info-panels/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ReorderPanelsBody } from "../types";
+import { reorderPanels } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: ReorderPanelsBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, order } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!Array.isArray(order) || order.length === 0) {
+    return NextResponse.json(
+      { error: "order must be a non-empty array of panel_ids" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    reorderPanels(creator_id, order);
+    return NextResponse.json({ message: "Panels reordered" });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (message.includes("No panels found")) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/channel/info-panels/route.ts
+++ b/app/api/routes-f/channel/info-panels/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { PostPanelBody, GetPanelsResponse } from "./types";
+import { getPanelsByCreator, createPanel } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const panels = getPanelsByCreator(creatorId);
+  return NextResponse.json({ panels } satisfies GetPanelsResponse);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: PostPanelBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, title, body_markdown, image_url } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.json(
+      { error: "title is required" },
+      { status: 400 }
+    );
+  }
+  if (
+    !body_markdown ||
+    typeof body_markdown !== "string" ||
+    body_markdown.trim().length === 0
+  ) {
+    return NextResponse.json(
+      { error: "body_markdown is required" },
+      { status: 400 }
+    );
+  }
+  if (image_url !== undefined && typeof image_url !== "string") {
+    return NextResponse.json(
+      { error: "image_url must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const panel = createPanel(creator_id, title, body_markdown, image_url);
+  return NextResponse.json(panel, { status: 201 });
+}

--- a/app/api/routes-f/channel/info-panels/store.ts
+++ b/app/api/routes-f/channel/info-panels/store.ts
@@ -1,0 +1,110 @@
+import type { InfoPanel } from "./types";
+
+let panelIdCounter = 1;
+
+const panels: InfoPanel[] = [];
+
+export function getPanelsByCreator(creatorId: string): InfoPanel[] {
+  return panels
+    .filter(p => p.creator_id === creatorId)
+    .sort((a, b) => a.sort_order - b.sort_order);
+}
+
+export function createPanel(
+  creatorId: string,
+  title: string,
+  bodyMarkdown: string,
+  imageUrl?: string
+): InfoPanel {
+  const existing = panels.filter(p => p.creator_id === creatorId);
+  const now = new Date().toISOString();
+  const panel: InfoPanel = {
+    panel_id: `pnl_${String(panelIdCounter++).padStart(6, "0")}`,
+    creator_id: creatorId,
+    title,
+    body_markdown: bodyMarkdown,
+    image_url: imageUrl ?? null,
+    sort_order: existing.length,
+    created_at: now,
+    updated_at: now,
+  };
+  panels.push(panel);
+  return panel;
+}
+
+export function findPanel(panelId: string): InfoPanel | undefined {
+  return panels.find(p => p.panel_id === panelId);
+}
+
+export function updatePanel(
+  panelId: string,
+  updates: { title?: string; body_markdown?: string; image_url?: string | null }
+): InfoPanel | null {
+  const panel = findPanel(panelId);
+  if (!panel) {
+    return null;
+  }
+
+  if (updates.title !== undefined) {
+    panel.title = updates.title;
+  }
+  if (updates.body_markdown !== undefined) {
+    panel.body_markdown = updates.body_markdown;
+  }
+  if (updates.image_url !== undefined) {
+    panel.image_url = updates.image_url;
+  }
+  panel.updated_at = new Date().toISOString();
+  return panel;
+}
+
+export function deletePanel(panelId: string): boolean {
+  const idx = panels.findIndex(p => p.panel_id === panelId);
+  if (idx === -1) {
+    return false;
+  }
+
+  const creatorId = panels[idx].creator_id;
+  panels.splice(idx, 1);
+
+  const creatorPanels = panels
+    .filter(p => p.creator_id === creatorId)
+    .sort((a, b) => a.sort_order - b.sort_order);
+  creatorPanels.forEach((p, i) => {
+    p.sort_order = i;
+  });
+
+  return true;
+}
+
+export function reorderPanels(creatorId: string, order: string[]): void {
+  const creatorPanels = panels.filter(p => p.creator_id === creatorId);
+  if (creatorPanels.length === 0) {
+    throw new Error("No panels found for creator");
+  }
+
+  const panelMap = new Map(creatorPanels.map(p => [p.panel_id, p]));
+  const reordered: InfoPanel[] = [];
+
+  for (const panelId of order) {
+    const panel = panelMap.get(panelId);
+    if (!panel) {
+      throw new Error(`panel_id '${panelId}' not found`);
+    }
+    reordered.push(panel);
+  }
+
+  if (reordered.length !== creatorPanels.length) {
+    throw new Error("Reorder list does not contain all panels");
+  }
+
+  reordered.forEach((panel, index) => {
+    panel.sort_order = index;
+    panel.updated_at = new Date().toISOString();
+  });
+}
+
+export function clearAllPanels(): void {
+  panels.length = 0;
+  panelIdCounter = 1;
+}

--- a/app/api/routes-f/channel/info-panels/types.ts
+++ b/app/api/routes-f/channel/info-panels/types.ts
@@ -1,0 +1,32 @@
+export interface InfoPanel {
+  panel_id: string;
+  creator_id: string;
+  title: string;
+  body_markdown: string;
+  image_url: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PostPanelBody {
+  creator_id: string;
+  title: string;
+  body_markdown: string;
+  image_url?: string;
+}
+
+export interface PatchPanelBody {
+  title?: string;
+  body_markdown?: string;
+  image_url?: string | null;
+}
+
+export interface ReorderPanelsBody {
+  creator_id: string;
+  order: string[];
+}
+
+export interface GetPanelsResponse {
+  panels: InfoPanel[];
+}

--- a/app/api/routes-f/channel/social-links/__tests__/route.test.ts
+++ b/app/api/routes-f/channel/social-links/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../route";
+import { clearAllSocialLinks } from "../store";
+import { MAX_SOCIAL_LINKS } from "../types";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/channel/social-links");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePutReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/channel/social-links", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("channel/social-links", () => {
+  beforeEach(() => {
+    clearAllSocialLinks();
+  });
+
+  describe("GET", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns empty links for unknown creator", async () => {
+      const res = await GET(makeGetReq({ creator_id: "creator_new" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.links).toEqual([]);
+    });
+
+    it("returns saved links", async () => {
+      await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          links: [
+            { platform: "twitter", url: "https://twitter.com/streamer" },
+            { platform: "discord", url: "https://discord.gg/streamfi" },
+          ],
+        })
+      );
+
+      const res = await GET(makeGetReq({ creator_id: "creator_1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.links).toHaveLength(2);
+      expect(data.links[0].platform).toBe("twitter");
+    });
+  });
+
+  describe("PUT", () => {
+    it("overwrites links for a creator", async () => {
+      await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          links: [{ platform: "twitter", url: "https://twitter.com/old" }],
+        })
+      );
+
+      const res = await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          links: [
+            { platform: "instagram", url: "https://instagram.com/streamer" },
+          ],
+        })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.links).toHaveLength(1);
+      expect(data.links[0].platform).toBe("instagram");
+
+      const getRes = await GET(makeGetReq({ creator_id: "creator_1" }));
+      const getData = await getRes.json();
+      expect(getData.links[0].url).toBe("https://instagram.com/streamer");
+    });
+
+    it("rejects invalid URLs", async () => {
+      const res = await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          links: [{ platform: "twitter", url: "not-a-valid-url" }],
+        })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Invalid URL");
+    });
+
+    it("rejects more than 8 links", async () => {
+      const links = Array.from({ length: MAX_SOCIAL_LINKS + 1 }, (_, i) => ({
+        platform: `platform_${i}`,
+        url: `https://example.com/${i}`,
+      }));
+
+      const res = await PUT(
+        makePutReq({ creator_id: "creator_1", links })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("8");
+    });
+
+    it("accepts exactly 8 links", async () => {
+      const links = Array.from({ length: MAX_SOCIAL_LINKS }, (_, i) => ({
+        platform: `platform_${i}`,
+        url: `https://example.com/${i}`,
+      }));
+
+      const res = await PUT(
+        makePutReq({ creator_id: "creator_1", links })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.links).toHaveLength(MAX_SOCIAL_LINKS);
+    });
+
+    it("allows clearing all links with empty array", async () => {
+      await PUT(
+        makePutReq({
+          creator_id: "creator_1",
+          links: [{ platform: "twitter", url: "https://twitter.com/streamer" }],
+        })
+      );
+
+      const res = await PUT(
+        makePutReq({ creator_id: "creator_1", links: [] })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.links).toEqual([]);
+    });
+  });
+});

--- a/app/api/routes-f/channel/social-links/route.ts
+++ b/app/api/routes-f/channel/social-links/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { GetSocialLinksResponse, PutSocialLinksBody } from "./types";
+import { MAX_SOCIAL_LINKS } from "./types";
+import { getSocialLinks, setSocialLinks, isValidUrl } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const links = getSocialLinks(creatorId);
+  return NextResponse.json({ links } satisfies GetSocialLinksResponse);
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: PutSocialLinksBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, links } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!Array.isArray(links)) {
+    return NextResponse.json(
+      { error: "links must be an array" },
+      { status: 400 }
+    );
+  }
+  if (links.length > MAX_SOCIAL_LINKS) {
+    return NextResponse.json(
+      { error: `Cannot exceed ${MAX_SOCIAL_LINKS} social links` },
+      { status: 400 }
+    );
+  }
+
+  for (const link of links) {
+    if (!link || typeof link !== "object") {
+      return NextResponse.json(
+        { error: "Each link must be an object with platform and url" },
+        { status: 400 }
+      );
+    }
+    if (!link.platform || typeof link.platform !== "string") {
+      return NextResponse.json(
+        { error: "Each link must have a platform string" },
+        { status: 400 }
+      );
+    }
+    if (!link.url || typeof link.url !== "string") {
+      return NextResponse.json(
+        { error: "Each link must have a url string" },
+        { status: 400 }
+      );
+    }
+    if (!isValidUrl(link.url)) {
+      return NextResponse.json(
+        { error: `Invalid URL for platform '${link.platform}': ${link.url}` },
+        { status: 400 }
+      );
+    }
+  }
+
+  const saved = setSocialLinks(creator_id, links);
+  return NextResponse.json({ links: saved });
+}

--- a/app/api/routes-f/channel/social-links/store.ts
+++ b/app/api/routes-f/channel/social-links/store.ts
@@ -1,0 +1,29 @@
+import type { SocialLink } from "./types";
+
+const socialLinksByCreator = new Map<string, SocialLink[]>();
+
+export function getSocialLinks(creatorId: string): SocialLink[] {
+  return [...(socialLinksByCreator.get(creatorId) ?? [])];
+}
+
+export function setSocialLinks(
+  creatorId: string,
+  links: SocialLink[]
+): SocialLink[] {
+  const copy = links.map(l => ({ platform: l.platform, url: l.url }));
+  socialLinksByCreator.set(creatorId, copy);
+  return copy;
+}
+
+export function clearAllSocialLinks(): void {
+  socialLinksByCreator.clear();
+}
+
+export function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/api/routes-f/channel/social-links/types.ts
+++ b/app/api/routes-f/channel/social-links/types.ts
@@ -1,0 +1,25 @@
+export type SocialPlatform =
+  | "twitter"
+  | "instagram"
+  | "discord"
+  | "youtube"
+  | "twitch"
+  | "tiktok"
+  | "website"
+  | "other";
+
+export interface SocialLink {
+  platform: string;
+  url: string;
+}
+
+export interface GetSocialLinksResponse {
+  links: SocialLink[];
+}
+
+export interface PutSocialLinksBody {
+  creator_id: string;
+  links: SocialLink[];
+}
+
+export const MAX_SOCIAL_LINKS = 8;

--- a/app/api/routes-f/viewer/dvr-bookmarks/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer/dvr-bookmarks/__tests__/route.test.ts
@@ -1,0 +1,155 @@
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE } from "../route";
+import { clearAllBookmarks } from "../store";
+
+function makeGetReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/viewer/dvr-bookmarks");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url.toString());
+}
+
+function makePostReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/viewer/dvr-bookmarks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/viewer/dvr-bookmarks", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("viewer/dvr-bookmarks", () => {
+  beforeEach(() => {
+    clearAllBookmarks();
+  });
+
+  describe("POST", () => {
+    it("creates a bookmark and returns bookmark_id", async () => {
+      const res = await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_live_abc",
+          time_seconds: 342,
+          label: "Epic play",
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.bookmark_id).toMatch(/^bmk_/);
+    });
+
+    it("creates a bookmark without optional label", async () => {
+      const res = await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_live_abc",
+          time_seconds: 120,
+        })
+      );
+      expect(res.status).toBe(201);
+    });
+
+    it("returns 400 when required fields are missing", async () => {
+      const res = await POST(makePostReq({ viewer_id: "viewer_1" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for negative time_seconds", async () => {
+      const res = await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_live_abc",
+          time_seconds: -1,
+        })
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns 400 when viewer_id is missing", async () => {
+      const res = await GET(makeGetReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns recent bookmarks for a viewer", async () => {
+      await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_a",
+          time_seconds: 100,
+        })
+      );
+      await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_b",
+          time_seconds: 200,
+          label: "Second moment",
+        })
+      );
+      await POST(
+        makePostReq({
+          viewer_id: "viewer_2",
+          stream_id: "stream_a",
+          time_seconds: 50,
+        })
+      );
+
+      const res = await GET(makeGetReq({ viewer_id: "viewer_1" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.bookmarks).toHaveLength(2);
+      expect(data.bookmarks.every((b: { viewer_id: string }) => b.viewer_id === "viewer_1")).toBe(true);
+    });
+
+    it("returns empty list for unknown viewer", async () => {
+      const res = await GET(makeGetReq({ viewer_id: "unknown" }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.bookmarks).toEqual([]);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("removes a bookmark", async () => {
+      const createRes = await POST(
+        makePostReq({
+          viewer_id: "viewer_1",
+          stream_id: "stream_a",
+          time_seconds: 100,
+        })
+      );
+      const { bookmark_id } = await createRes.json();
+
+      const res = await DELETE(
+        makeDeleteReq({ viewer_id: "viewer_1", bookmark_id })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.removed).toBe(true);
+
+      const listRes = await GET(makeGetReq({ viewer_id: "viewer_1" }));
+      const list = await listRes.json();
+      expect(list.bookmarks).toHaveLength(0);
+    });
+
+    it("returns 404 when bookmark not found", async () => {
+      const res = await DELETE(
+        makeDeleteReq({ viewer_id: "viewer_1", bookmark_id: "bmk_missing" })
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when fields are missing", async () => {
+      const res = await DELETE(makeDeleteReq({ viewer_id: "viewer_1" }));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/viewer/dvr-bookmarks/route.ts
+++ b/app/api/routes-f/viewer/dvr-bookmarks/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import type {
+  PostBookmarkBody,
+  PostBookmarkResponse,
+  GetBookmarksResponse,
+  DeleteBookmarkBody,
+} from "./types";
+import {
+  createBookmark,
+  getBookmarksByViewer,
+  deleteBookmark,
+} from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const viewerId = req.nextUrl.searchParams.get("viewer_id");
+
+  if (!viewerId) {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const bookmarks = getBookmarksByViewer(viewerId);
+  return NextResponse.json({ bookmarks } satisfies GetBookmarksResponse);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: PostBookmarkBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, stream_id, time_seconds, label } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+  if (typeof time_seconds !== "number" || time_seconds < 0) {
+    return NextResponse.json(
+      { error: "time_seconds must be a non-negative number" },
+      { status: 400 }
+    );
+  }
+  if (label !== undefined && typeof label !== "string") {
+    return NextResponse.json(
+      { error: "label must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const bookmark = createBookmark(
+    viewer_id,
+    stream_id,
+    time_seconds,
+    label
+  );
+
+  return NextResponse.json(
+    { bookmark_id: bookmark.bookmark_id } satisfies PostBookmarkResponse,
+    { status: 201 }
+  );
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: DeleteBookmarkBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, bookmark_id } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!bookmark_id || typeof bookmark_id !== "string") {
+    return NextResponse.json(
+      { error: "bookmark_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const removed = deleteBookmark(viewer_id, bookmark_id);
+  if (!removed) {
+    return NextResponse.json(
+      { error: "Bookmark not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ removed: true });
+}

--- a/app/api/routes-f/viewer/dvr-bookmarks/store.ts
+++ b/app/api/routes-f/viewer/dvr-bookmarks/store.ts
@@ -1,0 +1,51 @@
+import type { DvrBookmark } from "./types";
+
+let bookmarkIdCounter = 1;
+
+const bookmarks: DvrBookmark[] = [];
+
+export function createBookmark(
+  viewerId: string,
+  streamId: string,
+  timeSeconds: number,
+  label?: string
+): DvrBookmark {
+  const bookmark: DvrBookmark = {
+    bookmark_id: `bmk_${String(bookmarkIdCounter++).padStart(6, "0")}`,
+    viewer_id: viewerId,
+    stream_id: streamId,
+    time_seconds: timeSeconds,
+    label: label ?? null,
+    created_at: new Date().toISOString(),
+  };
+  bookmarks.push(bookmark);
+  return bookmark;
+}
+
+export function getBookmarksByViewer(viewerId: string): DvrBookmark[] {
+  return bookmarks
+    .filter(b => b.viewer_id === viewerId)
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+}
+
+export function deleteBookmark(
+  viewerId: string,
+  bookmarkId: string
+): boolean {
+  const idx = bookmarks.findIndex(
+    b => b.bookmark_id === bookmarkId && b.viewer_id === viewerId
+  );
+  if (idx === -1) {
+    return false;
+  }
+  bookmarks.splice(idx, 1);
+  return true;
+}
+
+export function clearAllBookmarks(): void {
+  bookmarks.length = 0;
+  bookmarkIdCounter = 1;
+}

--- a/app/api/routes-f/viewer/dvr-bookmarks/types.ts
+++ b/app/api/routes-f/viewer/dvr-bookmarks/types.ts
@@ -1,0 +1,28 @@
+export interface DvrBookmark {
+  bookmark_id: string;
+  viewer_id: string;
+  stream_id: string;
+  time_seconds: number;
+  label: string | null;
+  created_at: string;
+}
+
+export interface PostBookmarkBody {
+  viewer_id: string;
+  stream_id: string;
+  time_seconds: number;
+  label?: string;
+}
+
+export interface PostBookmarkResponse {
+  bookmark_id: string;
+}
+
+export interface GetBookmarksResponse {
+  bookmarks: DvrBookmark[];
+}
+
+export interface DeleteBookmarkBody {
+  viewer_id: string;
+  bookmark_id: string;
+}


### PR DESCRIPTION
## Summary

Adds four scoped `routes-f` practice APIs for viewer DVR bookmarks and creator channel management. All code lives under `app/api/routes-f/` with in-memory stores and Jest tests (32 passing).

### #1033 — DVR bookmarks (`viewer/dvr-bookmarks`)
- **POST** `{ viewer_id, stream_id, time_seconds, label? }` → `{ bookmark_id }`
- **GET** `?viewer_id` → recent bookmarks (newest first)
- **DELETE** `{ viewer_id, bookmark_id }` → removes one bookmark

### #1036 — Info panels (`channel/info-panels`)
- **GET** `?creator_id` → ordered list of panels
- **POST** `{ creator_id, title, body_markdown, image_url? }` → creates panel
- **PATCH** `/[panel_id]` → updates a panel
- **DELETE** `/[panel_id]` → removes a panel
- **POST** `/reorder` `{ creator_id, order: [panel_ids] }` → reorders panels

### #1038 — About page (`channel/about`)
- **GET** `?creator_id` → `{ about_markdown, last_updated }`
- **PUT** `{ creator_id, about_markdown }` → updates content (50KB cap via UTF-8 byte length)

### #1039 — Social links (`channel/social-links`)
- **GET** `?creator_id` → `{ links: [{ platform, url }] }`
- **PUT** `{ creator_id, links }` → overwrites links
- Validates each URL with `new URL()`, capped at 8 links

Closes #1033
Closes #1036
Closes #1038
Closes #1039

## Test plan

- [x] `npm test -- app/api/routes-f/viewer/dvr-bookmarks app/api/routes-f/channel/info-panels app/api/routes-f/channel/about app/api/routes-f/channel/social-links`
- [x] Pre-commit type-check and production build pass
- [ ] Manual smoke test of each endpoint via dev server (optional)


Made with [Cursor](https://cursor.com)