### PR TITLE
Feat/issues 1043 1046

### DIFF
--- a/app/api/routes-f/channel-bans/route.test.ts
+++ b/app/api/routes-f/channel-bans/route.test.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE, _resetBans } from "./route";
+
+describe("Channel Bans API", () => {
+  beforeEach(() => {
+    _resetBans();
+  });
+
+  const mockRequest = (method: string, url: string, body?: any) => {
+    return new NextRequest(`http://localhost${url}`, {
+      method,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+  };
+
+  it("should add a ban (POST)", async () => {
+    const req = mockRequest("POST", "/api/routes-f/channel-bans", {
+      creator_id: "c1",
+      viewer_id: "v1",
+      reason: "Spamming",
+    });
+    
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    
+    const data = await res.json();
+    expect(data.ban.creator_id).toBe("c1");
+    expect(data.ban.viewer_id).toBe("v1");
+    expect(data.ban.reason).toBe("Spamming");
+    expect(data.ban.ts).toBeDefined();
+  });
+
+  it("should list bans (GET)", async () => {
+    // Add a ban first
+    const postReq = mockRequest("POST", "/api/routes-f/channel-bans", {
+      creator_id: "c2",
+      viewer_id: "v2",
+      reason: "Toxicity",
+    });
+    await POST(postReq);
+
+    // List bans
+    const getReq = mockRequest("GET", "/api/routes-f/channel-bans?creator_id=c2");
+    const res = await GET(getReq);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.bans.length).toBe(1);
+    expect(data.bans[0].creator_id).toBe("c2");
+    expect(data.bans[0].viewer_id).toBe("v2");
+    expect(data.bans[0].reason).toBe("Toxicity");
+  });
+
+  it("should lift a ban (DELETE)", async () => {
+    // Add a ban first
+    const postReq = mockRequest("POST", "/api/routes-f/channel-bans", {
+      creator_id: "c3",
+      viewer_id: "v3",
+      reason: "Botting",
+    });
+    await POST(postReq);
+
+    // Lift the ban
+    const delReq = mockRequest(
+      "DELETE",
+      "/api/routes-f/channel-bans?creator_id=c3&viewer_id=v3"
+    );
+    const delRes = await DELETE(delReq);
+    expect(delRes.status).toBe(200);
+
+    // Verify it's gone
+    const getReq = mockRequest("GET", "/api/routes-f/channel-bans?creator_id=c3");
+    const getRes = await GET(getReq);
+    const data = await getRes.json();
+    expect(data.bans.length).toBe(0);
+  });
+});

--- a/app/api/routes-f/channel-bans/route.ts
+++ b/app/api/routes-f/channel-bans/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface Ban {
+  creator_id: string;
+  viewer_id: string;
+  reason: string;
+  ts: number;
+}
+
+// In-memory store for practice implementation
+let bans: Ban[] = [];
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+
+  const userBans = bans.filter((ban) => ban.creator_id === creatorId);
+  return NextResponse.json({ bans: userBans }, { status: 200 });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { creator_id, viewer_id, reason } = body;
+
+    if (!creator_id || !viewer_id || !reason) {
+      return NextResponse.json(
+        { error: "creator_id, viewer_id, and reason are required" },
+        { status: 400 }
+      );
+    }
+
+    // Check if ban already exists
+    const existingBanIndex = bans.findIndex(
+      (b) => b.creator_id === creator_id && b.viewer_id === viewer_id
+    );
+
+    const ts = Date.now();
+    const newBan: Ban = { creator_id, viewer_id, reason, ts };
+
+    if (existingBanIndex >= 0) {
+      bans[existingBanIndex] = newBan;
+    } else {
+      bans.push(newBan);
+    }
+
+    return NextResponse.json({ ban: newBan }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const creatorId = searchParams.get("creator_id");
+  const viewerId = searchParams.get("viewer_id");
+
+  if (!creatorId || !viewerId) {
+    return NextResponse.json(
+      { error: "creator_id and viewer_id are required" },
+      { status: 400 }
+    );
+  }
+
+  const initialLength = bans.length;
+  bans = bans.filter(
+    (ban) => !(ban.creator_id === creatorId && ban.viewer_id === viewerId)
+  );
+
+  if (bans.length === initialLength) {
+    return NextResponse.json({ error: "Ban not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}
+
+// For testing purposes
+export function _resetBans() {
+  bans = [];
+}

--- a/app/api/routes-f/stream-hosts/route.test.ts
+++ b/app/api/routes-f/stream-hosts/route.test.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+import { GET, POST, DELETE, _resetStreamHosts } from "./route";
+
+describe("Stream Hosts API", () => {
+  beforeEach(() => {
+    _resetStreamHosts();
+  });
+
+  const mockRequest = (method: string, url: string, body?: any) => {
+    return new NextRequest(`http://localhost${url}`, {
+      method,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+  };
+
+  it("should add a host (POST)", async () => {
+    const req = mockRequest("POST", "/api/routes-f/stream-hosts", {
+      stream_id: "s1",
+      host_user_id: "u1",
+      role: "host",
+    });
+    
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    
+    const data = await res.json();
+    expect(data.added_at).toBeDefined();
+  });
+
+  it("should list hosts (GET)", async () => {
+    const postReq = mockRequest("POST", "/api/routes-f/stream-hosts", {
+      stream_id: "s2",
+      host_user_id: "u2",
+      role: "guest",
+    });
+    await POST(postReq);
+
+    const getReq = mockRequest("GET", "/api/routes-f/stream-hosts?stream_id=s2");
+    const res = await GET(getReq);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.hosts.length).toBe(1);
+    expect(data.hosts[0].stream_id).toBe("s2");
+    expect(data.hosts[0].host_user_id).toBe("u2");
+    expect(data.hosts[0].role).toBe("guest");
+  });
+
+  it("should cap total hosts at 4", async () => {
+    // Add 4 hosts
+    for (let i = 1; i <= 4; i++) {
+      const postReq = mockRequest("POST", "/api/routes-f/stream-hosts", {
+        stream_id: "s3",
+        host_user_id: `u${i}`,
+        role: "co-host",
+      });
+      const res = await POST(postReq);
+      expect(res.status).toBe(201);
+    }
+
+    // Try to add 5th host
+    const failReq = mockRequest("POST", "/api/routes-f/stream-hosts", {
+      stream_id: "s3",
+      host_user_id: "u5",
+      role: "guest",
+    });
+    const failRes = await POST(failReq);
+    expect(failRes.status).toBe(403);
+    const failData = await failRes.json();
+    expect(failData.error).toContain("Maximum number of hosts");
+  });
+
+  it("should remove a host (DELETE)", async () => {
+    const postReq = mockRequest("POST", "/api/routes-f/stream-hosts", {
+      stream_id: "s4",
+      host_user_id: "u4",
+      role: "co-host",
+    });
+    await POST(postReq);
+
+    const delReq = mockRequest(
+      "DELETE",
+      "/api/routes-f/stream-hosts?stream_id=s4&host_user_id=u4"
+    );
+    const delRes = await DELETE(delReq);
+    expect(delRes.status).toBe(200);
+
+    const getReq = mockRequest("GET", "/api/routes-f/stream-hosts?stream_id=s4");
+    const getRes = await GET(getReq);
+    const data = await getRes.json();
+    expect(data.hosts.length).toBe(0);
+  });
+});

--- a/app/api/routes-f/stream-hosts/route.ts
+++ b/app/api/routes-f/stream-hosts/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type HostRole = "host" | "guest" | "co-host";
+
+export interface StreamHost {
+  stream_id: string;
+  host_user_id: string;
+  role: HostRole;
+  added_at: number;
+}
+
+let streamHosts: StreamHost[] = [];
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const streamId = searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  const hosts = streamHosts.filter((sh) => sh.stream_id === streamId);
+  return NextResponse.json({ hosts }, { status: 200 });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { stream_id, host_user_id, role } = body;
+
+    if (!stream_id || !host_user_id || !role) {
+      return NextResponse.json(
+        { error: "stream_id, host_user_id, and role are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!["host", "guest", "co-host"].includes(role)) {
+      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    }
+
+    // Check cap
+    const currentHosts = streamHosts.filter((sh) => sh.stream_id === stream_id);
+    
+    // Check if host already exists
+    const existingIndex = streamHosts.findIndex(
+      (sh) => sh.stream_id === stream_id && sh.host_user_id === host_user_id
+    );
+
+    if (existingIndex < 0 && currentHosts.length >= 4) {
+      return NextResponse.json(
+        { error: "Maximum number of hosts (4) reached" },
+        { status: 403 }
+      );
+    }
+
+    const added_at = Date.now();
+    const newHost: StreamHost = { stream_id, host_user_id, role, added_at };
+
+    if (existingIndex >= 0) {
+      streamHosts[existingIndex] = newHost;
+    } else {
+      streamHosts.push(newHost);
+    }
+
+    return NextResponse.json({ added_at: newHost.added_at }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const streamId = searchParams.get("stream_id");
+  const hostUserId = searchParams.get("host_user_id");
+
+  if (!streamId || !hostUserId) {
+    return NextResponse.json(
+      { error: "stream_id and host_user_id are required" },
+      { status: 400 }
+    );
+  }
+
+  const initialLength = streamHosts.length;
+  streamHosts = streamHosts.filter(
+    (sh) => !(sh.stream_id === streamId && sh.host_user_id === hostUserId)
+  );
+
+  if (streamHosts.length === initialLength) {
+    return NextResponse.json({ error: "Host not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}
+
+// For testing purposes
+export function _resetStreamHosts() {
+  streamHosts = [];
+}


### PR DESCRIPTION
### PR Description

**Title:** feat(routes-f): add channel bans and stream multi-host slots APIs

**Description:**
This PR introduces the mock API routes for managing channel bans and multi-host stream slots for practice implementation. All logic and tests are scoped within the `app/api/routes-f/` directory, following the isolation requirements. 

**Issues Solved:**
- closes #1043: Channel ban list (adds support for GET, POST, and DELETE channel bans)
- closes #1046: Stream multi-host slots (adds support for GET, POST, DELETE co-hosts with a maximum cap of 4 hosts per stream)

**Changes Include:**
- `app/api/routes-f/channel-bans/route.ts`: Implements in-memory store and Next.js handlers for channel bans.
- `app/api/routes-f/channel-bans/route.test.ts`: Jest tests covering the add, list, and lift ban functionality.
- `app/api/routes-f/stream-hosts/route.ts`: Implements in-memory store and Next.js handlers for managing stream hosts (with roles: `host`, `guest`, `co-host` and a 4-host cap).
- `app/api/routes-f/stream-hosts/route.test.ts`: Jest tests covering the add, list, remove, and cap limit functionality.

**Verification:**
Both implementations have companion Jest tests built out that cover the required functionality for each endpoint.