### PR TITLE
feat(routes-f): ban appeals, ban sync, and activity feed (#390, #1044, #1045)

### DIFF
--- a/app/api/routes-f/activity/__tests__/insert.test.ts
+++ b/app/api/routes-f/activity/__tests__/insert.test.ts
@@ -1,0 +1,60 @@
+import { sql } from "@vercel/postgres";
+import { insertActivityEvent } from "../_lib/insert";
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+
+describe("insertActivityEvent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates table and inserts an event", async () => {
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: "evt-new" }] });
+
+    const result = await insertActivityEvent({
+      userId: "user-creator",
+      type: "new_follower",
+      actorId: "user-follower",
+      metadata: { source: "routes-f/follows" },
+    });
+
+    expect(result).toEqual({ id: "evt-new" });
+    expect(sqlMock).toHaveBeenCalledTimes(2);
+    expect(sqlMock).toHaveBeenLastCalledWith(
+      expect.arrayContaining([expect.stringContaining("INSERT INTO activity_events")]),
+      "user-creator",
+      "new_follower",
+      "user-follower",
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("inserts paired tip events for sender and receiver", async () => {
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: "tip-recv" }] });
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({ rows: [{ id: "tip-sent" }] });
+
+    await insertActivityEvent({
+      userId: "creator-1",
+      type: "tip_received",
+      actorId: "viewer-1",
+      metadata: { amount: "25", currency: "XLM", tx_hash: "abc123" },
+    });
+
+    await insertActivityEvent({
+      userId: "viewer-1",
+      type: "tip_sent",
+      actorId: "creator-1",
+      metadata: { amount: "25", currency: "XLM", tx_hash: "abc123" },
+    });
+
+    expect(sqlMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/app/api/routes-f/activity/__tests__/route.test.ts
+++ b/app/api/routes-f/activity/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { sql } from "@vercel/postgres";
+import { GET } from "../route";
+import { GET as GETDaily } from "../daily/route";
+import { verifySession } from "@/lib/auth/verify-session";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+
+const USER_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function authRequest(url: string): Request {
+  return new Request(url, {
+    headers: { cookie: "session=mock-token" },
+  }) as any;
+}
+
+function mockAuth(userId = USER_ID) {
+  verifySessionMock.mockResolvedValueOnce({ ok: true, userId });
+}
+
+describe("GET /api/routes-f/activity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    verifySessionMock.mockResolvedValueOnce({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+      }),
+    });
+
+    const res = await GET(authRequest("http://localhost/api/routes-f/activity"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty state with null next_cursor", async () => {
+    mockAuth();
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(authRequest("http://localhost/api/routes-f/activity"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ events: [], next_cursor: null });
+  });
+
+  it("returns paginated events with actor details", async () => {
+    mockAuth();
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "evt-1",
+          user_id: USER_ID,
+          type: "tip_received",
+          actor_id: "actor-1",
+          metadata: { amount: "10", currency: "XLM" },
+          created_at: "2026-03-26T12:00:00.000Z",
+          actor_username: "bob",
+          actor_avatar: "https://cdn.example/bob.png",
+        },
+      ],
+    });
+
+    const res = await GET(authRequest("http://localhost/api/routes-f/activity?limit=20"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]).toEqual({
+      id: "evt-1",
+      type: "tip_received",
+      actor: { username: "bob", avatar: "https://cdn.example/bob.png" },
+      metadata: { amount: "10", currency: "XLM" },
+      created_at: "2026-03-26T12:00:00.000Z",
+    });
+    expect(body.next_cursor).toBeNull();
+  });
+
+  it("returns next_cursor when more pages exist", async () => {
+    mockAuth();
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "evt-1",
+          user_id: USER_ID,
+          type: "new_follower",
+          actor_id: "a1",
+          metadata: {},
+          created_at: "2026-03-26T12:00:00.000Z",
+          actor_username: "alice",
+          actor_avatar: null,
+        },
+        {
+          id: "evt-2",
+          user_id: USER_ID,
+          type: "new_follower",
+          actor_id: "a2",
+          metadata: {},
+          created_at: "2026-03-26T11:00:00.000Z",
+          actor_username: "carol",
+          actor_avatar: null,
+        },
+      ],
+    });
+
+    const res = await GET(
+      authRequest("http://localhost/api/routes-f/activity?limit=1")
+    );
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.next_cursor).toBe("2026-03-26T12:00:00.000Z");
+  });
+
+  it("returns 400 for invalid type filter", async () => {
+    mockAuth();
+    const res = await GET(
+      authRequest("http://localhost/api/routes-f/activity?type=invalid")
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts valid type filters", async () => {
+    mockAuth();
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({ rows: [] });
+
+    const res = await GET(
+      authRequest("http://localhost/api/routes-f/activity?type=tips")
+    );
+    expect(res.status).toBe(200);
+    expect(sqlMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining("ANY")]),
+      USER_ID,
+      expect.any(Array),
+      21
+    );
+  });
+});
+
+describe("GET /api/routes-f/activity/daily", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns aggregated counts for the day", async () => {
+    mockAuth();
+    sqlMock.mockResolvedValueOnce({});
+    sqlMock.mockResolvedValueOnce({
+      rows: [
+        { type: "tip_received", metadata: { amount: "5", currency: "XLM" } },
+        { type: "tip_received", metadata: { amount: "10", currency: "XLM" } },
+        { type: "new_follower", metadata: {} },
+        {
+          type: "stream_ended",
+          metadata: { duration_seconds: 3600, peak_viewers: 120 },
+        },
+      ],
+    });
+
+    const res = await GETDaily(
+      authRequest("http://localhost/api/routes-f/activity/daily?date=2026-03-26")
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      date: "2026-03-26",
+      tips_received: 2,
+      followers_gained: 1,
+      stream_duration_seconds: 3600,
+      peak_viewers: 120,
+    });
+  });
+
+  it("returns 400 when date is missing", async () => {
+    mockAuth();
+    const res = await GETDaily(
+      authRequest("http://localhost/api/routes-f/activity/daily")
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/activity/__tests__/upstream.test.ts
+++ b/app/api/routes-f/activity/__tests__/upstream.test.ts
@@ -1,0 +1,120 @@
+import { sql } from "@vercel/postgres";
+import { POST as followPost } from "../../follows/route";
+import { POST as streamStartPost } from "../../streams/start/route";
+import { POST as tipPaymentPost } from "../../tips/payment/route";
+import { verifySession } from "@/lib/auth/verify-session";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: { "Content-Type": "application/json" },
+      }),
+  },
+}));
+
+jest.mock("@vercel/postgres", () => ({
+  sql: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/verify-session", () => ({
+  verifySession: jest.fn(),
+}));
+
+jest.mock("@/app/api/routes-f/activity/_lib/insert", () => ({
+  insertActivityEvent: jest.fn().mockResolvedValue({ id: "mock-event-id" }),
+}));
+
+import { insertActivityEvent } from "@/app/api/routes-f/activity/_lib/insert";
+
+const sqlMock = sql as unknown as jest.Mock;
+const verifySessionMock = verifySession as jest.Mock;
+const insertMock = insertActivityEvent as jest.Mock;
+
+const FOLLOWER_ID = "550e8400-e29b-41d4-a716-446655440001";
+const CREATOR_ID = "550e8400-e29b-41d4-a716-446655440002";
+
+function jsonReq(url: string, body: object): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", cookie: "session=token" },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+describe("Activity upstream side effects (routes-f)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifySessionMock.mockResolvedValue({ ok: true, userId: FOLLOWER_ID });
+  });
+
+  it("routes-f/follows POST inserts new_follower for the creator", async () => {
+    sqlMock
+      .mockResolvedValueOnce({ rows: [{ id: CREATOR_ID, username: "alice", avatar: null, bio: null }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ follower_id: FOLLOWER_ID }] })
+      .mockResolvedValueOnce({ rows: [{ follower_count: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }] });
+
+    const res = await followPost(
+      jsonReq("http://localhost/api/routes-f/follows", { creator_id: CREATOR_ID })
+    );
+    expect(res.status).toBe(201);
+    expect(insertMock).toHaveBeenCalledWith({
+      userId: CREATOR_ID,
+      type: "new_follower",
+      actorId: FOLLOWER_ID,
+      metadata: { source: "routes-f/follows" },
+    });
+  });
+
+  it("routes-f/streams/start POST inserts stream_started", async () => {
+    verifySessionMock.mockResolvedValue({ ok: true, userId: CREATOR_ID });
+    sqlMock.mockResolvedValueOnce({ rows: [{ username: "alice" }] });
+
+    const res = await streamStartPost(
+      jsonReq("http://localhost/api/routes-f/streams/start", {
+        stream_title: "Friday Night Stream",
+        peak_viewers: 42,
+      })
+    );
+    expect(res.status).toBe(201);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: CREATOR_ID,
+        type: "stream_started",
+        metadata: expect.objectContaining({
+          stream_title: "Friday Night Stream",
+          peak_viewers: 42,
+        }),
+      })
+    );
+  });
+
+  it("routes-f/tips/payment POST inserts tip_received and tip_sent", async () => {
+    const res = await tipPaymentPost(
+      jsonReq("http://localhost/api/routes-f/tips/payment", {
+        creator_id: CREATOR_ID,
+        amount: "10",
+        currency: "XLM",
+        tx_hash: "stellar-tx-abc",
+      })
+    );
+    expect(res.status).toBe(201);
+    expect(insertMock).toHaveBeenCalledTimes(2);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: CREATOR_ID,
+        type: "tip_received",
+        actorId: FOLLOWER_ID,
+      })
+    );
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: FOLLOWER_ID,
+        type: "tip_sent",
+        actorId: CREATOR_ID,
+      })
+    );
+  });
+});

