### PR TITLE
feat(routes-f): channel banner metadata + stream handoff endpoints   

### DIFF
--- a/app/api/routes-f/channel/banner/__tests__/route.test.ts
+++ b/app/api/routes-f/channel/banner/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../route";
+import { __resetBanners } from "../store";
+
+function putReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/channel/banner", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/channel/banner${query}`
+  );
+}
+
+beforeEach(() => {
+  __resetBanners();
+});
+
+describe("GET /api/routes-f/channel/banner", () => {
+  it("requires creator_id", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns defaults when no banner is set", async () => {
+    const res = await GET(getReq("?creator_id=creator_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.banner_url).toBe("");
+    expect(body.focal_point).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("returns the stored banner", async () => {
+    await PUT(
+      putReq({
+        creator_id: "creator_1",
+        banner_url: "https://cdn.example.com/banner.png",
+        focal_point: { x: 0.3, y: 0.7 },
+      })
+    );
+    const res = await GET(getReq("?creator_id=creator_1"));
+    const body = await res.json();
+    expect(body.banner_url).toBe("https://cdn.example.com/banner.png");
+    expect(body.focal_point).toEqual({ x: 0.3, y: 0.7 });
+  });
+});
+
+describe("PUT /api/routes-f/channel/banner", () => {
+  it("updates banner with a focal point", async () => {
+    const res = await PUT(
+      putReq({
+        creator_id: "creator_1",
+        banner_url: "https://cdn.example.com/b.png",
+        focal_point: { x: 0.1, y: 0.9 },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.banner_url).toBe("https://cdn.example.com/b.png");
+    expect(body.focal_point).toEqual({ x: 0.1, y: 0.9 });
+  });
+
+  it("defaults focal_point to center when omitted on first set", async () => {
+    const res = await PUT(
+      putReq({
+        creator_id: "creator_2",
+        banner_url: "https://cdn.example.com/b.png",
+      })
+    );
+    const body = await res.json();
+    expect(body.focal_point).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("preserves prior focal_point when omitted on subsequent updates", async () => {
+    await PUT(
+      putReq({
+        creator_id: "creator_3",
+        banner_url: "https://cdn.example.com/a.png",
+        focal_point: { x: 0.2, y: 0.4 },
+      })
+    );
+    const res = await PUT(
+      putReq({
+        creator_id: "creator_3",
+        banner_url: "https://cdn.example.com/b.png",
+      })
+    );
+    const body = await res.json();
+    expect(body.banner_url).toBe("https://cdn.example.com/b.png");
+    expect(body.focal_point).toEqual({ x: 0.2, y: 0.4 });
+  });
+
+  it("requires creator_id", async () => {
+    const res = await PUT(
+      putReq({ banner_url: "https://cdn.example.com/b.png" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("requires banner_url", async () => {
+    const res = await PUT(putReq({ creator_id: "creator_4" }));
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    [{ x: -0.1, y: 0.5 }, "x below range"],
+    [{ x: 1.1, y: 0.5 }, "x above range"],
+    [{ x: 0.5, y: -0.1 }, "y below range"],
+    [{ x: 0.5, y: 1.1 }, "y above range"],
+    [{ x: "0", y: 0.5 }, "x not a number"],
+    [{ y: 0.5 }, "x missing"],
+    [{ x: 0.5 }, "y missing"],
+  ])("rejects invalid focal_point (%j — %s)", async (focal_point) => {
+    const res = await PUT(
+      putReq({
+        creator_id: "creator_5",
+        banner_url: "https://cdn.example.com/b.png",
+        focal_point,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts focal point boundaries 0 and 1", async () => {
+    const res = await PUT(
+      putReq({
+        creator_id: "creator_6",
+        banner_url: "https://cdn.example.com/b.png",
+        focal_point: { x: 0, y: 1 },
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/channel/banner",
+      {
+        method: "PUT",
+        body: "{not json",
+        headers: { "content-type": "application/json" },
+      }
+    );
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/channel/banner/route.ts
+++ b/app/api/routes-f/channel/banner/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { GetBannerResponse, PutBannerBody } from "./types";
+import { DEFAULT_FOCAL_POINT } from "./types";
+import { getBanner, isValidFocalPoint, upsertBanner } from "./store";
+
+/**
+ * GET /api/routes-f/channel/banner?creator_id=...
+ * Returns the banner_url and focal_point for the creator. Defaults to an
+ * empty banner_url and center focal point if no banner has been set yet.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creatorId = req.nextUrl.searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const banner = getBanner(creatorId);
+  if (!banner) {
+    return NextResponse.json({
+      banner_url: "",
+      focal_point: DEFAULT_FOCAL_POINT,
+    } satisfies GetBannerResponse);
+  }
+
+  return NextResponse.json({
+    banner_url: banner.banner_url,
+    focal_point: banner.focal_point,
+  } satisfies GetBannerResponse);
+}
+
+/**
+ * PUT /api/routes-f/channel/banner
+ * Body: { creator_id, banner_url, focal_point? }
+ *
+ * Validates focal_point.x and y are in [0, 1]. Omitting focal_point preserves
+ * the previously stored value (or defaults to {0.5, 0.5}).
+ */
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: Partial<PutBannerBody>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, banner_url, focal_point } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!banner_url || typeof banner_url !== "string") {
+    return NextResponse.json(
+      { error: "banner_url is required" },
+      { status: 400 }
+    );
+  }
+  if (focal_point !== undefined && !isValidFocalPoint(focal_point)) {
+    return NextResponse.json(
+      { error: "focal_point.x and focal_point.y must be numbers in [0, 1]" },
+      { status: 400 }
+    );
+  }
+
+  const updated = upsertBanner(creator_id, banner_url, focal_point);
+  return NextResponse.json({
+    banner_url: updated.banner_url,
+    focal_point: updated.focal_point,
+  } satisfies GetBannerResponse);
+}

--- a/app/api/routes-f/channel/banner/store.ts
+++ b/app/api/routes-f/channel/banner/store.ts
@@ -1,0 +1,47 @@
+import type { ChannelBanner, FocalPoint } from "./types";
+import { DEFAULT_FOCAL_POINT } from "./types";
+
+/**
+ * In-memory banner metadata store. State lives only for the lifetime of the
+ * process. Each creator has at most one banner record.
+ */
+const banners = new Map<string, ChannelBanner>();
+
+export function getBanner(creatorId: string): ChannelBanner | null {
+  return banners.get(creatorId) ?? null;
+}
+
+export function upsertBanner(
+  creatorId: string,
+  bannerUrl: string,
+  focalPoint?: FocalPoint
+): ChannelBanner {
+  const existing = banners.get(creatorId);
+  const record: ChannelBanner = {
+    creator_id: creatorId,
+    banner_url: bannerUrl,
+    focal_point: focalPoint ?? existing?.focal_point ?? DEFAULT_FOCAL_POINT,
+    last_updated: new Date().toISOString(),
+  };
+  banners.set(creatorId, record);
+  return record;
+}
+
+export function __resetBanners(): void {
+  banners.clear();
+}
+
+export function isValidFocalPoint(value: unknown): value is FocalPoint {
+  if (typeof value !== "object" || value === null) return false;
+  const fp = value as { x?: unknown; y?: unknown };
+  return (
+    typeof fp.x === "number" &&
+    Number.isFinite(fp.x) &&
+    fp.x >= 0 &&
+    fp.x <= 1 &&
+    typeof fp.y === "number" &&
+    Number.isFinite(fp.y) &&
+    fp.y >= 0 &&
+    fp.y <= 1
+  );
+}

--- a/app/api/routes-f/channel/banner/types.ts
+++ b/app/api/routes-f/channel/banner/types.ts
@@ -1,0 +1,24 @@
+export interface FocalPoint {
+  x: number;
+  y: number;
+}
+
+export interface ChannelBanner {
+  creator_id: string;
+  banner_url: string;
+  focal_point: FocalPoint;
+  last_updated: string;
+}
+
+export interface GetBannerResponse {
+  banner_url: string;
+  focal_point: FocalPoint;
+}
+
+export interface PutBannerBody {
+  creator_id: string;
+  banner_url: string;
+  focal_point?: FocalPoint;
+}
+
+export const DEFAULT_FOCAL_POINT: FocalPoint = { x: 0.5, y: 0.5 };

--- a/app/api/routes-f/stream-handoff/__tests__/route.test.ts
+++ b/app/api/routes-f/stream-handoff/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { __resetHandoffStore, getStream, upsertStream } from "../store";
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/stream-handoff", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stream-handoff${query}`
+  );
+}
+
+function seedStream(
+  stream_id = "stream_1",
+  current_host_id = "host_a",
+  hosts: string[] = ["host_a", "host_b"]
+) {
+  upsertStream({ stream_id, current_host_id, hosts });
+}
+
+beforeEach(() => {
+  __resetHandoffStore();
+});
+
+describe("POST /api/routes-f/stream-handoff", () => {
+  it("hands off control from the current host to a permitted host", async () => {
+    seedStream();
+    const res = await POST(
+      postReq({
+        stream_id: "stream_1",
+        from_user_id: "host_a",
+        to_user_id: "host_b",
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.handed_off_at).toBe("string");
+    expect(new Date(body.handed_off_at).toString()).not.toBe("Invalid Date");
+
+    // current host is updated.
+    expect(getStream("stream_1")?.current_host_id).toBe("host_b");
+  });
+
+  it("rejects a handoff initiated by a non-current host (unauthorized)", async () => {
+    seedStream();
+    const res = await POST(
+      postReq({
+        stream_id: "stream_1",
+        from_user_id: "host_b",
+        to_user_id: "host_a",
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a handoff to a user not in the hosts list", async () => {
+    seedStream();
+    const res = await POST(
+      postReq({
+        stream_id: "stream_1",
+        from_user_id: "host_a",
+        to_user_id: "stranger",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404s when the stream does not exist", async () => {
+    const res = await POST(
+      postReq({
+        stream_id: "nope",
+        from_user_id: "host_a",
+        to_user_id: "host_b",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    [{ from_user_id: "host_a", to_user_id: "host_b" }, "missing stream_id"],
+    [{ stream_id: "stream_1", to_user_id: "host_b" }, "missing from_user_id"],
+    [{ stream_id: "stream_1", from_user_id: "host_a" }, "missing to_user_id"],
+    [
+      {
+        stream_id: "stream_1",
+        from_user_id: "host_a",
+        to_user_id: "host_a",
+      },
+      "from equals to",
+    ],
+  ])("400s for invalid body (%s)", async (body) => {
+    seedStream();
+    const res = await POST(postReq(body));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stream-handoff", {
+      method: "POST",
+      body: "{not json",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("appends to the handoff log on each successful handoff", async () => {
+    seedStream("stream_2", "host_a", ["host_a", "host_b", "host_c"]);
+
+    await POST(
+      postReq({
+        stream_id: "stream_2",
+        from_user_id: "host_a",
+        to_user_id: "host_b",
+      })
+    );
+    await POST(
+      postReq({
+        stream_id: "stream_2",
+        from_user_id: "host_b",
+        to_user_id: "host_c",
+      })
+    );
+
+    const res = await GET(getReq("?stream_id=stream_2"));
+    const body = await res.json();
+    expect(body.log).toHaveLength(2);
+    expect(body.log[0].from_user_id).toBe("host_a");
+    expect(body.log[0].to_user_id).toBe("host_b");
+    expect(body.log[1].from_user_id).toBe("host_b");
+    expect(body.log[1].to_user_id).toBe("host_c");
+  });
+});
+
+describe("GET /api/routes-f/stream-handoff", () => {
+  it("requires stream_id", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown stream", async () => {
+    const res = await GET(getReq("?stream_id=nope"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns an empty log for a stream with no handoffs yet", async () => {
+    seedStream();
+    const res = await GET(getReq("?stream_id=stream_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stream_id).toBe("stream_1");
+    expect(body.log).toEqual([]);
+  });
+});

--- a/app/api/routes-f/stream-handoff/route.ts
+++ b/app/api/routes-f/stream-handoff/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import type {
+  HandoffLogResponse,
+  HandoffRequest,
+  HandoffResponse,
+} from "./types";
+import { applyHandoff, getHandoffLog, getStream } from "./store";
+
+/**
+ * POST /api/routes-f/stream-handoff
+ * Body: { stream_id, from_user_id, to_user_id }
+ *
+ * Hands control of a live stream from the current host (from_user_id) to
+ * another permitted host (to_user_id). Validates that:
+ *   - the stream exists
+ *   - from_user_id is the current host (otherwise 403)
+ *   - to_user_id is in the stream's hosts list
+ *
+ * On success returns { handed_off_at } and appends to the handoff log.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: Partial<HandoffRequest>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id, from_user_id, to_user_id } = body;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!from_user_id || typeof from_user_id !== "string") {
+    return NextResponse.json(
+      { error: "from_user_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!to_user_id || typeof to_user_id !== "string") {
+    return NextResponse.json(
+      { error: "to_user_id is required" },
+      { status: 400 }
+    );
+  }
+  if (from_user_id === to_user_id) {
+    return NextResponse.json(
+      { error: "from_user_id and to_user_id must differ" },
+      { status: 400 }
+    );
+  }
+
+  const stream = getStream(stream_id);
+  if (!stream) {
+    return NextResponse.json(
+      { error: `unknown stream_id: ${stream_id}` },
+      { status: 404 }
+    );
+  }
+
+  // Only the active host may initiate a handoff.
+  if (stream.current_host_id !== from_user_id) {
+    return NextResponse.json(
+      { error: "from_user_id is not the current host" },
+      { status: 403 }
+    );
+  }
+
+  if (!stream.hosts.includes(to_user_id)) {
+    return NextResponse.json(
+      { error: "to_user_id is not in the hosts list" },
+      { status: 400 }
+    );
+  }
+
+  const entry = applyHandoff(stream_id, from_user_id, to_user_id);
+  return NextResponse.json({
+    handed_off_at: entry.handed_off_at,
+  } satisfies HandoffResponse);
+}
+
+/**
+ * GET /api/routes-f/stream-handoff?stream_id=...
+ * Returns the append-only handoff log for the stream (oldest first).
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const stream = getStream(streamId);
+  if (!stream) {
+    return NextResponse.json(
+      { error: `unknown stream_id: ${streamId}` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    stream_id: streamId,
+    log: getHandoffLog(streamId),
+  } satisfies HandoffLogResponse);
+}

--- a/app/api/routes-f/stream-handoff/store.ts
+++ b/app/api/routes-f/stream-handoff/store.ts
@@ -1,0 +1,63 @@
+import type { HandoffEntry, StreamRecord } from "./types";
+
+/**
+ * In-memory stream + handoff log store.
+ *
+ * `streams` tracks the current host and the allowed hosts list for each
+ * stream. `handoffLog` keeps an append-only history of every handoff, keyed by
+ * stream_id. State lives only for the lifetime of the process.
+ */
+const streams = new Map<string, StreamRecord>();
+const handoffLog = new Map<string, HandoffEntry[]>();
+
+export function __resetHandoffStore(): void {
+  streams.clear();
+  handoffLog.clear();
+}
+
+export function upsertStream(record: StreamRecord): StreamRecord {
+  const normalized: StreamRecord = {
+    stream_id: record.stream_id,
+    current_host_id: record.current_host_id,
+    hosts: Array.from(new Set([record.current_host_id, ...record.hosts])),
+  };
+  streams.set(record.stream_id, normalized);
+  return normalized;
+}
+
+export function getStream(streamId: string): StreamRecord | undefined {
+  return streams.get(streamId);
+}
+
+export function getHandoffLog(streamId: string): HandoffEntry[] {
+  return handoffLog.get(streamId) ?? [];
+}
+
+/**
+ * Apply a handoff: re-point the stream's current host and append a log entry.
+ * Caller is responsible for authorisation and target validation.
+ */
+export function applyHandoff(
+  streamId: string,
+  fromUserId: string,
+  toUserId: string
+): HandoffEntry {
+  const stream = streams.get(streamId);
+  if (!stream) {
+    throw new Error(`unknown stream_id: ${streamId}`);
+  }
+  stream.current_host_id = toUserId;
+  if (!stream.hosts.includes(toUserId)) {
+    stream.hosts.push(toUserId);
+  }
+  const entry: HandoffEntry = {
+    stream_id: streamId,
+    from_user_id: fromUserId,
+    to_user_id: toUserId,
+    handed_off_at: new Date().toISOString(),
+  };
+  const existing = handoffLog.get(streamId) ?? [];
+  existing.push(entry);
+  handoffLog.set(streamId, existing);
+  return entry;
+}

--- a/app/api/routes-f/stream-handoff/types.ts
+++ b/app/api/routes-f/stream-handoff/types.ts
@@ -1,0 +1,34 @@
+export interface HandoffEntry {
+  stream_id: string;
+  from_user_id: string;
+  to_user_id: string;
+  handed_off_at: string;
+}
+
+export interface HandoffRequest {
+  stream_id: string;
+  from_user_id: string;
+  to_user_id: string;
+}
+
+export interface HandoffResponse {
+  handed_off_at: string;
+}
+
+export interface HandoffLogResponse {
+  stream_id: string;
+  log: HandoffEntry[];
+}
+
+/**
+ * Minimal stream record used by the handoff endpoint. In a real app this would
+ * be backed by the live stream table; here we keep a self-contained shape so
+ * the route is scope-clean.
+ */
+export interface StreamRecord {
+  stream_id: string;
+  /** The user currently in control of the broadcast. */
+  current_host_id: string;
+  /** Allowed hosts that may receive a handoff. */
+  hosts: string[];
+}


### PR DESCRIPTION
 ## Summary
  Adds two self-contained routes-f endpoints, both scoped entirely to `app/api/routes-f/` per the per-issue scope constraint.

  - **Channel banner metadata** (#1040) — `app/api/routes-f/channel/banner/`
    - `GET ?creator_id` returns `{ banner_url, focal_point: { x, y } }` (defaults to empty url + center focal point when none set)
    - `PUT { creator_id, banner_url, focal_point? }` upserts; omitting `focal_point` preserves the prior value
    - Validates `focal_point.x` and `focal_point.y` are finite numbers in `[0, 1]`
  - **Stream handoff endpoint** (#1047) — `app/api/routes-f/stream-handoff/`
    - `POST { stream_id, from_user_id, to_user_id }` → `{ handed_off_at }`
    - Validates `to_user_id` is in the stream's hosts list, and that `from_user_id` is the current host (403 otherwise)
    - Appends every handoff to an in-memory log
    - `GET ?stream_id` returns the handoff log
    
  Both features use process-local in-memory stores following the existing routes-f pattern (e.g. `watch-party`). No imports outside
  `app/api/routes-f/`.
  
  ## Test plan
  - [ ] `app/api/routes-f/channel/banner/__tests__/route.test.ts` — GET defaults, GET stored, PUT update + preservation, focal-point
  boundary + invalid-range cases, missing-field cases, invalid JSON
  - [ ] `app/api/routes-f/stream-handoff/__tests__/route.test.ts` — successful handoff updates current host, unauthorized (non-current
  host) → 403, target not in hosts → 400, missing-field cases, unknown stream → 404, multi-handoff log append, GET empty log, GET unknown
  stream
  
  ## Issues
  Closes #1040
  Closes #1047
  Closes #418