### PR TITLE
feat(routes-f): channel theme override (#1041)

### DIFF
--- a/app/api/routes-f/channel-theme/route.test.ts
+++ b/app/api/routes-f/channel-theme/route.test.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from "next/server";
+import { GET, PUT, DEFAULT_THEME, _resetThemes } from "./route";
+
+describe("Channel Theme API", () => {
+  beforeEach(() => {
+    _resetThemes();
+  });
+
+  const mockRequest = (method: string, url: string, body?: any) => {
+    return new NextRequest(`http://localhost${url}`, {
+      method,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+  };
+
+  it("should return default theme if no custom theme exists (GET)", async () => {
+    const getReq = mockRequest("GET", "/api/routes-f/channel-theme?creator_id=c1");
+    const res = await GET(getReq);
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.accent_color).toBe(DEFAULT_THEME.accent_color);
+    expect(data.secondary_color).toBe(DEFAULT_THEME.secondary_color);
+  });
+
+  it("should update and return a custom theme (PUT)", async () => {
+    const putReq = mockRequest("PUT", "/api/routes-f/channel-theme", {
+      creator_id: "c2",
+      accent_color: "#ff0000",
+      secondary_color: "#00ff00",
+    });
+    
+    const putRes = await PUT(putReq);
+    expect(putRes.status).toBe(200);
+
+    // Verify GET returns updated theme
+    const getReq = mockRequest("GET", "/api/routes-f/channel-theme?creator_id=c2");
+    const getRes = await GET(getReq);
+    const data = await getRes.json();
+    
+    expect(data.accent_color).toBe("#ff0000");
+    expect(data.secondary_color).toBe("#00ff00");
+  });
+
+  it("should reject invalid hex colors (PUT)", async () => {
+    const putReq = mockRequest("PUT", "/api/routes-f/channel-theme", {
+      creator_id: "c3",
+      accent_color: "invalid-color",
+      secondary_color: "#000",
+    });
+    
+    const putRes = await PUT(putReq);
+    expect(putRes.status).toBe(400);
+
+    const data = await putRes.json();
+    expect(data.error).toContain("Invalid hex color format");
+  });
+
+  it("should allow short hex colors (PUT)", async () => {
+    const putReq = mockRequest("PUT", "/api/routes-f/channel-theme", {
+      creator_id: "c4",
+      accent_color: "#f00",
+      secondary_color: "#0f0",
+    });
+    
+    const putRes = await PUT(putReq);
+    expect(putRes.status).toBe(200);
+  });
+});

--- a/app/api/routes-f/channel-theme/route.ts
+++ b/app/api/routes-f/channel-theme/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface ChannelTheme {
+  creator_id: string;
+  accent_color: string;
+  secondary_color: string;
+}
+
+export const DEFAULT_THEME = {
+  accent_color: "#1E90FF",
+  secondary_color: "#FF4500",
+};
+
+// In-memory store for practice implementation
+let themes: ChannelTheme[] = [];
+
+const hexRegex = /^#([0-9A-Fa-f]{3}){1,2}$/;
+
+function isValidHex(hex: string): boolean {
+  return hexRegex.test(hex);
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+
+  const theme = themes.find((t) => t.creator_id === creatorId);
+
+  if (!theme) {
+    return NextResponse.json(
+      {
+        accent_color: DEFAULT_THEME.accent_color,
+        secondary_color: DEFAULT_THEME.secondary_color,
+      },
+      { status: 200 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      accent_color: theme.accent_color,
+      secondary_color: theme.secondary_color,
+    },
+    { status: 200 }
+  );
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { creator_id, accent_color, secondary_color } = body;
+
+    if (!creator_id || !accent_color || !secondary_color) {
+      return NextResponse.json(
+        { error: "creator_id, accent_color, and secondary_color are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidHex(accent_color) || !isValidHex(secondary_color)) {
+      return NextResponse.json(
+        { error: "Invalid hex color format" },
+        { status: 400 }
+      );
+    }
+
+    const existingIndex = themes.findIndex((t) => t.creator_id === creator_id);
+
+    const newTheme: ChannelTheme = { creator_id, accent_color, secondary_color };
+
+    if (existingIndex >= 0) {
+      themes[existingIndex] = newTheme;
+    } else {
+      themes.push(newTheme);
+    }
+
+    return NextResponse.json({ success: true, theme: newTheme }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}
+
+// For testing purposes
+export function _resetThemes() {
+  themes = [];
+}


### PR DESCRIPTION
**Description:**
This PR introduces the mock API route for managing a creator's channel accent color theme override. All logic and tests are scoped within the `app/api/routes-f/channel-theme/` directory, following the isolation requirements. 

**Issues Solved:**
- closes #1041: Channel theme override

**Changes Include:**
- `app/api/routes-f/channel-theme/route.ts`: Implements in-memory store and Next.js handlers (GET, PUT) for channel themes, validates incoming colors with a proper Hex Regex, and defaults to a bundled fallback theme if a channel theme is absent.
- `app/api/routes-f/channel-theme/route.test.ts`: Jest tests covering the update endpoint, invalid hex format rejection, short-hex code handling, and the fallback to the default theme.

**Verification:**
The endpoint includes comprehensive unit tests verifying valid/invalid inputs and the behavior for falling back to default themes.

The push completed successfully. You should be able to see the new pull request for `#1041` by following the link above. Let me know if there's any other issue you'd like me to look at!