--- a/app/api/routes-f/activity/_lib/db.ts
+++ b/app/api/routes-f/activity/_lib/db.ts
@@ -1,0 +1,238 @@
+import { sql } from "@vercel/postgres";
+import type {
+  ActivityEventRow,
+  ActivityEventResponse,
+  DailySummaryResponse,
+  InsertActivityEventInput,
+} from "./types";
+import type { ActivityEventType } from "./types";
+import { typesForFilter } from "./filters";
+import type { ActivityFeedFilter } from "./types";
+
+export async function ensureActivityEventsTable(): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS activity_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL,
+      type TEXT NOT NULL,
+      actor_id UUID,
+      metadata JSONB DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS activity_user_feed
+    ON activity_events (user_id, created_at DESC)
+  `;
+}
+
+export async function insertActivityEvent(
+  input: InsertActivityEventInput
+): Promise<{ id: string }> {
+  await ensureActivityEventsTable();
+
+  const metadata = JSON.stringify(input.metadata ?? {});
+  const createdAt = input.createdAt ?? new Date().toISOString();
+
+  const { rows } = await sql<{ id: string }>`
+    INSERT INTO activity_events (user_id, type, actor_id, metadata, created_at)
+    VALUES (
+      ${input.userId},
+      ${input.type},
+      ${input.actorId ?? null},
+      ${metadata}::jsonb,
+      ${createdAt}
+    )
+    RETURNING id
+  `;
+
+  return { id: rows[0].id };
+}
+
+type FeedRow = ActivityEventRow & {
+  actor_username: string | null;
+  actor_avatar: string | null;
+};
+
+function mapFeedRow(row: FeedRow): ActivityEventResponse {
+  return {
+    id: row.id,
+    type: row.type,
+    actor:
+      row.actor_id && row.actor_username
+        ? { username: row.actor_username, avatar: row.actor_avatar }
+        : null,
+    metadata: (row.metadata as Record<string, unknown>) ?? {},
+    created_at:
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : String(row.created_at),
+  };
+}
+
+export async function fetchActivityFeed(params: {
+  userId: string;
+  limit: number;
+  cursor?: string;
+  filter: ActivityFeedFilter;
+}): Promise<{ events: ActivityEventResponse[]; next_cursor: string | null }> {
+  await ensureActivityEventsTable();
+
+  const typeFilter = typesForFilter(params.filter);
+  const fetchLimit = params.limit + 1;
+
+  let rows: FeedRow[];
+
+  if (params.cursor && typeFilter) {
+    const { rows: result } = await sql<FeedRow>`
+      SELECT
+        ae.id,
+        ae.user_id,
+        ae.type,
+        ae.actor_id,
+        ae.metadata,
+        ae.created_at,
+        u.username AS actor_username,
+        u.avatar AS actor_avatar
+      FROM activity_events ae
+      LEFT JOIN users u ON u.id = ae.actor_id
+      WHERE ae.user_id = ${params.userId}
+        AND ae.created_at < ${params.cursor}
+        AND ae.type = ANY(${typeFilter}::text[])
+      ORDER BY ae.created_at DESC
+      LIMIT ${fetchLimit}
+    `;
+    rows = result;
+  } else if (params.cursor) {
+    const { rows: result } = await sql<FeedRow>`
+      SELECT
+        ae.id,
+        ae.user_id,
+        ae.type,
+        ae.actor_id,
+        ae.metadata,
+        ae.created_at,
+        u.username AS actor_username,
+        u.avatar AS actor_avatar
+      FROM activity_events ae
+      LEFT JOIN users u ON u.id = ae.actor_id
+      WHERE ae.user_id = ${params.userId}
+        AND ae.created_at < ${params.cursor}
+      ORDER BY ae.created_at DESC
+      LIMIT ${fetchLimit}
+    `;
+    rows = result;
+  } else if (typeFilter) {
+    const { rows: result } = await sql<FeedRow>`
+      SELECT
+        ae.id,
+        ae.user_id,
+        ae.type,
+        ae.actor_id,
+        ae.metadata,
+        ae.created_at,
+        u.username AS actor_username,
+        u.avatar AS actor_avatar
+      FROM activity_events ae
+      LEFT JOIN users u ON u.id = ae.actor_id
+      WHERE ae.user_id = ${params.userId}
+        AND ae.type = ANY(${typeFilter}::text[])
+      ORDER BY ae.created_at DESC
+      LIMIT ${fetchLimit}
+    `;
+    rows = result;
+  } else {
+    const { rows: result } = await sql<FeedRow>`
+      SELECT
+        ae.id,
+        ae.user_id,
+        ae.type,
+        ae.actor_id,
+        ae.metadata,
+        ae.created_at,
+        u.username AS actor_username,
+        u.avatar AS actor_avatar
+      FROM activity_events ae
+      LEFT JOIN users u ON u.id = ae.actor_id
+      WHERE ae.user_id = ${params.userId}
+      ORDER BY ae.created_at DESC
+      LIMIT ${fetchLimit}
+    `;
+    rows = result;
+  }
+
+  const hasMore = rows.length > params.limit;
+  const page = hasMore ? rows.slice(0, params.limit) : rows;
+  const events = page.map(mapFeedRow);
+  const next_cursor =
+    hasMore && page.length > 0
+      ? events[events.length - 1].created_at
+      : null;
+
+  return { events, next_cursor };
+}
+
+export async function fetchDailySummary(
+  userId: string,
+  date: string
+): Promise<DailySummaryResponse> {
+  await ensureActivityEventsTable();
+
+  const dayStart = `${date}T00:00:00.000Z`;
+  const dayEnd = `${date}T23:59:59.999Z`;
+
+  const { rows } = await sql<{
+    type: ActivityEventType;
+    metadata: Record<string, unknown> | null;
+  }>`
+    SELECT type, metadata
+    FROM activity_events
+    WHERE user_id = ${userId}
+      AND created_at >= ${dayStart}
+      AND created_at <= ${dayEnd}
+  `;
+
+  let tips_received = 0;
+  let followers_gained = 0;
+  let stream_duration_seconds = 0;
+  let peak_viewers = 0;
+
+  for (const row of rows) {
+    const meta = (row.metadata as Record<string, unknown>) ?? {};
+
+    if (row.type === "tip_received") {
+      tips_received += 1;
+    }
+
+    if (row.type === "new_follower") {
+      followers_gained += 1;
+    }
+
+    if (row.type === "stream_ended") {
+      const duration = Number(meta.duration_seconds ?? 0);
+      if (!Number.isNaN(duration)) {
+        stream_duration_seconds += duration;
+      }
+      const peak = Number(meta.peak_viewers ?? 0);
+      if (!Number.isNaN(peak)) {
+        peak_viewers = Math.max(peak_viewers, peak);
+      }
+    }
+
+    if (row.type === "stream_started") {
+      const peak = Number(meta.peak_viewers ?? 0);
+      if (!Number.isNaN(peak)) {
+        peak_viewers = Math.max(peak_viewers, peak);
+      }
+    }
+  }
+
+  return {
+    date,
+    tips_received,
+    followers_gained,
+    stream_duration_seconds,
+    peak_viewers,
+  };
+}

--- a/app/api/routes-f/activity/_lib/filters.ts
+++ b/app/api/routes-f/activity/_lib/filters.ts
@@ -1,0 +1,22 @@
+import type { ActivityFeedFilter, ActivityEventType } from "./types";
+
+const FILTER_TYPE_MAP: Record<
+  Exclude<ActivityFeedFilter, "all">,
+  ActivityEventType[]
+> = {
+  tips: ["tip_received", "tip_sent"],
+  follows: ["new_follower"],
+  streams: ["stream_started", "stream_ended", "recording_ready"],
+  gifts: ["gift_received", "gift_sent"],
+};
+
+export function typesForFilter(filter: ActivityFeedFilter): ActivityEventType[] | null {
+  if (filter === "all") {
+    return null;
+  }
+  return FILTER_TYPE_MAP[filter];
+}
+
+export function isValidActivityFeedFilter(value: string): value is ActivityFeedFilter {
+  return ["all", "tips", "follows", "streams", "gifts"].includes(value);
+}

--- a/app/api/routes-f/activity/_lib/insert.ts
+++ b/app/api/routes-f/activity/_lib/insert.ts
@@ -1,0 +1,2 @@
+export { insertActivityEvent, fetchActivityFeed, fetchDailySummary, ensureActivityEventsTable } from "./db";
+export type { InsertActivityEventInput } from "./types";

--- a/app/api/routes-f/activity/_lib/types.ts
+++ b/app/api/routes-f/activity/_lib/types.ts
@@ -1,0 +1,52 @@
+export const ACTIVITY_EVENT_TYPES = [
+  "tip_received",
+  "tip_sent",
+  "new_follower",
+  "stream_started",
+  "stream_ended",
+  "gift_received",
+  "gift_sent",
+  "recording_ready",
+] as const;
+
+export type ActivityEventType = (typeof ACTIVITY_EVENT_TYPES)[number];
+
+export type ActivityFeedFilter = "all" | "tips" | "follows" | "streams" | "gifts";
+
+export interface ActivityEventRow {
+  id: string;
+  user_id: string;
+  type: ActivityEventType;
+  actor_id: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ActivityEventResponse {
+  id: string;
+  type: ActivityEventType;
+  actor: { username: string; avatar: string | null } | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface ActivityFeedResponse {
+  events: ActivityEventResponse[];
+  next_cursor: string | null;
+}
+
+export interface DailySummaryResponse {
+  date: string;
+  tips_received: number;
+  followers_gained: number;
+  stream_duration_seconds: number;
+  peak_viewers: number;
+}
+
+export interface InsertActivityEventInput {
+  userId: string;
+  type: ActivityEventType;
+  actorId?: string | null;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+}

--- a/app/api/routes-f/activity/daily/route.ts
+++ b/app/api/routes-f/activity/daily/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { fetchDailySummary } from "../_lib/db";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const date = new URL(req.url).searchParams.get("date")?.trim();
+
+  if (!date || !DATE_RE.test(date)) {
+    return NextResponse.json(
+      { error: "date query parameter is required (YYYY-MM-DD)" },
+      { status: 400 }
+    );
+  }
+
+  if (Number.isNaN(Date.parse(`${date}T00:00:00.000Z`))) {
+    return NextResponse.json({ error: "date is not a valid calendar date" }, { status: 400 });
+  }
+
+  try {
+    const summary = await fetchDailySummary(session.userId, date);
+    return NextResponse.json(summary);
+  } catch (error) {
+    console.error("[routes-f activity/daily GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch daily activity summary" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/activity/route.ts
+++ b/app/api/routes-f/activity/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { fetchActivityFeed } from "./_lib/db";
+import { isValidActivityFeedFilter } from "./_lib/filters";
+import type { ActivityFeedFilter } from "./_lib/types";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get("limit");
+  const cursor = searchParams.get("cursor") ?? undefined;
+  const typeParam = searchParams.get("type") ?? "all";
+
+  if (!isValidActivityFeedFilter(typeParam)) {
+    return NextResponse.json(
+      { error: "type must be one of: all, tips, follows, streams, gifts" },
+      { status: 400 }
+    );
+  }
+
+  let limit = DEFAULT_LIMIT;
+  if (limitParam !== null) {
+    const parsed = Number(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+      return NextResponse.json(
+        { error: `limit must be an integer between 1 and ${MAX_LIMIT}` },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  if (cursor && Number.isNaN(Date.parse(cursor))) {
+    return NextResponse.json(
+      { error: "cursor must be a valid ISO timestamp" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await fetchActivityFeed({
+      userId: session.userId,
+      limit,
+      cursor,
+      filter: typeParam as ActivityFeedFilter,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[routes-f activity GET]", error);
+    return NextResponse.json(
+      { error: "Failed to fetch activity feed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/ban-appeals/__tests__/route.test.ts
+++ b/app/api/routes-f/ban-appeals/__tests__/route.test.ts
@@ -1,0 +1,161 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { POST as POSTResolve } from "../resolve/route";
+import { __resetBanAppealsStore } from "../store";
+
+const BASE = "http://localhost/api/routes-f/ban-appeals";
+const RESOLVE = `${BASE}/resolve`;
+
+function req(
+  method: string,
+  url: string,
+  body?: object
+): NextRequest {
+  return new NextRequest(url, {
+    method,
+    ...(body
+      ? {
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+        }
+      : {}),
+  });
+}
+
+beforeEach(() => {
+  __resetBanAppealsStore();
+});
+
+describe("Ban appeals lifecycle", () => {
+  it("submits an appeal and lists it as pending", async () => {
+    const createRes = await POST(
+      req("POST", BASE, {
+        creator_id: "creator-1",
+        viewer_id: "viewer-1",
+        message: "I did not break any rules.",
+      })
+    );
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    expect(created).toEqual({
+      appeal_id: expect.any(String),
+      status: "pending",
+    });
+
+    const listRes = await GET(req("GET", `${BASE}?creator_id=creator-1`));
+    expect(listRes.status).toBe(200);
+    const listed = await listRes.json();
+    expect(listed.appeals).toHaveLength(1);
+    expect(listed.appeals[0]).toMatchObject({
+      appeal_id: created.appeal_id,
+      viewer_id: "viewer-1",
+      message: "I did not break any rules.",
+      status: "pending",
+    });
+  });
+
+  it("resolves an appeal as accepted and removes it from pending list", async () => {
+    const createRes = await POST(
+      req("POST", BASE, {
+        creator_id: "creator-1",
+        viewer_id: "viewer-2",
+        message: "Please unban me.",
+      })
+    );
+    const { appeal_id } = await createRes.json();
+
+    const resolveRes = await POSTResolve(
+      req("POST", RESOLVE, {
+        appeal_id,
+        decision: "accept",
+        mod_note: "First offense, lifting ban.",
+      })
+    );
+    expect(resolveRes.status).toBe(200);
+    const resolved = await resolveRes.json();
+    expect(resolved).toMatchObject({
+      appeal_id,
+      status: "accepted",
+      mod_note: "First offense, lifting ban.",
+    });
+    expect(resolved.resolved_at).toBeTruthy();
+
+    const listRes = await GET(req("GET", `${BASE}?creator_id=creator-1`));
+    const listed = await listRes.json();
+    expect(listed.appeals).toHaveLength(0);
+  });
+
+  it("resolves an appeal as rejected", async () => {
+    const createRes = await POST(
+      req("POST", BASE, {
+        creator_id: "creator-2",
+        viewer_id: "viewer-3",
+        message: "It was a joke.",
+      })
+    );
+    const { appeal_id } = await createRes.json();
+
+    const resolveRes = await POSTResolve(
+      req("POST", RESOLVE, {
+        appeal_id,
+        decision: "reject",
+      })
+    );
+    expect(resolveRes.status).toBe(200);
+    expect((await resolveRes.json()).status).toBe("rejected");
+  });
+
+  it("returns 409 when resolving an already resolved appeal", async () => {
+    const createRes = await POST(
+      req("POST", BASE, {
+        creator_id: "creator-3",
+        viewer_id: "viewer-4",
+        message: "Appeal text.",
+      })
+    );
+    const { appeal_id } = await createRes.json();
+
+    await POSTResolve(
+      req("POST", RESOLVE, { appeal_id, decision: "reject" })
+    );
+
+    const secondResolve = await POSTResolve(
+      req("POST", RESOLVE, { appeal_id, decision: "accept" })
+    );
+    expect(secondResolve.status).toBe(409);
+  });
+
+  it("returns 409 for duplicate pending appeals from the same viewer", async () => {
+    await POST(
+      req("POST", BASE, {
+        creator_id: "creator-4",
+        viewer_id: "viewer-5",
+        message: "First appeal.",
+      })
+    );
+
+    const dupRes = await POST(
+      req("POST", BASE, {
+        creator_id: "creator-4",
+        viewer_id: "viewer-5",
+        message: "Second appeal.",
+      })
+    );
+    expect(dupRes.status).toBe(409);
+  });
+
+  it("returns 400 when creator_id is missing on GET", async () => {
+    const res = await GET(req("GET", BASE));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when resolving unknown appeal_id", async () => {
+    const res = await POSTResolve(
+      req("POST", RESOLVE, {
+        appeal_id: "00000000-0000-0000-0000-000000000099",
+        decision: "accept",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/routes-f/ban-appeals/resolve/route.ts
+++ b/app/api/routes-f/ban-appeals/resolve/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolveAppeal } from "../store";
+import type { AppealDecision } from "../types";
+
+const VALID_DECISIONS: AppealDecision[] = ["accept", "reject"];
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: {
+    appeal_id?: unknown;
+    decision?: unknown;
+    mod_note?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const appeal_id = typeof body.appeal_id === "string" ? body.appeal_id.trim() : "";
+  const decision = body.decision as AppealDecision;
+  const mod_note =
+    typeof body.mod_note === "string" ? body.mod_note : undefined;
+
+  if (!appeal_id) {
+    return NextResponse.json({ error: "appeal_id is required." }, { status: 400 });
+  }
+
+  if (!VALID_DECISIONS.includes(decision)) {
+    return NextResponse.json(
+      { error: "decision must be accept or reject." },
+      { status: 400 }
+    );
+  }
+
+  const result = resolveAppeal({ appeal_id, decision, mod_note });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  const { appeal } = result;
+  return NextResponse.json({
+    appeal_id: appeal.appeal_id,
+    status: appeal.status,
+    mod_note: appeal.mod_note,
+    resolved_at: appeal.resolved_at,
+  });
+}

--- a/app/api/routes-f/ban-appeals/route.ts
+++ b/app/api/routes-f/ban-appeals/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAppeal, listPendingAppeals } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creator_id = req.nextUrl.searchParams.get("creator_id")?.trim();
+
+  if (!creator_id) {
+    return NextResponse.json(
+      { error: "creator_id query parameter is required." },
+      { status: 400 }
+    );
+  }
+
+  const appeals = listPendingAppeals(creator_id);
+  return NextResponse.json({ appeals });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: {
+    creator_id?: unknown;
+    viewer_id?: unknown;
+    message?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const creator_id =
+    typeof body.creator_id === "string" ? body.creator_id : "";
+  const viewer_id = typeof body.viewer_id === "string" ? body.viewer_id : "";
+  const message = typeof body.message === "string" ? body.message : "";
+
+  const result = createAppeal({ creator_id, viewer_id, message });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.result, { status: 201 });
+}

--- a/app/api/routes-f/ban-appeals/store.ts
+++ b/app/api/routes-f/ban-appeals/store.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "crypto";
+import type {
+  BanAppeal,
+  CreateAppealInput,
+  CreateAppealResult,
+  PendingAppealSummary,
+  ResolveAppealInput,
+} from "./types";
+
+const appeals = new Map<string, BanAppeal>();
+
+export function createAppeal(
+  input: CreateAppealInput
+): { ok: true; result: CreateAppealResult } | { ok: false; error: string; status: number } {
+  const creator_id = input.creator_id.trim();
+  const viewer_id = input.viewer_id.trim();
+  const message = input.message.trim();
+
+  if (!creator_id || !viewer_id || !message) {
+    return {
+      ok: false,
+      error: "creator_id, viewer_id, and message are required.",
+      status: 400,
+    };
+  }
+
+  if (creator_id === viewer_id) {
+    return {
+      ok: false,
+      error: "A creator cannot submit an appeal against their own channel.",
+      status: 400,
+    };
+  }
+
+  const existingPending = Array.from(appeals.values()).find(
+    (a) =>
+      a.creator_id === creator_id &&
+      a.viewer_id === viewer_id &&
+      a.status === "pending"
+  );
+
+  if (existingPending) {
+    return {
+      ok: false,
+      error: "A pending appeal already exists for this viewer on this channel.",
+      status: 409,
+    };
+  }
+
+  const appeal_id = randomUUID();
+  const record: BanAppeal = {
+    appeal_id,
+    creator_id,
+    viewer_id,
+    message,
+    status: "pending",
+    mod_note: null,
+    created_at: new Date().toISOString(),
+    resolved_at: null,
+  };
+
+  appeals.set(appeal_id, record);
+
+  return {
+    ok: true,
+    result: { appeal_id, status: "pending" },
+  };
+}
+
+export function listPendingAppeals(creator_id: string): PendingAppealSummary[] {
+  return Array.from(appeals.values())
+    .filter((a) => a.creator_id === creator_id && a.status === "pending")
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .map(({ appeal_id, viewer_id, message, status, created_at }) => ({
+      appeal_id,
+      viewer_id,
+      message,
+      status,
+      created_at,
+    }));
+}
+
+export function resolveAppeal(
+  input: ResolveAppealInput
+): { ok: true; appeal: BanAppeal } | { ok: false; error: string; status: number } {
+  const appeal = appeals.get(input.appeal_id);
+
+  if (!appeal) {
+    return { ok: false, error: "Appeal not found.", status: 404 };
+  }
+
+  if (appeal.status !== "pending") {
+    return {
+      ok: false,
+      error: `Appeal has already been ${appeal.status}.`,
+      status: 409,
+    };
+  }
+
+  const status = input.decision === "accept" ? "accepted" : "rejected";
+  const updated: BanAppeal = {
+    ...appeal,
+    status,
+    mod_note: input.mod_note?.trim() || null,
+    resolved_at: new Date().toISOString(),
+  };
+
+  appeals.set(input.appeal_id, updated);
+  return { ok: true, appeal: updated };
+}
+
+export function __resetBanAppealsStore(): void {
+  appeals.clear();
+}

--- a/app/api/routes-f/ban-appeals/types.ts
+++ b/app/api/routes-f/ban-appeals/types.ts
@@ -1,0 +1,39 @@
+export type AppealStatus = "pending" | "accepted" | "rejected";
+
+export type AppealDecision = "accept" | "reject";
+
+export interface BanAppeal {
+  appeal_id: string;
+  creator_id: string;
+  viewer_id: string;
+  message: string;
+  status: AppealStatus;
+  mod_note: string | null;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export interface CreateAppealInput {
+  creator_id: string;
+  viewer_id: string;
+  message: string;
+}
+
+export interface CreateAppealResult {
+  appeal_id: string;
+  status: "pending";
+}
+
+export interface ResolveAppealInput {
+  appeal_id: string;
+  decision: AppealDecision;
+  mod_note?: string;
+}
+
+export interface PendingAppealSummary {
+  appeal_id: string;
+  viewer_id: string;
+  message: string;
+  status: "pending";
+  created_at: string;
+}

--- a/app/api/routes-f/ban-sync/__tests__/route.test.ts
+++ b/app/api/routes-f/ban-sync/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { POST as POSTUnsubscribe } from "../unsubscribe/route";
+import {
+  __resetBanSyncStore,
+  __seedChannelBan,
+  getBanSyncStatus,
+  isViewerBannedOnChannel,
+} from "../store";
+
+const BASE = "http://localhost/api/routes-f/ban-sync";
+const UNSUB = `${BASE}/unsubscribe`;
+
+function req(method: string, url: string, body?: object): NextRequest {
+  return new NextRequest(url, {
+    method,
+    ...(body
+      ? {
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+        }
+      : {}),
+  });
+}
+
+beforeEach(() => {
+  __resetBanSyncStore();
+});
+
+describe("Ban sync subscriptions", () => {
+  it("subscribes target to source bans with bidirectional status", async () => {
+    const res = await POST(
+      req("POST", BASE, {
+        source_creator_id: "creator-alpha",
+        target_creator_id: "creator-beta",
+      })
+    );
+    expect(res.status).toBe(201);
+
+    const targetStatus = await GET(
+      req("GET", `${BASE}?creator_id=creator-beta`)
+    );
+    expect((await targetStatus.json()).subscribed_to).toEqual(["creator-alpha"]);
+
+    const sourceStatus = await GET(
+      req("GET", `${BASE}?creator_id=creator-alpha`)
+    );
+    expect((await sourceStatus.json()).subscribed_by).toEqual(["creator-beta"]);
+  });
+
+  it("copies existing bans when copy_existing is true", async () => {
+    __seedChannelBan("creator-src", "viewer-toxic");
+    __seedChannelBan("creator-src", "viewer-spam");
+
+    await POST(
+      req("POST", BASE, {
+        source_creator_id: "creator-src",
+        target_creator_id: "creator-dst",
+        copy_existing: true,
+      })
+    );
+
+    expect(isViewerBannedOnChannel("creator-dst", "viewer-toxic")).toBe(true);
+    expect(isViewerBannedOnChannel("creator-dst", "viewer-spam")).toBe(true);
+    expect(isViewerBannedOnChannel("creator-dst", "viewer-other")).toBe(false);
+  });
+
+  it("inherits new source bans after subscription without copy_existing", async () => {
+    await POST(
+      req("POST", BASE, {
+        source_creator_id: "creator-src",
+        target_creator_id: "creator-dst",
+      })
+    );
+
+    expect(isViewerBannedOnChannel("creator-dst", "viewer-new")).toBe(false);
+
+    __seedChannelBan("creator-src", "viewer-new");
+    expect(isViewerBannedOnChannel("creator-dst", "viewer-new")).toBe(true);
+  });
+
+  it("unsubscribes and clears bidirectional links", async () => {
+    await POST(
+      req("POST", BASE, {
+        source_creator_id: "creator-a",
+        target_creator_id: "creator-b",
+      })
+    );
+
+    const unsubRes = await POSTUnsubscribe(
+      req("POST", UNSUB, {
+        source_creator_id: "creator-a",
+        target_creator_id: "creator-b",
+      })
+    );
+    expect(unsubRes.status).toBe(200);
+
+    expect(getBanSyncStatus("creator-b").subscribed_to).toEqual([]);
+    expect(getBanSyncStatus("creator-a").subscribed_by).toEqual([]);
+  });
+
+  it("returns 404 when unsubscribing a non-existent link", async () => {
+    const res = await POSTUnsubscribe(
+      req("POST", UNSUB, {
+        source_creator_id: "ghost-src",
+        target_creator_id: "ghost-dst",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 for duplicate subscription", async () => {
+    const body = {
+      source_creator_id: "creator-x",
+      target_creator_id: "creator-y",
+    };
+    await POST(req("POST", BASE, body));
+    const dup = await POST(req("POST", BASE, body));
+    expect(dup.status).toBe(409);
+  });
+
+  it("returns 400 when creator_id is missing on GET", async () => {
+    const res = await GET(req("GET", BASE));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/ban-sync/route.ts
+++ b/app/api/routes-f/ban-sync/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBanSyncStatus, subscribeToBans } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creator_id = req.nextUrl.searchParams.get("creator_id")?.trim();
+
+  if (!creator_id) {
+    return NextResponse.json(
+      { error: "creator_id query parameter is required." },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(getBanSyncStatus(creator_id));
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: {
+    source_creator_id?: unknown;
+    target_creator_id?: unknown;
+    copy_existing?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const source_creator_id =
+    typeof body.source_creator_id === "string" ? body.source_creator_id : "";
+  const target_creator_id =
+    typeof body.target_creator_id === "string" ? body.target_creator_id : "";
+  const copy_existing = body.copy_existing === true;
+
+  const result = subscribeToBans({
+    source_creator_id,
+    target_creator_id,
+    copy_existing,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(
+    getBanSyncStatus(target_creator_id),
+    { status: 201 }
+  );
+}

--- a/app/api/routes-f/ban-sync/store.ts
+++ b/app/api/routes-f/ban-sync/store.ts
@@ -1,0 +1,174 @@
+import type {
+  BanSyncStatus,
+  ChannelBan,
+  SubscribeInput,
+  UnsubscribeInput,
+} from "./types";
+
+// creator_id -> set of banned viewer_ids
+const channelBans = new Map<string, Map<string, ChannelBan>>();
+
+// target -> sources they subscribe to
+const subscribedTo = new Map<string, Set<string>>();
+
+// source -> targets subscribed to them
+const subscribedBy = new Map<string, Set<string>>();
+
+export function addChannelBan(creator_id: string, viewer_id: string): ChannelBan {
+  let bans = channelBans.get(creator_id);
+  if (!bans) {
+    bans = new Map();
+    channelBans.set(creator_id, bans);
+  }
+
+  const existing = bans.get(viewer_id);
+  if (existing) {
+    return existing;
+  }
+
+  const record: ChannelBan = {
+    creator_id,
+    viewer_id,
+    banned_at: new Date().toISOString(),
+  };
+  bans.set(viewer_id, record);
+  return record;
+}
+
+export function subscribeToBans(
+  input: SubscribeInput
+): { ok: true } | { ok: false; error: string; status: number } {
+  const source = input.source_creator_id.trim();
+  const target = input.target_creator_id.trim();
+
+  if (!source || !target) {
+    return {
+      ok: false,
+      error: "source_creator_id and target_creator_id are required.",
+      status: 400,
+    };
+  }
+
+  if (source === target) {
+    return {
+      ok: false,
+      error: "A creator cannot subscribe to their own ban list.",
+      status: 400,
+    };
+  }
+
+  let toSet = subscribedTo.get(target);
+  if (!toSet) {
+    toSet = new Set();
+    subscribedTo.set(target, toSet);
+  }
+
+  if (toSet.has(source)) {
+    return {
+      ok: false,
+      error: "Target creator is already subscribed to this source ban list.",
+      status: 409,
+    };
+  }
+
+  toSet.add(source);
+
+  let bySet = subscribedBy.get(source);
+  if (!bySet) {
+    bySet = new Set();
+    subscribedBy.set(source, bySet);
+  }
+  bySet.add(target);
+
+  if (input.copy_existing) {
+    const sourceBans = channelBans.get(source);
+    if (sourceBans) {
+      for (const ban of sourceBans.values()) {
+        addChannelBan(target, ban.viewer_id);
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+export function unsubscribeFromBans(
+  input: UnsubscribeInput
+): { ok: true } | { ok: false; error: string; status: number } {
+  const source = input.source_creator_id.trim();
+  const target = input.target_creator_id.trim();
+
+  if (!source || !target) {
+    return {
+      ok: false,
+      error: "source_creator_id and target_creator_id are required.",
+      status: 400,
+    };
+  }
+
+  const toSet = subscribedTo.get(target);
+  if (!toSet?.has(source)) {
+    return {
+      ok: false,
+      error: "Subscription not found.",
+      status: 404,
+    };
+  }
+
+  toSet.delete(source);
+  if (toSet.size === 0) {
+    subscribedTo.delete(target);
+  }
+
+  const bySet = subscribedBy.get(source);
+  bySet?.delete(target);
+  if (bySet && bySet.size === 0) {
+    subscribedBy.delete(source);
+  }
+
+  return { ok: true };
+}
+
+export function getBanSyncStatus(creator_id: string): BanSyncStatus {
+  const to = subscribedTo.get(creator_id);
+  const by = subscribedBy.get(creator_id);
+
+  return {
+    subscribed_to: to ? Array.from(to).sort() : [],
+    subscribed_by: by ? Array.from(by).sort() : [],
+  };
+}
+
+export function isViewerBannedOnChannel(
+  creator_id: string,
+  viewer_id: string
+): boolean {
+  const ownBans = channelBans.get(creator_id);
+  if (ownBans?.has(viewer_id)) {
+    return true;
+  }
+
+  const sources = subscribedTo.get(creator_id);
+  if (!sources) {
+    return false;
+  }
+
+  for (const sourceId of sources) {
+    const sourceBans = channelBans.get(sourceId);
+    if (sourceBans?.has(viewer_id)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function __resetBanSyncStore(): void {
+  channelBans.clear();
+  subscribedTo.clear();
+  subscribedBy.clear();
+}
+
+export function __seedChannelBan(creator_id: string, viewer_id: string): void {
+  addChannelBan(creator_id, viewer_id);
+}

--- a/app/api/routes-f/ban-sync/types.ts
+++ b/app/api/routes-f/ban-sync/types.ts
@@ -1,0 +1,27 @@
+export interface BanSyncSubscription {
+  source_creator_id: string;
+  target_creator_id: string;
+  created_at: string;
+}
+
+export interface SubscribeInput {
+  source_creator_id: string;
+  target_creator_id: string;
+  copy_existing?: boolean;
+}
+
+export interface UnsubscribeInput {
+  source_creator_id: string;
+  target_creator_id: string;
+}
+
+export interface BanSyncStatus {
+  subscribed_to: string[];
+  subscribed_by: string[];
+}
+
+export interface ChannelBan {
+  creator_id: string;
+  viewer_id: string;
+  banned_at: string;
+}

--- a/app/api/routes-f/ban-sync/unsubscribe/route.ts
+++ b/app/api/routes-f/ban-sync/unsubscribe/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBanSyncStatus, unsubscribeFromBans } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: {
+    source_creator_id?: unknown;
+    target_creator_id?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const source_creator_id =
+    typeof body.source_creator_id === "string" ? body.source_creator_id : "";
+  const target_creator_id =
+    typeof body.target_creator_id === "string" ? body.target_creator_id : "";
+
+  const result = unsubscribeFromBans({
+    source_creator_id,
+    target_creator_id,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(getBanSyncStatus(target_creator_id));
+}

--- a/app/api/routes-f/follows/route.ts
+++ b/app/api/routes-f/follows/route.ts
@@ -3,6 +3,7 @@ import { sql } from "@vercel/postgres";
 import { z } from "zod";
 import { verifySession } from "@/lib/auth/verify-session";
 import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { insertActivityEvent } from "@/app/api/routes-f/activity/_lib/insert";
 
 const createFollowSchema = z.object({
   creator_id: z.string().uuid(),
@@ -151,6 +152,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         { error: "Already following creator" },
         { status: 409 }
       );
+    }
+
+    try {
+      await insertActivityEvent({
+        userId: creator_id,
+        type: "new_follower",
+        actorId: session.userId,
+        metadata: { source: "routes-f/follows" },
+      });
+    } catch (activityErr) {
+      console.error("[follows] activity event insert failed:", activityErr);
     }
 
     const followerCount = await getFollowerCount(creator_id);

--- a/app/api/routes-f/streams/start/route.ts
+++ b/app/api/routes-f/streams/start/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "@vercel/postgres";
+import { verifySession } from "@/lib/auth/verify-session";
+import { insertActivityEvent } from "@/app/api/routes-f/activity/_lib/insert";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Practice implementation of stream go-live for routes-f.
+ * Inserts a stream_started activity event for the authenticated creator.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  let body: { stream_title?: unknown; peak_viewers?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const stream_title =
+    typeof body.stream_title === "string" && body.stream_title.trim()
+      ? body.stream_title.trim()
+      : "Untitled Stream";
+  const peak_viewers =
+    typeof body.peak_viewers === "number" && body.peak_viewers >= 0
+      ? body.peak_viewers
+      : 0;
+
+  try {
+    const { rows } = await sql<{ username: string }>`
+      SELECT username FROM users WHERE id = ${session.userId} LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const { id: event_id } = await insertActivityEvent({
+      userId: session.userId,
+      type: "stream_started",
+      actorId: session.userId,
+      metadata: {
+        stream_title,
+        peak_viewers,
+        username: rows[0].username,
+      },
+    });
+
+    return NextResponse.json(
+      { event_id, type: "stream_started", stream_title },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f streams/start POST]", error);
+    return NextResponse.json(
+      { error: "Failed to start stream activity" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/routes-f/tips/payment/route.ts
+++ b/app/api/routes-f/tips/payment/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifySession } from "@/lib/auth/verify-session";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { z } from "zod";
+import { insertActivityEvent } from "@/app/api/routes-f/activity/_lib/insert";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const paymentSchema = z.object({
+  creator_id: z.string().uuid(),
+  amount: z.string().min(1),
+  currency: z.enum(["XLM", "USDC"]),
+  tx_hash: z.string().min(1),
+});
+
+/**
+ * Practice tip payment route — records tip_received + tip_sent activity events.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await verifySession(req);
+  if (!session.ok) {
+    return session.response;
+  }
+
+  const bodyResult = await validateBody(req, paymentSchema);
+  if (bodyResult instanceof NextResponse) {
+    return bodyResult;
+  }
+
+  const { creator_id, amount, currency, tx_hash } = bodyResult.data;
+
+  if (creator_id === session.userId) {
+    return NextResponse.json(
+      { error: "Cannot tip yourself" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const metadata = { amount, currency, tx_hash };
+
+    const [received, sent] = await Promise.all([
+      insertActivityEvent({
+        userId: creator_id,
+        type: "tip_received",
+        actorId: session.userId,
+        metadata,
+      }),
+      insertActivityEvent({
+        userId: session.userId,
+        type: "tip_sent",
+        actorId: creator_id,
+        metadata,
+      }),
+    ]);
+
+    return NextResponse.json(
+      {
+        tip_received_event_id: received.id,
+        tip_sent_event_id: sent.id,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[routes-f tips/payment POST]", error);
+    return NextResponse.json(
+      { error: "Failed to record tip activity" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds three scoped `routes-f` practice implementations:

- **#1044 — Channel ban appeals:** viewers submit appeals; creators list pending appeals and resolve with accept/reject.
- **#1045 — Ban list sync:** cooperating creators subscribe/unsubscribe to share ban lists, with optional copy of existing bans and bidirectional status.
- **#390 — Activity feed:** cursor-paginated activity events with type filters, daily summary endpoint, Postgres `activity_events` table, and upstream side-effect wiring in routes-f.

## Changes

### #1044 — `app/api/routes-f/ban-appeals/`
- `POST /api/routes-f/ban-appeals` — `{ creator_id, viewer_id, message }` → `{ appeal_id, status: pending }`
- `GET /api/routes-f/ban-appeals?creator_id=` — pending appeals for a creator
- `POST /api/routes-f/ban-appeals/resolve` — `{ appeal_id, decision: accept|reject, mod_note? }`
- In-memory store + lifecycle tests

### #1045 — `app/api/routes-f/ban-sync/`
- `POST /api/routes-f/ban-sync` — `{ source_creator_id, target_creator_id, copy_existing? }`
- `POST /api/routes-f/ban-sync/unsubscribe` — remove subscription link
- `GET /api/routes-f/ban-sync?creator_id=` — `{ subscribed_to, subscribed_by }`
- In-memory store + bidirectional/unsubscribe tests

### #390 — `app/api/routes-f/activity/`
- `GET /api/routes-f/activity?limit=&cursor=&type=all|tips|follows|streams|gifts` — session-authenticated, own-activity-only feed
- `GET /api/routes-f/activity/daily?date=YYYY-MM-DD` — daily aggregates (tips received, followers gained, stream duration, peak viewers)
- `activity_events` table via `ensureActivityEventsTable()`
- Shared `insertActivityEvent` helper

**Upstream side effects (routes-f):**
- `follows/route.ts` → inserts `new_follower`
- `streams/start/route.ts` → inserts `stream_started`
- `tips/payment/route.ts` → inserts `tip_received` + `tip_sent`

## Test plan

- [ ] `npm test -- app/api/routes-f/ban-appeals app/api/routes-f/ban-sync app/api/routes-f/activity --no-coverage`
- [ ] Verify ban appeal lifecycle: submit → list pending → resolve accept/reject
- [ ] Verify ban sync bidirectional links and unsubscribe
- [ ] Verify activity feed auth, pagination, type filters, empty state, and daily summary
- [ ] Verify upstream routes emit expected activity events

Closes #390
Closes #1044
Closes #1045

Made with [Cursor](https://cursor.com)