### PR TITLE
feat(routes-f): analytics + watch party endpoints (#1024, #1026, #1027, #1034)

### DIFF
--- a/app/api/routes-f/category-performance/__tests__/route.test.ts
+++ b/app/api/routes-f/category-performance/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { aggregateByCategory } from "../aggregate";
+import { streamsForCreator } from "../seed";
+import type { CategoryPerformance } from "../types";
+
+function makeReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/category-performance${query}`
+  );
+}
+
+describe("aggregateByCategory", () => {
+  const streams = streamsForCreator("creator_a");
+
+  it("counts streams per category", () => {
+    const result = aggregateByCategory(streams);
+    const gaming = result.find(c => c.category === "gaming")!;
+    expect(gaming.stream_count).toBe(3);
+  });
+
+  it("computes average viewers per stream", () => {
+    // gaming: (100+200+300)/3 = 200.
+    const result = aggregateByCategory(streams);
+    const gaming = result.find(c => c.category === "gaming")!;
+    expect(gaming.avg_viewers).toBe(200);
+  });
+
+  it("computes average tips per stream", () => {
+    // gaming: (20+40+30)/3 = 30.
+    const result = aggregateByCategory(streams);
+    const gaming = result.find(c => c.category === "gaming")!;
+    expect(gaming.avg_tips_usdc).toBe(30);
+  });
+
+  it("rounds non-integer averages to 2 decimals", () => {
+    // esports: viewers (500+700)/2 = 600, tips (100+150)/2 = 125.
+    const result = aggregateByCategory(streams);
+    const esports = result.find(c => c.category === "esports")!;
+    expect(esports.avg_viewers).toBe(600);
+    expect(esports.avg_tips_usdc).toBe(125);
+  });
+
+  it("sorts by stream_count descending", () => {
+    const result = aggregateByCategory(streams);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1].stream_count).toBeGreaterThanOrEqual(
+        result[i].stream_count
+      );
+    }
+    // gaming (3) should come before esports (2) and irl (1).
+    expect(result[0].category).toBe("gaming");
+  });
+
+  it("handles a single-stream category", () => {
+    const result = aggregateByCategory(streams);
+    const irl = result.find(c => c.category === "irl")!;
+    expect(irl.stream_count).toBe(1);
+    expect(irl.avg_viewers).toBe(80);
+    expect(irl.avg_tips_usdc).toBe(5);
+  });
+
+  it("returns an empty array for no streams", () => {
+    expect(aggregateByCategory([])).toEqual<CategoryPerformance[]>([]);
+  });
+});
+
+describe("GET /api/routes-f/category-performance", () => {
+  it("requires creator_id", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("creator_id");
+  });
+
+  it("returns per-category performance sorted by stream_count", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.categories[0].category).toBe("gaming");
+    expect(body.categories[0].stream_count).toBe(3);
+  });
+
+  it("only includes the requested creator's streams", async () => {
+    const res = await GET(makeReq("?creator_id=creator_b"));
+    const body = await res.json();
+    expect(body.categories).toHaveLength(1);
+    expect(body.categories[0].category).toBe("music");
+    // music: viewers (60+90)/2 = 75, tips (12+18)/2 = 15.
+    expect(body.categories[0].avg_viewers).toBe(75);
+    expect(body.categories[0].avg_tips_usdc).toBe(15);
+  });
+
+  it("returns an empty list for an unknown creator", async () => {
+    const res = await GET(makeReq("?creator_id=ghost"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.categories).toEqual([]);
+  });
+});

--- a/app/api/routes-f/category-performance/aggregate.ts
+++ b/app/api/routes-f/category-performance/aggregate.ts
@@ -1,0 +1,51 @@
+import type { CategoryPerformance, StreamRecord } from "./types";
+
+/** Round to 2 decimal places, avoiding negative-zero. */
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100 || 0;
+}
+
+interface Accumulator {
+  stream_count: number;
+  total_viewers: number;
+  total_tips: number;
+}
+
+/**
+ * Aggregate a creator's streams into per-category performance.
+ *
+ * For each category, computes stream_count and the mean viewers and tips per
+ * stream. Results are sorted by stream_count descending (ties broken by
+ * category name for stable ordering).
+ */
+export function aggregateByCategory(
+  streams: StreamRecord[]
+): CategoryPerformance[] {
+  const byCategory = new Map<string, Accumulator>();
+
+  for (const stream of streams) {
+    const acc = byCategory.get(stream.category) ?? {
+      stream_count: 0,
+      total_viewers: 0,
+      total_tips: 0,
+    };
+    acc.stream_count += 1;
+    acc.total_viewers += stream.viewers;
+    acc.total_tips += stream.tips_usdc;
+    byCategory.set(stream.category, acc);
+  }
+
+  return [...byCategory.entries()]
+    .map(([category, acc]) => ({
+      category,
+      stream_count: acc.stream_count,
+      avg_viewers: round2(acc.total_viewers / acc.stream_count),
+      avg_tips_usdc: round2(acc.total_tips / acc.stream_count),
+    }))
+    .sort((a, b) => {
+      if (b.stream_count !== a.stream_count) {
+        return b.stream_count - a.stream_count;
+      }
+      return a.category.localeCompare(b.category);
+    });
+}

--- a/app/api/routes-f/category-performance/route.ts
+++ b/app/api/routes-f/category-performance/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { CategoryPerformanceResponse } from "./types";
+import { streamsForCreator } from "./seed";
+import { aggregateByCategory } from "./aggregate";
+
+/**
+ * GET /api/routes-f/category-performance?creator_id=creator_a
+ *
+ * Aggregates a creator's stream performance by category: stream count plus
+ * average viewers and average tips (USDC) per stream, sorted by stream count
+ * descending.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const params = req.nextUrl.searchParams;
+
+  const creatorId = params.get("creator_id");
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const streams = streamsForCreator(creatorId);
+  const categories = aggregateByCategory(streams);
+
+  return NextResponse.json({ categories } as CategoryPerformanceResponse);
+}

--- a/app/api/routes-f/category-performance/seed.ts
+++ b/app/api/routes-f/category-performance/seed.ts
@@ -1,0 +1,24 @@
+import type { StreamRecord } from "./types";
+
+/**
+ * Seed creator streams spread across several categories.
+ *
+ * creator_a streams in gaming, esports and irl with varying viewer/tip levels
+ * so the per-category averages are non-trivial. creator_b is a second creator
+ * used to confirm filtering by creator_id.
+ */
+export const streamRecords: StreamRecord[] = [
+  { creator_id: "creator_a", stream_id: "s1", category: "gaming", viewers: 100, tips_usdc: 20 },
+  { creator_id: "creator_a", stream_id: "s2", category: "gaming", viewers: 200, tips_usdc: 40 },
+  { creator_id: "creator_a", stream_id: "s3", category: "gaming", viewers: 300, tips_usdc: 30 },
+  { creator_id: "creator_a", stream_id: "s4", category: "esports", viewers: 500, tips_usdc: 100 },
+  { creator_id: "creator_a", stream_id: "s5", category: "esports", viewers: 700, tips_usdc: 150 },
+  { creator_id: "creator_a", stream_id: "s6", category: "irl", viewers: 80, tips_usdc: 5 },
+
+  { creator_id: "creator_b", stream_id: "s7", category: "music", viewers: 60, tips_usdc: 12 },
+  { creator_id: "creator_b", stream_id: "s8", category: "music", viewers: 90, tips_usdc: 18 },
+];
+
+export function streamsForCreator(creatorId: string): StreamRecord[] {
+  return streamRecords.filter(s => s.creator_id === creatorId);
+}

--- a/app/api/routes-f/category-performance/types.ts
+++ b/app/api/routes-f/category-performance/types.ts
@@ -1,0 +1,22 @@
+export interface StreamRecord {
+  creator_id: string;
+  stream_id: string;
+  category: string;
+  /** Peak / average concurrent viewers for the stream. */
+  viewers: number;
+  /** Total tips received during the stream, in USDC. */
+  tips_usdc: number;
+}
+
+export interface CategoryPerformance {
+  category: string;
+  stream_count: number;
+  /** Mean viewers per stream in this category, rounded to 2 decimals. */
+  avg_viewers: number;
+  /** Mean tips (USDC) per stream in this category, rounded to 2 decimals. */
+  avg_tips_usdc: number;
+}
+
+export interface CategoryPerformanceResponse {
+  categories: CategoryPerformance[];
+}

--- a/app/api/routes-f/follower-growth/__tests__/route.test.ts
+++ b/app/api/routes-f/follower-growth/__tests__/route.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { bucketStart, buildGrowthSeries } from "../buckets";
+import { eventsForCreator } from "../seed";
+import type { GrowthBucket } from "../types";
+
+function makeReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/follower-growth${query}`
+  );
+}
+
+describe("bucketStart", () => {
+  it("buckets by day at midnight UTC", () => {
+    expect(bucketStart("2026-01-03T18:30:00Z", "day")).toBe("2026-01-03");
+  });
+
+  it("buckets by month on the first", () => {
+    expect(bucketStart("2026-02-21T11:00:00Z", "month")).toBe("2026-02-01");
+  });
+
+  it("buckets by week on the preceding Monday", () => {
+    // 2026-01-03 is a Saturday -> week starts Monday 2025-12-29.
+    expect(bucketStart("2026-01-03T10:00:00Z", "week")).toBe("2025-12-29");
+  });
+
+  it("keeps a Monday as its own week start", () => {
+    // 2026-01-05 is a Monday.
+    expect(bucketStart("2026-01-05T09:15:00Z", "week")).toBe("2026-01-05");
+  });
+});
+
+describe("buildGrowthSeries", () => {
+  const events = eventsForCreator("creator_a");
+
+  it("produces a strictly cumulative (non-decreasing) count", () => {
+    const { series } = buildGrowthSeries(events, "day");
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i].count).toBeGreaterThanOrEqual(series[i - 1].count);
+    }
+  });
+
+  it("final cumulative count equals the number of events", () => {
+    const { series, total } = buildGrowthSeries(events, "month");
+    expect(total).toBe(events.length);
+    expect(series[series.length - 1].count).toBe(events.length);
+  });
+
+  it("orders buckets chronologically", () => {
+    const { series } = buildGrowthSeries(events, "month");
+    const starts = series.map(s => s.bucket_start);
+    expect([...starts].sort()).toEqual(starts);
+  });
+
+  it("computes correct per-month cumulative values", () => {
+    // creator_a: Jan=5, Feb=3, Mar=1 => cumulative 5, 8, 9.
+    const { series } = buildGrowthSeries(events, "month");
+    expect(series).toEqual<GrowthBucket[]>([
+      { bucket_start: "2026-01-01", count: 5 },
+      { bucket_start: "2026-02-01", count: 8 },
+      { bucket_start: "2026-03-01", count: 9 },
+    ]);
+  });
+
+  it("collapses same-day events into one bucket", () => {
+    // Two creator_a follows on 2026-01-03.
+    const { series } = buildGrowthSeries(events, "day");
+    const jan3 = series.find(s => s.bucket_start === "2026-01-03");
+    expect(jan3!.count).toBe(2);
+  });
+
+  it("returns an empty series and zero total for no events", () => {
+    const { series, total } = buildGrowthSeries([], "day");
+    expect(series).toEqual([]);
+    expect(total).toBe(0);
+  });
+});
+
+describe("GET /api/routes-f/follower-growth", () => {
+  it("requires creator_id", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("creator_id");
+  });
+
+  it("rejects an invalid granularity", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a&granularity=hour"));
+    expect(res.status).toBe(400);
+  });
+
+  it("defaults to day granularity", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // creator_a has follows on 6 distinct days.
+    expect(body.series.length).toBe(6);
+  });
+
+  it("returns the cumulative series and total", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a&granularity=month"));
+    const body = await res.json();
+    expect(body.total).toBe(9);
+    expect(body.series[body.series.length - 1].count).toBe(9);
+  });
+
+  it("returns an empty series for an unknown creator", async () => {
+    const res = await GET(makeReq("?creator_id=ghost"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.series).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});

--- a/app/api/routes-f/follower-growth/buckets.ts
+++ b/app/api/routes-f/follower-growth/buckets.ts
@@ -1,0 +1,63 @@
+import type { FollowEvent, Granularity, GrowthBucket } from "./types";
+
+/** Format a Date as a UTC ISO date string (YYYY-MM-DD). */
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Return the UTC bucket-start date for a timestamp at the given granularity.
+ *
+ * - day:   midnight of that day.
+ * - week:  the preceding Monday (ISO week start).
+ * - month: the first of the month.
+ */
+export function bucketStart(timestamp: string, granularity: Granularity): string {
+  const d = new Date(timestamp);
+  const year = d.getUTCFullYear();
+  const month = d.getUTCMonth();
+  const day = d.getUTCDate();
+
+  if (granularity === "month") {
+    return toIsoDate(new Date(Date.UTC(year, month, 1)));
+  }
+  if (granularity === "week") {
+    const start = new Date(Date.UTC(year, month, day));
+    // getUTCDay: 0 = Sunday .. 6 = Saturday. Shift so Monday is the start.
+    const dow = start.getUTCDay();
+    const diff = dow === 0 ? 6 : dow - 1;
+    start.setUTCDate(start.getUTCDate() - diff);
+    return toIsoDate(start);
+  }
+  // day
+  return toIsoDate(new Date(Date.UTC(year, month, day)));
+}
+
+/**
+ * Build a cumulative growth series from raw follow events.
+ *
+ * Events are grouped into buckets by `bucket_start`, buckets are ordered
+ * chronologically, and each bucket's `count` is the running cumulative total of
+ * followers up to and including that bucket. `total` is the final cumulative
+ * count (equal to the number of events).
+ */
+export function buildGrowthSeries(
+  events: FollowEvent[],
+  granularity: Granularity
+): { series: GrowthBucket[]; total: number } {
+  const perBucket = new Map<string, number>();
+  for (const event of events) {
+    const key = bucketStart(event.followed_at, granularity);
+    perBucket.set(key, (perBucket.get(key) ?? 0) + 1);
+  }
+
+  const orderedKeys = [...perBucket.keys()].sort();
+  const series: GrowthBucket[] = [];
+  let cumulative = 0;
+  for (const key of orderedKeys) {
+    cumulative += perBucket.get(key)!;
+    series.push({ bucket_start: key, count: cumulative });
+  }
+
+  return { series, total: cumulative };
+}

--- a/app/api/routes-f/follower-growth/route.ts
+++ b/app/api/routes-f/follower-growth/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { FollowerGrowthResponse, Granularity } from "./types";
+import { eventsForCreator } from "./seed";
+import { buildGrowthSeries } from "./buckets";
+
+const VALID_GRANULARITIES: Granularity[] = ["day", "week", "month"];
+const DEFAULT_GRANULARITY: Granularity = "day";
+
+/**
+ * GET /api/routes-f/follower-growth?creator_id=creator_a&granularity=day|week|month
+ *
+ * Returns a cumulative follower growth time series bucketed at the requested
+ * granularity, plus the total follower count.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const params = req.nextUrl.searchParams;
+
+  const creatorId = params.get("creator_id");
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  let granularity = DEFAULT_GRANULARITY;
+  const granularityRaw = params.get("granularity");
+  if (granularityRaw !== null) {
+    if (!VALID_GRANULARITIES.includes(granularityRaw as Granularity)) {
+      return NextResponse.json(
+        { error: `granularity must be one of: ${VALID_GRANULARITIES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+    granularity = granularityRaw as Granularity;
+  }
+
+  const events = eventsForCreator(creatorId);
+  const { series, total } = buildGrowthSeries(events, granularity);
+
+  return NextResponse.json({ series, total } as FollowerGrowthResponse);
+}

--- a/app/api/routes-f/follower-growth/seed.ts
+++ b/app/api/routes-f/follower-growth/seed.ts
@@ -1,0 +1,28 @@
+import type { FollowEvent } from "./types";
+
+/**
+ * Seed follow events for the growth chart.
+ *
+ * Timestamps are intentionally spread across several days, weeks and months so
+ * that bucketing at every granularity has meaningful structure. creator_a has
+ * the bulk of the activity; creator_b is a quieter creator.
+ */
+export const followEvents: FollowEvent[] = [
+  { creator_id: "creator_a", follower_id: "v1", followed_at: "2026-01-03T10:00:00Z" },
+  { creator_id: "creator_a", follower_id: "v2", followed_at: "2026-01-03T18:30:00Z" },
+  { creator_id: "creator_a", follower_id: "v3", followed_at: "2026-01-05T09:15:00Z" },
+  { creator_id: "creator_a", follower_id: "v4", followed_at: "2026-01-12T22:00:00Z" },
+  { creator_id: "creator_a", follower_id: "v5", followed_at: "2026-01-19T08:45:00Z" },
+  { creator_id: "creator_a", follower_id: "v6", followed_at: "2026-02-02T14:00:00Z" },
+  { creator_id: "creator_a", follower_id: "v7", followed_at: "2026-02-02T15:30:00Z" },
+  { creator_id: "creator_a", follower_id: "v8", followed_at: "2026-02-21T11:00:00Z" },
+  { creator_id: "creator_a", follower_id: "v9", followed_at: "2026-03-04T19:00:00Z" },
+
+  { creator_id: "creator_b", follower_id: "v10", followed_at: "2026-01-08T12:00:00Z" },
+  { creator_id: "creator_b", follower_id: "v11", followed_at: "2026-01-29T17:20:00Z" },
+  { creator_id: "creator_b", follower_id: "v12", followed_at: "2026-03-15T06:00:00Z" },
+];
+
+export function eventsForCreator(creatorId: string): FollowEvent[] {
+  return followEvents.filter(e => e.creator_id === creatorId);
+}

--- a/app/api/routes-f/follower-growth/types.ts
+++ b/app/api/routes-f/follower-growth/types.ts
@@ -1,0 +1,20 @@
+export type Granularity = "day" | "week" | "month";
+
+export interface FollowEvent {
+  creator_id: string;
+  follower_id: string;
+  /** ISO 8601 timestamp of when the follow happened. */
+  followed_at: string;
+}
+
+export interface GrowthBucket {
+  /** ISO date (YYYY-MM-DD) marking the start of the bucket. */
+  bucket_start: string;
+  /** Cumulative follower count at the end of this bucket. */
+  count: number;
+}
+
+export interface FollowerGrowthResponse {
+  series: GrowthBucket[];
+  total: number;
+}

--- a/app/api/routes-f/viewer-sources/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer-sources/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { attributeSources } from "../attribution";
+import { sessionsForStream } from "../seed";
+import type { SourceBreakdown } from "../types";
+
+function makeReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/viewer-sources${query}`
+  );
+}
+
+describe("attributeSources", () => {
+  it("returns total equal to the session count", () => {
+    const sessions = sessionsForStream("stream_1");
+    const { total } = attributeSources(sessions);
+    expect(total).toBe(sessions.length);
+  });
+
+  it("percentages sum to ~100 when there are sessions", () => {
+    const { sources } = attributeSources(sessionsForStream("stream_1"));
+    const sum = sources.reduce((acc, s) => acc + s.percent, 0);
+    expect(Math.round(sum)).toBe(100);
+  });
+
+  it("computes correct viewer counts and percentages", () => {
+    // stream_1: direct=2, explore=3, social=4, embed=1, total=10.
+    const { sources, total } = attributeSources(sessionsForStream("stream_1"));
+    expect(total).toBe(10);
+    const social = sources.find(s => s.source === "social")!;
+    expect(social.viewers).toBe(4);
+    expect(social.percent).toBe(40);
+    const embed = sources.find(s => s.source === "embed")!;
+    expect(embed.percent).toBe(10);
+  });
+
+  it("sorts by viewers descending", () => {
+    const { sources } = attributeSources(sessionsForStream("stream_1"));
+    for (let i = 1; i < sources.length; i++) {
+      expect(sources[i - 1].viewers).toBeGreaterThanOrEqual(sources[i].viewers);
+    }
+  });
+
+  it("omits sources with no viewers (no zero-fill)", () => {
+    // stream_2 has no embed traffic.
+    const { sources } = attributeSources(sessionsForStream("stream_2"));
+    expect(sources.find(s => s.source === "embed")).toBeUndefined();
+  });
+
+  it("rounds percentages to 2 decimals", () => {
+    // stream_2: direct=1, social=2, explore=1, total=4.
+    const { sources } = attributeSources(sessionsForStream("stream_2"));
+    const direct = sources.find(s => s.source === "direct")!;
+    expect(direct.percent).toBe(25);
+    const social = sources.find(s => s.source === "social")!;
+    expect(social.percent).toBe(50);
+  });
+
+  it("handles an empty session list", () => {
+    const { sources, total } = attributeSources([]);
+    expect(sources).toEqual<SourceBreakdown[]>([]);
+    expect(total).toBe(0);
+  });
+});
+
+describe("GET /api/routes-f/viewer-sources", () => {
+  it("requires stream_id", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("stream_id");
+  });
+
+  it("returns the source breakdown and total", async () => {
+    const res = await GET(makeReq("?stream_id=stream_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(10);
+    expect(Array.isArray(body.sources)).toBe(true);
+    expect(body.sources[0].source).toBe("social");
+  });
+
+  it("returns an empty breakdown for an unknown stream", async () => {
+    const res = await GET(makeReq("?stream_id=ghost"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sources).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});

--- a/app/api/routes-f/viewer-sources/attribution.ts
+++ b/app/api/routes-f/viewer-sources/attribution.ts
@@ -1,0 +1,38 @@
+import type { ReferrerSource, SourceBreakdown, ViewerSession } from "./types";
+
+/** Round to 2 decimal places, avoiding negative-zero. */
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100 || 0;
+}
+
+/**
+ * Break viewer sessions down by referrer source.
+ *
+ * Returns one entry per source that has at least one viewer, sorted by viewer
+ * count descending (ties broken by source name for stable ordering), with each
+ * source's percentage of the total. `total` is the number of sessions.
+ */
+export function attributeSources(sessions: ViewerSession[]): {
+  sources: SourceBreakdown[];
+  total: number;
+} {
+  const total = sessions.length;
+
+  const counts = new Map<ReferrerSource, number>();
+  for (const session of sessions) {
+    counts.set(session.source, (counts.get(session.source) ?? 0) + 1);
+  }
+
+  const sources: SourceBreakdown[] = [...counts.entries()]
+    .map(([source, viewers]) => ({
+      source,
+      viewers,
+      percent: total === 0 ? 0 : round2((viewers / total) * 100),
+    }))
+    .sort((a, b) => {
+      if (b.viewers !== a.viewers) return b.viewers - a.viewers;
+      return a.source.localeCompare(b.source);
+    });
+
+  return { sources, total };
+}

--- a/app/api/routes-f/viewer-sources/route.ts
+++ b/app/api/routes-f/viewer-sources/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ViewerSourcesResponse } from "./types";
+import { sessionsForStream } from "./seed";
+import { attributeSources } from "./attribution";
+
+/**
+ * GET /api/routes-f/viewer-sources?stream_id=stream_1
+ *
+ * Breaks a stream's viewers down by referrer source (direct, explore, social,
+ * embed), sorted by viewer count descending, with each source's percentage of
+ * the total.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const params = req.nextUrl.searchParams;
+
+  const streamId = params.get("stream_id");
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const sessions = sessionsForStream(streamId);
+  const { sources, total } = attributeSources(sessions);
+
+  return NextResponse.json({ sources, total } as ViewerSourcesResponse);
+}

--- a/app/api/routes-f/viewer-sources/seed.ts
+++ b/app/api/routes-f/viewer-sources/seed.ts
@@ -1,0 +1,30 @@
+import type { ViewerSession } from "./types";
+
+/**
+ * Seed viewer sessions with referrer attribution.
+ *
+ * stream_1 has a mix across all four sources; stream_2 is smaller and lacks any
+ * "embed" traffic so callers can verify zero-fill behaviour is NOT assumed
+ * (absent sources are simply omitted).
+ */
+export const viewerSessions: ViewerSession[] = [
+  { stream_id: "stream_1", viewer_id: "v1", source: "direct" },
+  { stream_id: "stream_1", viewer_id: "v2", source: "direct" },
+  { stream_id: "stream_1", viewer_id: "v3", source: "explore" },
+  { stream_id: "stream_1", viewer_id: "v4", source: "explore" },
+  { stream_id: "stream_1", viewer_id: "v5", source: "explore" },
+  { stream_id: "stream_1", viewer_id: "v6", source: "social" },
+  { stream_id: "stream_1", viewer_id: "v7", source: "social" },
+  { stream_id: "stream_1", viewer_id: "v8", source: "social" },
+  { stream_id: "stream_1", viewer_id: "v9", source: "social" },
+  { stream_id: "stream_1", viewer_id: "v10", source: "embed" },
+
+  { stream_id: "stream_2", viewer_id: "v11", source: "direct" },
+  { stream_id: "stream_2", viewer_id: "v12", source: "social" },
+  { stream_id: "stream_2", viewer_id: "v13", source: "social" },
+  { stream_id: "stream_2", viewer_id: "v14", source: "explore" },
+];
+
+export function sessionsForStream(streamId: string): ViewerSession[] {
+  return viewerSessions.filter(s => s.stream_id === streamId);
+}

--- a/app/api/routes-f/viewer-sources/types.ts
+++ b/app/api/routes-f/viewer-sources/types.ts
@@ -1,0 +1,20 @@
+export type ReferrerSource = "direct" | "explore" | "social" | "embed";
+
+export interface ViewerSession {
+  stream_id: string;
+  viewer_id: string;
+  /** Where the viewer arrived from. */
+  source: ReferrerSource;
+}
+
+export interface SourceBreakdown {
+  source: ReferrerSource;
+  viewers: number;
+  /** Share of total viewers, 0..100, rounded to 2 decimals. */
+  percent: number;
+}
+
+export interface ViewerSourcesResponse {
+  sources: SourceBreakdown[];
+  total: number;
+}

--- a/app/api/routes-f/watch-party/__tests__/route.test.ts
+++ b/app/api/routes-f/watch-party/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { POST as CREATE } from "../create/route";
+import { POST as SYNC } from "../sync/route";
+import { POST as JOIN } from "../join/route";
+import { __resetStore, getPartyByJoinCode } from "../store";
+
+function jsonReq(url: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${url}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getReq(query = ""): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-f/watch-party${query}`);
+}
+
+async function createParty(host_id = "host_1", vod_id = "vod_1") {
+  const res = await CREATE(
+    jsonReq("/api/routes-f/watch-party/create", { host_id, vod_id })
+  );
+  return { res, body: await res.json() };
+}
+
+beforeEach(() => {
+  __resetStore();
+});
+
+describe("POST create", () => {
+  it("creates a party and returns party_id + join_code", async () => {
+    const { res, body } = await createParty();
+    expect(res.status).toBe(201);
+    expect(typeof body.party_id).toBe("string");
+    expect(typeof body.join_code).toBe("string");
+    expect(body.join_code.length).toBe(6);
+  });
+
+  it("indexes the party by its join_code", async () => {
+    const { body } = await createParty();
+    const party = getPartyByJoinCode(body.join_code);
+    expect(party?.party_id).toBe(body.party_id);
+  });
+
+  it("requires host_id", async () => {
+    const res = await CREATE(
+      jsonReq("/api/routes-f/watch-party/create", { vod_id: "vod_1" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("requires vod_id", async () => {
+    const res = await CREATE(
+      jsonReq("/api/routes-f/watch-party/create", { host_id: "host_1" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("starts paused at position 0 with the host as the only member", async () => {
+    const { body } = await createParty();
+    const state = await (await GET(getReq(`?party_id=${body.party_id}`))).json();
+    expect(state.paused).toBe(true);
+    expect(state.position_seconds).toBe(0);
+    expect(state.members).toEqual(["host_1"]);
+  });
+});
+
+describe("GET state", () => {
+  it("requires party_id", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown party", async () => {
+    const res = await GET(getReq("?party_id=nope"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST join", () => {
+  it("adds a viewer to the party", async () => {
+    const { body } = await createParty();
+    const res = await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", {
+        party_id: body.party_id,
+        viewer_id: "v2",
+      })
+    );
+    expect(res.status).toBe(200);
+    const state = await res.json();
+    expect(state.members).toContain("v2");
+  });
+
+  it("is idempotent", async () => {
+    const { body } = await createParty();
+    await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", {
+        party_id: body.party_id,
+        viewer_id: "v2",
+      })
+    );
+    const res = await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", {
+        party_id: body.party_id,
+        viewer_id: "v2",
+      })
+    );
+    const state = await res.json();
+    expect(state.members.filter((m: string) => m === "v2")).toHaveLength(1);
+  });
+
+  it("404s for an unknown party", async () => {
+    const res = await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", {
+        party_id: "nope",
+        viewer_id: "v2",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("requires viewer_id", async () => {
+    const { body } = await createParty();
+    const res = await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", { party_id: body.party_id })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST sync", () => {
+  it("updates position and paused state", async () => {
+    const { body } = await createParty();
+    const res = await SYNC(
+      jsonReq("/api/routes-f/watch-party/sync", {
+        party_id: body.party_id,
+        position_seconds: 120,
+        paused: false,
+      })
+    );
+    expect(res.status).toBe(200);
+    const state = await res.json();
+    expect(state.position_seconds).toBe(120);
+    expect(state.paused).toBe(false);
+  });
+
+  it("rejects a negative position", async () => {
+    const { body } = await createParty();
+    const res = await SYNC(
+      jsonReq("/api/routes-f/watch-party/sync", {
+        party_id: body.party_id,
+        position_seconds: -5,
+        paused: false,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-boolean paused", async () => {
+    const { body } = await createParty();
+    const res = await SYNC(
+      jsonReq("/api/routes-f/watch-party/sync", {
+        party_id: body.party_id,
+        position_seconds: 10,
+        paused: "yes",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown party", async () => {
+    const res = await SYNC(
+      jsonReq("/api/routes-f/watch-party/sync", {
+        party_id: "nope",
+        position_seconds: 10,
+        paused: false,
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("create -> join -> sync flow", () => {
+  it("coordinates state across viewers", async () => {
+    const { body: created } = await createParty("host_1", "vod_42");
+
+    // A viewer joins.
+    await JOIN(
+      jsonReq("/api/routes-f/watch-party/join", {
+        party_id: created.party_id,
+        viewer_id: "v2",
+      })
+    );
+
+    // The host syncs playback forward and unpauses.
+    await SYNC(
+      jsonReq("/api/routes-f/watch-party/sync", {
+        party_id: created.party_id,
+        position_seconds: 300,
+        paused: false,
+      })
+    );
+
+    // The viewer polls the latest state and sees the synced position.
+    const state = await (
+      await GET(getReq(`?party_id=${created.party_id}`))
+    ).json();
+    expect(state.members).toEqual(["host_1", "v2"]);
+    expect(state.position_seconds).toBe(300);
+    expect(state.paused).toBe(false);
+    expect(state.vod_id).toBe("vod_42");
+  });
+});

--- a/app/api/routes-f/watch-party/create/route.ts
+++ b/app/api/routes-f/watch-party/create/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { CreateRequest, CreateResponse } from "../types";
+import { createParty } from "../store";
+
+/**
+ * POST /api/routes-f/watch-party/create
+ * Body: { host_id, vod_id }
+ *
+ * Creates a new watch party hosted by host_id for the given VOD and returns the
+ * party_id and a shareable join_code.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Partial<CreateRequest>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.host_id) {
+    return NextResponse.json({ error: "host_id is required" }, { status: 400 });
+  }
+  if (!body.vod_id) {
+    return NextResponse.json({ error: "vod_id is required" }, { status: 400 });
+  }
+
+  const party = createParty(body.host_id, body.vod_id);
+  const response: CreateResponse = {
+    party_id: party.party_id,
+    join_code: party.join_code,
+  };
+  return NextResponse.json(response, { status: 201 });
+}

--- a/app/api/routes-f/watch-party/join/route.ts
+++ b/app/api/routes-f/watch-party/join/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { JoinRequest } from "../types";
+import { joinParty } from "../store";
+
+/**
+ * POST /api/routes-f/watch-party/join
+ * Body: { party_id, viewer_id }
+ *
+ * Adds a viewer to an existing party. Idempotent — joining twice is a no-op.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Partial<JoinRequest>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.party_id) {
+    return NextResponse.json(
+      { error: "party_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!body.viewer_id) {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const party = joinParty(body.party_id, body.viewer_id);
+  if (!party) {
+    return NextResponse.json(
+      { error: `unknown party_id: ${body.party_id}` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(party);
+}

--- a/app/api/routes-f/watch-party/route.ts
+++ b/app/api/routes-f/watch-party/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getParty } from "./store";
+
+/**
+ * GET /api/routes-f/watch-party?party_id=party_x
+ *
+ * Returns the latest synced state for a watch party.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const partyId = req.nextUrl.searchParams.get("party_id");
+  if (!partyId) {
+    return NextResponse.json(
+      { error: "party_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const party = getParty(partyId);
+  if (!party) {
+    return NextResponse.json(
+      { error: `unknown party_id: ${partyId}` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(party);
+}

--- a/app/api/routes-f/watch-party/store.ts
+++ b/app/api/routes-f/watch-party/store.ts
@@ -1,0 +1,92 @@
+import type { WatchPartyState } from "./types";
+
+/**
+ * In-memory watch party store.
+ *
+ * This is a practice/demo store: state lives only for the lifetime of the
+ * process. A module-level Map keeps every active party keyed by party_id, with
+ * a secondary index from join_code -> party_id so viewers can join by code.
+ */
+const parties = new Map<string, WatchPartyState>();
+const joinCodeIndex = new Map<string, string>();
+
+let counter = 0;
+
+/** Reset all state. Intended for tests. */
+export function __resetStore(): void {
+  parties.clear();
+  joinCodeIndex.clear();
+  counter = 0;
+}
+
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}_${counter.toString(36)}${Date.now().toString(36)}`;
+}
+
+/** Generate a short, human-friendly uppercase join code. */
+function generateJoinCode(): string {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let code = "";
+  do {
+    code = "";
+    for (let i = 0; i < 6; i++) {
+      code += alphabet[Math.floor(Math.random() * alphabet.length)];
+    }
+  } while (joinCodeIndex.has(code));
+  return code;
+}
+
+export function createParty(hostId: string, vodId: string): WatchPartyState {
+  const party: WatchPartyState = {
+    party_id: nextId("party"),
+    join_code: generateJoinCode(),
+    host_id: hostId,
+    vod_id: vodId,
+    members: [hostId],
+    position_seconds: 0,
+    paused: true,
+    updated_at: new Date().toISOString(),
+  };
+  parties.set(party.party_id, party);
+  joinCodeIndex.set(party.join_code, party.party_id);
+  return party;
+}
+
+export function getParty(partyId: string): WatchPartyState | undefined {
+  return parties.get(partyId);
+}
+
+export function getPartyByJoinCode(code: string): WatchPartyState | undefined {
+  const partyId = joinCodeIndex.get(code);
+  return partyId ? parties.get(partyId) : undefined;
+}
+
+export function syncParty(
+  partyId: string,
+  positionSeconds: number,
+  paused: boolean
+): WatchPartyState | undefined {
+  const party = parties.get(partyId);
+  if (!party) return undefined;
+  party.position_seconds = positionSeconds;
+  party.paused = paused;
+  party.updated_at = new Date().toISOString();
+  return party;
+}
+
+/**
+ * Add a viewer to a party. Idempotent: joining twice does not duplicate the
+ * member. Returns undefined if the party does not exist.
+ */
+export function joinParty(
+  partyId: string,
+  viewerId: string
+): WatchPartyState | undefined {
+  const party = parties.get(partyId);
+  if (!party) return undefined;
+  if (!party.members.includes(viewerId)) {
+    party.members.push(viewerId);
+  }
+  return party;
+}

--- a/app/api/routes-f/watch-party/sync/route.ts
+++ b/app/api/routes-f/watch-party/sync/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { SyncRequest } from "../types";
+import { syncParty } from "../store";
+
+/**
+ * POST /api/routes-f/watch-party/sync
+ * Body: { party_id, position_seconds, paused }
+ *
+ * Updates the shared playback position and paused state for a party. Typically
+ * called by the host so other viewers can poll GET ?party_id for the latest.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Partial<SyncRequest>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.party_id) {
+    return NextResponse.json(
+      { error: "party_id is required" },
+      { status: 400 }
+    );
+  }
+  if (
+    typeof body.position_seconds !== "number" ||
+    !Number.isFinite(body.position_seconds) ||
+    body.position_seconds < 0
+  ) {
+    return NextResponse.json(
+      { error: "position_seconds must be a non-negative number" },
+      { status: 400 }
+    );
+  }
+  if (typeof body.paused !== "boolean") {
+    return NextResponse.json(
+      { error: "paused must be a boolean" },
+      { status: 400 }
+    );
+  }
+
+  const party = syncParty(body.party_id, body.position_seconds, body.paused);
+  if (!party) {
+    return NextResponse.json(
+      { error: `unknown party_id: ${body.party_id}` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(party);
+}

--- a/app/api/routes-f/watch-party/types.ts
+++ b/app/api/routes-f/watch-party/types.ts
@@ -1,0 +1,35 @@
+export interface WatchPartyState {
+  party_id: string;
+  join_code: string;
+  host_id: string;
+  vod_id: string;
+  /** Viewer ids currently in the party (host included). */
+  members: string[];
+  /** Current playback position in seconds. */
+  position_seconds: number;
+  /** Whether playback is paused. */
+  paused: boolean;
+  /** ISO timestamp of the last sync/update. */
+  updated_at: string;
+}
+
+export interface CreateRequest {
+  host_id: string;
+  vod_id: string;
+}
+
+export interface CreateResponse {
+  party_id: string;
+  join_code: string;
+}
+
+export interface SyncRequest {
+  party_id: string;
+  position_seconds: number;
+  paused: boolean;
+}
+
+export interface JoinRequest {
+  party_id: string;
+  viewer_id: string;
+}


### PR DESCRIPTION
## Summary

Adds four self-contained `app/api/routes-f/` features. Every file (route handlers, helpers, types, tests) lives inside its own subfolder with no imports from `lib/`, `utils/`, `types/`, or `components/`, per the scope constraint — so these merge independently in any order.

## Endpoints

### #1024 — Follower growth chart (`follower-growth/`)
- `GET ?creator_id&granularity=day|week|month` → `{ series: [{ bucket_start, count }], total }`
- Buckets seed follow events by UTC day / ISO-week (Monday start) / month and computes a cumulative count per bucket.

### #1026 — Viewer source attribution (`viewer-sources/`)
- `GET ?stream_id` → `{ sources: [{ source, viewers, percent }], total }`
- Breaks viewers down by referrer (direct, explore, social, embed), sorted by viewers desc, with percentage of total.

### #1027 — Category performance report (`category-performance/`)
- `GET ?creator_id` → `{ categories: [{ category, stream_count, avg_viewers, avg_tips_usdc }] }`
- Aggregates a creator's streams per category, sorted by stream_count desc.

### #1034 — Synced watch party state (`watch-party/`)
- `POST /create { host_id, vod_id }` → `{ party_id, join_code }`
- `POST /join { party_id, viewer_id }` (idempotent)
- `POST /sync { party_id, position_seconds, paused }`
- `GET ?party_id` → latest state
- In-memory store keyed by `party_id` with a `join_code` secondary index.

## Tests
Each feature ships a `__tests__/route.test.ts` covering the requirement-specified logic: cumulative correctness, percentage math, per-category averages, and the create → join → sync flow, plus validation and edge cases (empty/unknown inputs).

## Notes
- Realistic StreamFi-domain seed data; no real app code imported.
- Commits are split one-per-issue.

Closes #1024
Closes #1026
Closes #1027
Closes #1034
