### PR TITLE
feat(routes-f): viewer peaks, camera angles, chat velocity, creator export (#1022, #1025, #1028, #1032)

### DIFF
--- a/app/api/routes-f/camera-angles/__tests__/route.test.ts
+++ b/app/api/routes-f/camera-angles/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { getViewerAngle, resetStore } from "../store";
+
+function getReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/camera-angles${query}`
+  );
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/camera-angles", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+});
+
+describe("GET /api/routes-f/camera-angles", () => {
+  it("requires stream_id", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown stream", async () => {
+    const res = await GET(getReq("?stream_id=nope"));
+    expect(res.status).toBe(404);
+  });
+
+  it("lists angles for a multi-angle stream", async () => {
+    const res = await GET(getReq("?stream_id=stream_multi_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.angles).toHaveLength(3);
+    expect(body.angles[0]).toMatchObject({
+      id: expect.any(String),
+      label: expect.any(String),
+      playback_id: expect.any(String),
+    });
+    expect(body.angles.map((a: { id: string }) => a.id)).toEqual([
+      "main",
+      "caster",
+      "map",
+    ]);
+  });
+});
+
+describe("POST /api/routes-f/camera-angles", () => {
+  it("requires viewer_id, stream_id, and angle_id", async () => {
+    const res = await POST(postReq({ stream_id: "stream_multi_1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown stream", async () => {
+    const res = await POST(
+      postReq({
+        viewer_id: "v1",
+        stream_id: "nope",
+        angle_id: "main",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an unknown angle", async () => {
+    const res = await POST(
+      postReq({
+        viewer_id: "v1",
+        stream_id: "stream_multi_1",
+        angle_id: "backstage",
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("angle_id");
+  });
+
+  it("stores the viewer's angle selection", async () => {
+    const res = await POST(
+      postReq({
+        viewer_id: "v1",
+        stream_id: "stream_multi_1",
+        angle_id: "caster",
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      viewer_id: "v1",
+      stream_id: "stream_multi_1",
+      angle_id: "caster",
+    });
+    expect(getViewerAngle("v1", "stream_multi_1")?.angle_id).toBe("caster");
+  });
+
+  it("overwrites a previous selection for the same viewer+stream", async () => {
+    await POST(
+      postReq({
+        viewer_id: "v2",
+        stream_id: "stream_multi_2",
+        angle_id: "stage",
+      })
+    );
+    await POST(
+      postReq({
+        viewer_id: "v2",
+        stream_id: "stream_multi_2",
+        angle_id: "crowd",
+      })
+    );
+    expect(getViewerAngle("v2", "stream_multi_2")?.angle_id).toBe("crowd");
+  });
+});

--- a/app/api/routes-f/camera-angles/route.ts
+++ b/app/api/routes-f/camera-angles/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { findAngle, getStreamById } from "./seed";
+import { setViewerAngle } from "./store";
+import type {
+  AnglesListResponse,
+  SelectAngleBody,
+  SelectAngleResponse,
+} from "./types";
+
+/**
+ * GET /api/routes-f/camera-angles?stream_id=stream_multi_1
+ *
+ * Lists available camera angles for a multi-angle stream.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const stream = getStreamById(streamId);
+  if (!stream) {
+    return NextResponse.json(
+      { error: `unknown stream_id: ${streamId}` },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    angles: stream.angles,
+  } satisfies AnglesListResponse);
+}
+
+/**
+ * POST /api/routes-f/camera-angles
+ * Body: { viewer_id, stream_id, angle_id }
+ *
+ * Stores the viewer's selected camera angle for a stream.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: SelectAngleBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, stream_id, angle_id } = body;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+  if (!angle_id || typeof angle_id !== "string") {
+    return NextResponse.json(
+      { error: "angle_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const match = findAngle(stream_id, angle_id);
+  if (!match) {
+    const stream = getStreamById(stream_id);
+    if (!stream) {
+      return NextResponse.json(
+        { error: `unknown stream_id: ${stream_id}` },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json(
+      { error: `unknown angle_id: ${angle_id}` },
+      { status: 400 }
+    );
+  }
+
+  setViewerAngle(viewer_id, stream_id, angle_id);
+
+  return NextResponse.json({
+    viewer_id,
+    stream_id,
+    angle_id,
+  } satisfies SelectAngleResponse);
+}

--- a/app/api/routes-f/camera-angles/seed.ts
+++ b/app/api/routes-f/camera-angles/seed.ts
@@ -1,0 +1,46 @@
+import type { MultiAngleStream } from "./types";
+
+/** Seed streams that broadcast from multiple Mux camera angles. */
+export function getMultiAngleStreams(): MultiAngleStream[] {
+  return [
+    {
+      stream_id: "stream_multi_1",
+      title: "Esports Finals — Multi-Cam",
+      angles: [
+        { id: "main", label: "Main Stage", playback_id: "mux_playback_main_01" },
+        { id: "caster", label: "Caster Desk", playback_id: "mux_playback_caster_01" },
+        { id: "map", label: "Map Overview", playback_id: "mux_playback_map_01" },
+      ],
+    },
+    {
+      stream_id: "stream_multi_2",
+      title: "Music Festival Live",
+      angles: [
+        { id: "stage", label: "Main Stage", playback_id: "mux_playback_stage_02" },
+        { id: "crowd", label: "Crowd Cam", playback_id: "mux_playback_crowd_02" },
+      ],
+    },
+    {
+      stream_id: "stream_single_1",
+      title: "Solo Creator Stream",
+      angles: [
+        { id: "primary", label: "Primary", playback_id: "mux_playback_solo_01" },
+      ],
+    },
+  ];
+}
+
+export function getStreamById(streamId: string): MultiAngleStream | undefined {
+  return getMultiAngleStreams().find(s => s.stream_id === streamId);
+}
+
+export function findAngle(
+  streamId: string,
+  angleId: string
+): { stream: MultiAngleStream; angle: MultiAngleStream["angles"][number] } | undefined {
+  const stream = getStreamById(streamId);
+  if (!stream) return undefined;
+  const angle = stream.angles.find(a => a.id === angleId);
+  if (!angle) return undefined;
+  return { stream, angle };
+}

--- a/app/api/routes-f/camera-angles/store.ts
+++ b/app/api/routes-f/camera-angles/store.ts
@@ -1,0 +1,34 @@
+import type { ViewerAngleSelection } from "./types";
+
+const selections = new Map<string, ViewerAngleSelection>();
+
+function selectionKey(viewerId: string, streamId: string): string {
+  return `${viewerId}:${streamId}`;
+}
+
+export function setViewerAngle(
+  viewerId: string,
+  streamId: string,
+  angleId: string,
+  now: number = Date.now()
+): ViewerAngleSelection {
+  const record: ViewerAngleSelection = {
+    viewer_id: viewerId,
+    stream_id: streamId,
+    angle_id: angleId,
+    selected_at: new Date(now).toISOString(),
+  };
+  selections.set(selectionKey(viewerId, streamId), record);
+  return record;
+}
+
+export function getViewerAngle(
+  viewerId: string,
+  streamId: string
+): ViewerAngleSelection | undefined {
+  return selections.get(selectionKey(viewerId, streamId));
+}
+
+export function resetStore(): void {
+  selections.clear();
+}

--- a/app/api/routes-f/camera-angles/types.ts
+++ b/app/api/routes-f/camera-angles/types.ts
@@ -1,0 +1,34 @@
+export interface CameraAngle {
+  id: string;
+  label: string;
+  playback_id: string;
+}
+
+export interface MultiAngleStream {
+  stream_id: string;
+  title: string;
+  angles: CameraAngle[];
+}
+
+export interface AnglesListResponse {
+  angles: CameraAngle[];
+}
+
+export interface SelectAngleBody {
+  viewer_id: string;
+  stream_id: string;
+  angle_id: string;
+}
+
+export interface SelectAngleResponse {
+  viewer_id: string;
+  stream_id: string;
+  angle_id: string;
+}
+
+export interface ViewerAngleSelection {
+  viewer_id: string;
+  stream_id: string;
+  angle_id: string;
+  selected_at: string;
+}

--- a/app/api/routes-f/chat-velocity/__tests__/route.test.ts
+++ b/app/api/routes-f/chat-velocity/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { bucketByMinute, computeVelocity, findPeakMinute } from "../velocity";
+import { getChatStream } from "../seed";
+
+function makeReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/chat-velocity${query}`
+  );
+}
+
+describe("bucketByMinute", () => {
+  it("groups events into minute buckets", () => {
+    const stream = getChatStream("stream_chat_1")!;
+    const series = bucketByMinute(stream.events);
+    expect(series[0]).toEqual({ minute_offset: 0, messages: 4 });
+    expect(series[1]).toEqual({ minute_offset: 1, messages: 5 });
+    expect(series[2]).toEqual({ minute_offset: 2, messages: 3 });
+    expect(series[3]).toEqual({ minute_offset: 3, messages: 2 });
+    expect(series[4]).toEqual({ minute_offset: 4, messages: 1 });
+  });
+
+  it("returns an empty series for no events", () => {
+    expect(bucketByMinute([])).toEqual([]);
+  });
+});
+
+describe("findPeakMinute", () => {
+  it("returns the minute with the highest message count", () => {
+    const stream = getChatStream("stream_chat_1")!;
+    const series = bucketByMinute(stream.events);
+    expect(findPeakMinute(series)).toBe(1);
+  });
+});
+
+describe("computeVelocity", () => {
+  it("computes series, peak_minute, and total_messages", () => {
+    const stream = getChatStream("stream_chat_1")!;
+    const result = computeVelocity(stream.events);
+    expect(result.total_messages).toBe(15);
+    expect(result.peak_minute).toBe(1);
+    expect(result.series.reduce((sum, p) => sum + p.messages, 0)).toBe(15);
+  });
+});
+
+describe("GET /api/routes-f/chat-velocity", () => {
+  it("requires stream_id", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown stream", async () => {
+    const res = await GET(makeReq("?stream_id=nope"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns velocity series for a stream", async () => {
+    const res = await GET(makeReq("?stream_id=stream_chat_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_messages).toBe(15);
+    expect(body.peak_minute).toBe(1);
+    expect(body.series[1].messages).toBe(5);
+  });
+
+  it("handles a stream with no chat", async () => {
+    const res = await GET(makeReq("?stream_id=stream_chat_empty"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_messages).toBe(0);
+    expect(body.series).toEqual([]);
+    expect(body.peak_minute).toBe(0);
+  });
+});

--- a/app/api/routes-f/chat-velocity/route.ts
+++ b/app/api/routes-f/chat-velocity/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getChatStream } from "./seed";
+import { computeVelocity } from "./velocity";
+import type { ChatVelocityResponse } from "./types";
+
+/**
+ * GET /api/routes-f/chat-velocity?stream_id=stream_chat_1
+ *
+ * Computes chat messages per minute for a stream, including peak minute.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const streamId = req.nextUrl.searchParams.get("stream_id");
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const stream = getChatStream(streamId);
+  if (!stream) {
+    return NextResponse.json(
+      { error: `unknown stream_id: ${streamId}` },
+      { status: 404 }
+    );
+  }
+
+  const result = computeVelocity(stream.events);
+  return NextResponse.json(result satisfies ChatVelocityResponse);
+}

--- a/app/api/routes-f/chat-velocity/seed.ts
+++ b/app/api/routes-f/chat-velocity/seed.ts
@@ -1,0 +1,46 @@
+import type { ChatStream } from "./types";
+
+/** Seed timestamped chat events for velocity analysis. */
+export function getChatStreams(): ChatStream[] {
+  return [
+    {
+      stream_id: "stream_chat_1",
+      title: "Morning Crypto Chat",
+      events: [
+        { message_id: "m1", offset_seconds: 5 },
+        { message_id: "m2", offset_seconds: 12 },
+        { message_id: "m3", offset_seconds: 45 },
+        { message_id: "m4", offset_seconds: 58 },
+        { message_id: "m5", offset_seconds: 62 },
+        { message_id: "m6", offset_seconds: 75 },
+        { message_id: "m7", offset_seconds: 90 },
+        { message_id: "m8", offset_seconds: 95 },
+        { message_id: "m9", offset_seconds: 110 },
+        { message_id: "m10", offset_seconds: 125 },
+        { message_id: "m11", offset_seconds: 130 },
+        { message_id: "m12", offset_seconds: 145 },
+        { message_id: "m13", offset_seconds: 180 },
+        { message_id: "m14", offset_seconds: 185 },
+        { message_id: "m15", offset_seconds: 240 },
+      ],
+    },
+    {
+      stream_id: "stream_chat_2",
+      title: "Quiet VOD Replay",
+      events: [
+        { message_id: "q1", offset_seconds: 10 },
+        { message_id: "q2", offset_seconds: 70 },
+        { message_id: "q3", offset_seconds: 130 },
+      ],
+    },
+    {
+      stream_id: "stream_chat_empty",
+      title: "Silent Stream",
+      events: [],
+    },
+  ];
+}
+
+export function getChatStream(streamId: string): ChatStream | undefined {
+  return getChatStreams().find(s => s.stream_id === streamId);
+}

--- a/app/api/routes-f/chat-velocity/types.ts
+++ b/app/api/routes-f/chat-velocity/types.ts
@@ -1,0 +1,22 @@
+export interface ChatEvent {
+  message_id: string;
+  /** Seconds after the stream started. */
+  offset_seconds: number;
+}
+
+export interface ChatStream {
+  stream_id: string;
+  title: string;
+  events: ChatEvent[];
+}
+
+export interface MinuteSeriesPoint {
+  minute_offset: number;
+  messages: number;
+}
+
+export interface ChatVelocityResponse {
+  series: MinuteSeriesPoint[];
+  peak_minute: number;
+  total_messages: number;
+}

--- a/app/api/routes-f/chat-velocity/velocity.ts
+++ b/app/api/routes-f/chat-velocity/velocity.ts
@@ -1,0 +1,53 @@
+import type { ChatEvent, ChatVelocityResponse, MinuteSeriesPoint } from "./types";
+
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Bucket chat events into per-minute counts. minute_offset 0 covers [0, 60s),
+ * minute_offset 1 covers [60, 120s), and so on.
+ */
+export function bucketByMinute(events: ChatEvent[]): MinuteSeriesPoint[] {
+  if (events.length === 0) {
+    return [];
+  }
+
+  const counts = new Map<number, number>();
+  for (const event of events) {
+    const minute = Math.floor(event.offset_seconds / SECONDS_PER_MINUTE);
+    counts.set(minute, (counts.get(minute) ?? 0) + 1);
+  }
+
+  const maxMinute = Math.max(...counts.keys());
+  const series: MinuteSeriesPoint[] = [];
+  for (let minute = 0; minute <= maxMinute; minute++) {
+    series.push({
+      minute_offset: minute,
+      messages: counts.get(minute) ?? 0,
+    });
+  }
+  return series;
+}
+
+export function findPeakMinute(series: MinuteSeriesPoint[]): number {
+  if (series.length === 0) {
+    return 0;
+  }
+  let peakMinute = series[0].minute_offset;
+  let peakCount = series[0].messages;
+  for (const point of series) {
+    if (point.messages > peakCount) {
+      peakCount = point.messages;
+      peakMinute = point.minute_offset;
+    }
+  }
+  return peakMinute;
+}
+
+export function computeVelocity(events: ChatEvent[]): ChatVelocityResponse {
+  const series = bucketByMinute(events);
+  return {
+    series,
+    peak_minute: findPeakMinute(series),
+    total_messages: events.length,
+  };
+}

--- a/app/api/routes-f/creator-export/__tests__/route.test.ts
+++ b/app/api/routes-f/creator-export/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { getExport, resetStore, setCompletionDelayMs } from "../store";
+
+function getReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/creator-export${query}`
+  );
+}
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/creator-export", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+  jest.useRealTimers();
+});
+
+describe("POST /api/routes-f/creator-export", () => {
+  it("requires creator_id", async () => {
+    const res = await POST(postReq({ sections: ["streams"] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("requires valid sections", async () => {
+    const res = await POST(
+      postReq({ creator_id: "creator_a", sections: ["bad"] })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("invalid section");
+  });
+
+  it("enqueues an export with queued status", async () => {
+    const res = await POST(
+      postReq({
+        creator_id: "creator_a",
+        sections: ["streams", "tips"],
+      })
+    );
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.status).toBe("queued");
+    expect(typeof body.export_id).toBe("string");
+    expect(getExport(body.export_id)?.status).toBe("queued");
+  });
+});
+
+describe("GET /api/routes-f/creator-export", () => {
+  it("requires export_id", async () => {
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an unknown export", async () => {
+    const res = await GET(getReq("?export_id=exp_missing"));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("export lifecycle (queued -> ready)", () => {
+  it("transitions to ready after the synthetic delay", async () => {
+    jest.useFakeTimers();
+    setCompletionDelayMs(100);
+
+    const create = await POST(
+      postReq({
+        creator_id: "creator_a",
+        sections: ["followers", "subscribers"],
+      })
+    );
+    const { export_id } = await create.json();
+
+    const queued = await GET(getReq(`?export_id=${export_id}`));
+    expect((await queued.json()).status).toBe("queued");
+
+    jest.advanceTimersByTime(100);
+
+    const ready = await GET(getReq(`?export_id=${export_id}`));
+    const readyBody = await ready.json();
+    expect(readyBody.status).toBe("ready");
+    expect(readyBody.download_url).toContain(export_id);
+  });
+});

--- a/app/api/routes-f/creator-export/route.ts
+++ b/app/api/routes-f/creator-export/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { enqueueExport, getExport, isValidSection } from "./store";
+import type {
+  CreateExportBody,
+  CreateExportResponse,
+  ExportSection,
+  ExportStatusResponse,
+} from "./types";
+import { EXPORT_SECTIONS } from "./types";
+
+function validateSections(
+  sections: unknown
+): { ok: true; sections: ExportSection[] } | { ok: false; error: string } {
+  if (!Array.isArray(sections) || sections.length === 0) {
+    return {
+      ok: false,
+      error: `sections must be a non-empty array of: ${EXPORT_SECTIONS.join("|")}`,
+    };
+  }
+
+  const normalized: ExportSection[] = [];
+  for (const section of sections) {
+    if (!isValidSection(section)) {
+      return {
+        ok: false,
+        error: `invalid section '${String(section)}'; must be one of: ${EXPORT_SECTIONS.join("|")}`,
+      };
+    }
+    if (!normalized.includes(section)) {
+      normalized.push(section);
+    }
+  }
+
+  return { ok: true, sections: normalized };
+}
+
+/**
+ * POST /api/routes-f/creator-export
+ * Body: { creator_id, sections: [streams|tips|followers|subscribers] }
+ *
+ * Enqueues a CSV export of a creator's analytics data.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: CreateExportBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, sections } = body;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const sectionResult = validateSections(sections);
+  if (!sectionResult.ok) {
+    return NextResponse.json({ error: sectionResult.error }, { status: 400 });
+  }
+
+  const job = enqueueExport(creator_id, sectionResult.sections);
+
+  return NextResponse.json(
+    {
+      export_id: job.export_id,
+      status: "queued",
+    } satisfies CreateExportResponse,
+    { status: 202 }
+  );
+}
+
+/**
+ * GET /api/routes-f/creator-export?export_id=exp_1
+ *
+ * Returns the current status of an export job.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const exportId = req.nextUrl.searchParams.get("export_id");
+  if (!exportId) {
+    return NextResponse.json(
+      { error: "export_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const job = getExport(exportId);
+  if (!job) {
+    return NextResponse.json(
+      { error: `unknown export_id: ${exportId}` },
+      { status: 404 }
+    );
+  }
+
+  const response: ExportStatusResponse = { status: job.status };
+  if (job.status === "ready" && job.download_url) {
+    response.download_url = job.download_url;
+  }
+  if (job.status === "failed" && job.error) {
+    response.error = job.error;
+  }
+
+  return NextResponse.json(response);
+}

--- a/app/api/routes-f/creator-export/store.ts
+++ b/app/api/routes-f/creator-export/store.ts
@@ -1,0 +1,92 @@
+import { EXPORT_SECTIONS, type ExportJob, type ExportSection } from "./types";
+
+const jobs = new Map<string, ExportJob>();
+let counter = 0;
+
+/** Synthetic processing delay before an export becomes ready (ms). */
+export let completionDelayMs = 50;
+
+const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function setCompletionDelayMs(ms: number): void {
+  completionDelayMs = ms;
+}
+
+function buildDownloadUrl(exportId: string): string {
+  return `/api/routes-f/creator-export/download/${exportId}.csv`;
+}
+
+function scheduleCompletion(exportId: string, now: number): void {
+  const existing = pendingTimers.get(exportId);
+  if (existing) {
+    clearTimeout(existing);
+  }
+
+  const timer = setTimeout(() => {
+    const job = jobs.get(exportId);
+    if (!job || job.status !== "queued") {
+      pendingTimers.delete(exportId);
+      return;
+    }
+    jobs.set(exportId, {
+      ...job,
+      status: "ready",
+      ready_at: new Date(now + completionDelayMs).toISOString(),
+      download_url: buildDownloadUrl(exportId),
+    });
+    pendingTimers.delete(exportId);
+  }, completionDelayMs);
+
+  pendingTimers.set(exportId, timer);
+}
+
+export function enqueueExport(
+  creatorId: string,
+  sections: ExportSection[],
+  now: number = Date.now()
+): ExportJob {
+  const exportId = `exp_${++counter}`;
+  const job: ExportJob = {
+    export_id: exportId,
+    creator_id: creatorId,
+    sections,
+    status: "queued",
+    created_at: new Date(now).toISOString(),
+  };
+  jobs.set(exportId, job);
+  scheduleCompletion(exportId, now);
+  return job;
+}
+
+export function getExport(exportId: string): ExportJob | undefined {
+  return jobs.get(exportId);
+}
+
+export function markFailed(exportId: string, error: string): boolean {
+  const job = jobs.get(exportId);
+  if (!job) return false;
+  jobs.set(exportId, { ...job, status: "failed", error });
+  const timer = pendingTimers.get(exportId);
+  if (timer) {
+    clearTimeout(timer);
+    pendingTimers.delete(exportId);
+  }
+  return true;
+}
+
+export function resetStore(): void {
+  for (const timer of pendingTimers.values()) {
+    clearTimeout(timer);
+  }
+  pendingTimers.clear();
+  jobs.clear();
+  counter = 0;
+  completionDelayMs = 50;
+}
+
+export function isValidSection(value: unknown): value is ExportSection {
+  return (
+    typeof value === "string" &&
+    EXPORT_SECTIONS.includes(value as ExportSection)
+  );
+}

--- a/app/api/routes-f/creator-export/types.ts
+++ b/app/api/routes-f/creator-export/types.ts
@@ -1,0 +1,37 @@
+export const EXPORT_SECTIONS = [
+  "streams",
+  "tips",
+  "followers",
+  "subscribers",
+] as const;
+
+export type ExportSection = (typeof EXPORT_SECTIONS)[number];
+
+export type ExportStatus = "queued" | "ready" | "failed";
+
+export interface ExportJob {
+  export_id: string;
+  creator_id: string;
+  sections: ExportSection[];
+  status: ExportStatus;
+  created_at: string;
+  ready_at?: string;
+  download_url?: string;
+  error?: string;
+}
+
+export interface CreateExportBody {
+  creator_id: string;
+  sections: ExportSection[];
+}
+
+export interface CreateExportResponse {
+  export_id: string;
+  status: "queued";
+}
+
+export interface ExportStatusResponse {
+  status: ExportStatus;
+  download_url?: string;
+  error?: string;
+}

--- a/app/api/routes-f/viewer-peaks/__tests__/route.test.ts
+++ b/app/api/routes-f/viewer-peaks/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { computePeak, getTopPeaks } from "../peaks";
+import { getSessionsForCreator } from "../seed";
+
+function makeReq(query = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-f/viewer-peaks${query}`
+  );
+}
+
+describe("computePeak", () => {
+  it("finds the max viewer sample and its timestamp", () => {
+    const session = getSessionsForCreator("creator_a")[0];
+    const peak = computePeak(session);
+    expect(peak.peak_viewers).toBe(620);
+    expect(peak.peaked_at).toBe("2026-06-20T19:00:00.000Z");
+    expect(peak.title).toBe("Stellar DeFi Deep Dive");
+  });
+});
+
+describe("getTopPeaks", () => {
+  it("sorts peaks by peak_viewers descending", () => {
+    const sessions = getSessionsForCreator("creator_a");
+    const peaks = getTopPeaks(sessions, 10);
+    for (let i = 1; i < peaks.length; i++) {
+      expect(peaks[i - 1].peak_viewers).toBeGreaterThanOrEqual(
+        peaks[i].peak_viewers
+      );
+    }
+  });
+
+  it("respects the limit", () => {
+    const sessions = getSessionsForCreator("creator_a");
+    const peaks = getTopPeaks(sessions, 2);
+    expect(peaks).toHaveLength(2);
+    expect(peaks[0].peak_viewers).toBe(620);
+    expect(peaks[1].peak_viewers).toBe(450);
+  });
+});
+
+describe("GET /api/routes-f/viewer-peaks", () => {
+  it("requires creator_id", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("creator_id");
+  });
+
+  it("rejects invalid limit", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a&limit=0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns peaks sorted by peak_viewers desc with default limit", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.peaks.length).toBeGreaterThan(0);
+    expect(body.peaks[0]).toMatchObject({
+      stream_id: expect.any(String),
+      peak_viewers: expect.any(Number),
+      peaked_at: expect.any(String),
+      title: expect.any(String),
+    });
+    expect(body.peaks[0].peak_viewers).toBe(620);
+    expect(body.peaks[1].peak_viewers).toBe(450);
+  });
+
+  it("honors a custom limit", async () => {
+    const res = await GET(makeReq("?creator_id=creator_a&limit=1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.peaks).toHaveLength(1);
+    expect(body.peaks[0].peak_viewers).toBe(620);
+  });
+
+  it("returns an empty list for an unknown creator", async () => {
+    const res = await GET(makeReq("?creator_id=unknown"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.peaks).toEqual([]);
+  });
+});

--- a/app/api/routes-f/viewer-peaks/peaks.ts
+++ b/app/api/routes-f/viewer-peaks/peaks.ts
@@ -1,0 +1,54 @@
+import type { StreamSessionPeak, ViewerPeakEntry } from "./types";
+
+/**
+ * Derive the peak concurrent viewer count and the timestamp when it occurred
+ * from a stream's sampled viewer timeline.
+ */
+export function computePeak(session: StreamSessionPeak): ViewerPeakEntry {
+  if (session.viewer_samples.length === 0) {
+    return {
+      stream_id: session.stream_id,
+      peak_viewers: 0,
+      peaked_at: session.sample_timestamps[0] ?? new Date(0).toISOString(),
+      title: session.title,
+    };
+  }
+
+  let peakIndex = 0;
+  for (let i = 1; i < session.viewer_samples.length; i++) {
+    if (session.viewer_samples[i] > session.viewer_samples[peakIndex]) {
+      peakIndex = i;
+    }
+  }
+
+  return {
+    stream_id: session.stream_id,
+    peak_viewers: session.viewer_samples[peakIndex],
+    peaked_at: session.sample_timestamps[peakIndex],
+    title: session.title,
+  };
+}
+
+/**
+ * Return the top N peak viewer entries for a creator, sorted by peak desc.
+ */
+export function getTopPeaks(
+  sessions: StreamSessionPeak[],
+  limit: number
+): ViewerPeakEntry[] {
+  return sessions
+    .map(computePeak)
+    .sort((a, b) => b.peak_viewers - a.peak_viewers)
+    .slice(0, limit);
+}
+
+export function parseLimit(raw: string | null, defaultLimit = 10): number | null {
+  if (raw === null || raw === "") {
+    return defaultLimit;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return null;
+  }
+  return parsed;
+}

--- a/app/api/routes-f/viewer-peaks/route.ts
+++ b/app/api/routes-f/viewer-peaks/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionsForCreator } from "./seed";
+import { getTopPeaks, parseLimit } from "./peaks";
+import type { ViewerPeaksResponse } from "./types";
+
+/**
+ * GET /api/routes-f/viewer-peaks?creator_id=creator_a&limit=10
+ *
+ * Returns the top N peak concurrent viewer counts across a creator's streams.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = req.nextUrl;
+  const creatorId = searchParams.get("creator_id");
+  const limitParam = searchParams.get("limit");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const limit = parseLimit(limitParam);
+  if (limit === null) {
+    return NextResponse.json(
+      { error: "limit must be a positive integer" },
+      { status: 400 }
+    );
+  }
+
+  const sessions = getSessionsForCreator(creatorId);
+  const peaks = getTopPeaks(sessions, limit);
+
+  return NextResponse.json({ peaks } satisfies ViewerPeaksResponse);
+}

--- a/app/api/routes-f/viewer-peaks/seed.ts
+++ b/app/api/routes-f/viewer-peaks/seed.ts
@@ -1,0 +1,87 @@
+import type { StreamSessionPeak } from "./types";
+
+const MINUTE = 60 * 1000;
+
+/**
+ * Seed stream sessions with viewer samples and aligned timestamps so peak
+ * moments can be resolved for a creator's past streams.
+ */
+export function getStreamSessions(
+  now: number = Date.now()
+): StreamSessionPeak[] {
+  return [
+    {
+      stream_id: "stream_peak_1",
+      creator_id: "creator_a",
+      title: "Stellar DeFi Deep Dive",
+      viewer_samples: [120, 340, 510, 480, 620, 590, 410, 250],
+      sample_timestamps: [
+        "2026-06-20T18:00:00.000Z",
+        "2026-06-20T18:15:00.000Z",
+        "2026-06-20T18:30:00.000Z",
+        "2026-06-20T18:45:00.000Z",
+        "2026-06-20T19:00:00.000Z",
+        "2026-06-20T19:15:00.000Z",
+        "2026-06-20T19:30:00.000Z",
+        "2026-06-20T19:45:00.000Z",
+      ],
+    },
+    {
+      stream_id: "stream_peak_2",
+      creator_id: "creator_a",
+      title: "Community AMA: XLM Tips & Tricks",
+      viewer_samples: [85, 210, 450, 380, 290],
+      sample_timestamps: [
+        "2026-06-18T20:00:00.000Z",
+        "2026-06-18T20:10:00.000Z",
+        "2026-06-18T20:20:00.000Z",
+        "2026-06-18T20:30:00.000Z",
+        "2026-06-18T20:40:00.000Z",
+      ],
+    },
+    {
+      stream_id: "stream_peak_3",
+      creator_id: "creator_a",
+      title: "Late Night Chill Beats",
+      viewer_samples: [42, 55, 61, 48],
+      sample_timestamps: [
+        "2026-06-15T23:00:00.000Z",
+        "2026-06-15T23:15:00.000Z",
+        "2026-06-15T23:30:00.000Z",
+        "2026-06-15T23:45:00.000Z",
+      ],
+    },
+    {
+      stream_id: "stream_peak_4",
+      creator_id: "creator_b",
+      title: "USDC Payout Walkthrough",
+      viewer_samples: [200, 310, 280],
+      sample_timestamps: [
+        "2026-06-19T14:00:00.000Z",
+        "2026-06-19T14:20:00.000Z",
+        "2026-06-19T14:40:00.000Z",
+      ],
+    },
+    {
+      // Live stream: samples relative to now for realism.
+      stream_id: "stream_peak_live",
+      creator_id: "creator_a",
+      title: "Live: Building on StreamFi",
+      viewer_samples: [80, 150, 220, 300, 410],
+      sample_timestamps: [
+        new Date(now - 35 * MINUTE).toISOString(),
+        new Date(now - 28 * MINUTE).toISOString(),
+        new Date(now - 21 * MINUTE).toISOString(),
+        new Date(now - 14 * MINUTE).toISOString(),
+        new Date(now - 7 * MINUTE).toISOString(),
+      ],
+    },
+  ];
+}
+
+export function getSessionsForCreator(
+  creatorId: string,
+  now: number = Date.now()
+): StreamSessionPeak[] {
+  return getStreamSessions(now).filter(s => s.creator_id === creatorId);
+}

--- a/app/api/routes-f/viewer-peaks/types.ts
+++ b/app/api/routes-f/viewer-peaks/types.ts
@@ -1,0 +1,20 @@
+export interface StreamSessionPeak {
+  stream_id: string;
+  creator_id: string;
+  title: string;
+  /** Concurrent viewer counts sampled at regular intervals during the stream. */
+  viewer_samples: number[];
+  /** ISO-8601 timestamps aligned with each viewer sample. */
+  sample_timestamps: string[];
+}
+
+export interface ViewerPeakEntry {
+  stream_id: string;
+  peak_viewers: number;
+  peaked_at: string;
+  title: string;
+}
+
+export interface ViewerPeaksResponse {
+  peaks: ViewerPeakEntry[];
+}


### PR DESCRIPTION
## Summary

Implements four self-contained `routes-f` practice endpoints, each scoped entirely under `app/api/routes-f/`:

- **#1025 — Viewer peaks** (`/api/routes-f/viewer-peaks`)
  - `GET ?creator_id&limit=10` → top N peak concurrent viewer counts across a creator's streams
  - Seed stream sessions with aligned viewer samples and timestamps
  - Sorted by `peak_viewers` descending

- **#1032 — Multi-camera angles** (`/api/routes-f/camera-angles`)
  - `GET ?stream_id` → available camera angles (`id`, `label`, `playback_id`)
  - `POST { viewer_id, stream_id, angle_id }` → stores viewer's angle selection in memory
  - Rejects unknown streams (404) and unknown angles (400)

- **#1022 — Chat velocity** (`/api/routes-f/chat-velocity`)
  - `GET ?stream_id` → `{ series, peak_minute, total_messages }`
  - Buckets timestamped chat events into per-minute counts
  - Detects the minute with the highest message volume

- **#1028 — Creator data export** (`/api/routes-f/creator-export`)
  - `POST { creator_id, sections }` → `{ export_id, status: queued }`
  - `GET ?export_id` → `{ status, download_url? }`
  - In-memory queue with synthetic auto-complete delay

All routes include bundled seed data and Jest tests covering ordering, limits, selection, bucketing, lifecycle, and validation.

## Test plan

- [ ] `npm test -- --testPathPattern="viewer-peaks|camera-angles|chat-velocity|creator-export"`
- [ ] `GET /api/routes-f/viewer-peaks?creator_id=creator_a&limit=2` returns peaks sorted desc
- [ ] `GET /api/routes-f/camera-angles?stream_id=stream_multi_1` lists 3 angles
- [ ] `POST /api/routes-f/camera-angles` with unknown `angle_id` returns 400
- [ ] `GET /api/routes-f/chat-velocity?stream_id=stream_chat_1` returns minute series + peak
- [ ] `POST /api/routes-f/creator-export` then `GET ?export_id` after delay shows `ready` + `download_url`

## Issues

Closes #1022
Closes #1025
Closes #1028
Closes #1032