### PR TITLE
feat(routes-f): mark notifications read, email digest, creator dashboard, retention curve

### DIFF
--- a/app/api/routes-f/__tests__/creator-dashboard-edge.test.ts
+++ b/app/api/routes-f/__tests__/creator-dashboard-edge.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../creator-dashboard/route";
+import { roundUsdc } from "../creator-dashboard/currency";
+
+function makeGet(qs: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/creator-dashboard?${qs}`
+  );
+}
+
+describe("GET /api/routes-f/creator-dashboard — edge cases", () => {
+  it("returns 404 for unknown creator_id", async () => {
+    const res = await GET(makeGet("creator_id=creator_999"));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/routes-f/creator-dashboard")
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when creator_id is empty string", async () => {
+    const res = await GET(makeGet("creator_id="));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("roundUsdc utility", () => {
+  it("rounds down correctly", () => {
+    expect(roundUsdc(12.333)).toBe(12.33);
+  });
+
+  it("rounds up correctly", () => {
+    expect(roundUsdc(12.335)).toBe(12.34);
+  });
+
+  it("leaves exact 2-decimal values unchanged", () => {
+    expect(roundUsdc(100.5)).toBe(100.5);
+    expect(roundUsdc(0.0)).toBe(0);
+  });
+
+  it("handles zero", () => {
+    expect(roundUsdc(0)).toBe(0);
+  });
+});

--- a/app/api/routes-f/__tests__/creator-dashboard.test.ts
+++ b/app/api/routes-f/__tests__/creator-dashboard.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../creator-dashboard/route";
+
+function makeGet(creatorId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/creator-dashboard?creator_id=${creatorId}`
+  );
+}
+
+describe("GET /api/routes-f/creator-dashboard", () => {
+  it("returns all five metric fields for a known creator", async () => {
+    const res = await GET(makeGet("creator_001"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(typeof data.follower_count).toBe("number");
+    expect(typeof data.monthly_recurring_revenue_usdc).toBe("number");
+    expect(typeof data.total_tips_lifetime_usdc).toBe("number");
+    expect(typeof data.active_subs).toBe("number");
+    expect("last_stream_at" in data).toBe(true);
+  });
+
+  it("returns correct values for creator_001", async () => {
+    const res = await GET(makeGet("creator_001"));
+    const data = await res.json();
+    expect(data.follower_count).toBe(14823);
+    expect(data.active_subs).toBe(312);
+    expect(data.last_stream_at).toBe("2026-06-25T20:00:00Z");
+  });
+
+  it("returns null last_stream_at for creator who has never streamed", async () => {
+    const res = await GET(makeGet("creator_003"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.last_stream_at).toBeNull();
+    expect(data.active_subs).toBe(0);
+  });
+
+  it("rounds MRR to 2 decimal places", async () => {
+    const res = await GET(makeGet("creator_001"));
+    const data = await res.json();
+    const decimals = (data.monthly_recurring_revenue_usdc.toString().split(".")[1] ?? "").length;
+    expect(decimals).toBeLessThanOrEqual(2);
+  });
+
+  it("rounds total_tips_lifetime_usdc to 2 decimal places", async () => {
+    const res = await GET(makeGet("creator_003"));
+    const data = await res.json();
+    expect(data.total_tips_lifetime_usdc).toBe(12.33);
+  });
+});

--- a/app/api/routes-f/__tests__/email-digest-sections.test.ts
+++ b/app/api/routes-f/__tests__/email-digest-sections.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { PUT } from "../email-digest/route";
+import { resetStore } from "../email-digest/store";
+import { VALID_SECTIONS, isValidSection, validateSections } from "../email-digest/sections";
+
+function makePut(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/email-digest", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => resetStore());
+
+describe("email-digest section validation helpers", () => {
+  it("VALID_SECTIONS contains all four allowed values", () => {
+    expect(VALID_SECTIONS).toContain("live_alerts");
+    expect(VALID_SECTIONS).toContain("new_clips");
+    expect(VALID_SECTIONS).toContain("tip_summary");
+    expect(VALID_SECTIONS).toContain("recommendations");
+    expect(VALID_SECTIONS).toHaveLength(4);
+  });
+
+  it("isValidSection returns true for known sections", () => {
+    expect(isValidSection("live_alerts")).toBe(true);
+    expect(isValidSection("recommendations")).toBe(true);
+  });
+
+  it("isValidSection returns false for unknown strings", () => {
+    expect(isValidSection("weekly_recap")).toBe(false);
+    expect(isValidSection("")).toBe(false);
+  });
+
+  it("validateSections returns typed array for valid input", () => {
+    const result = validateSections(["live_alerts", "tip_summary"]);
+    expect(result).toEqual(["live_alerts", "tip_summary"]);
+  });
+
+  it("validateSections returns null for invalid input", () => {
+    expect(validateSections(["live_alerts", "bad_section"])).toBeNull();
+  });
+});
+
+describe("PUT /api/routes-f/email-digest section validation", () => {
+  it("returns 400 for unrecognised section value", async () => {
+    const res = await PUT(
+      makePut({
+        viewer_id: "viewer_001",
+        sections: ["live_alerts", "weekly_recap"],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts all four sections in one PUT", async () => {
+    const res = await PUT(
+      makePut({
+        viewer_id: "viewer_001",
+        sections: ["live_alerts", "new_clips", "tip_summary", "recommendations"],
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.sections).toHaveLength(4);
+  });
+
+  it("accepts empty sections array to opt out of all digest content", async () => {
+    const res = await PUT(
+      makePut({ viewer_id: "viewer_001", sections: [] })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.sections).toEqual([]);
+  });
+});

--- a/app/api/routes-f/__tests__/email-digest.test.ts
+++ b/app/api/routes-f/__tests__/email-digest.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../email-digest/route";
+import { resetStore } from "../email-digest/store";
+
+function makeGet(viewerId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/email-digest?viewer_id=${viewerId}`
+  );
+}
+
+function makePut(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/email-digest", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => resetStore());
+
+describe("GET /api/routes-f/email-digest", () => {
+  it("returns seeded prefs for known viewer", async () => {
+    const res = await GET(makeGet("viewer_001"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.enabled).toBe(true);
+    expect(data.day_of_week).toBe("monday");
+    expect(data.sections).toContain("live_alerts");
+    expect(data.sections).toContain("tip_summary");
+  });
+
+  it("returns disabled defaults for unknown viewer", async () => {
+    const res = await GET(makeGet("unknown_viewer"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.enabled).toBe(false);
+    expect(Array.isArray(data.sections)).toBe(true);
+  });
+
+  it("returns 400 when viewer_id is missing", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/routes-f/email-digest")
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /api/routes-f/email-digest", () => {
+  it("toggles enabled flag", async () => {
+    const res = await PUT(
+      makePut({ viewer_id: "viewer_001", enabled: false })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.enabled).toBe(false);
+    expect(data.day_of_week).toBe("monday");
+  });
+
+  it("updates day_of_week", async () => {
+    const res = await PUT(
+      makePut({ viewer_id: "viewer_001", day_of_week: "thursday" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.day_of_week).toBe("thursday");
+    expect(data.enabled).toBe(true);
+  });
+
+  it("updates sections subset", async () => {
+    const res = await PUT(
+      makePut({
+        viewer_id: "viewer_001",
+        sections: ["new_clips", "recommendations"],
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.sections).toEqual(["new_clips", "recommendations"]);
+  });
+
+  it("creates new prefs for unknown viewer via PUT", async () => {
+    const res = await PUT(
+      makePut({
+        viewer_id: "viewer_new",
+        enabled: true,
+        day_of_week: "saturday",
+        sections: ["tip_summary"],
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.enabled).toBe(true);
+    expect(data.day_of_week).toBe("saturday");
+    expect(data.sections).toEqual(["tip_summary"]);
+  });
+
+  it("GET reflects updated prefs after PUT", async () => {
+    await PUT(makePut({ viewer_id: "viewer_002", enabled: true }));
+    const res = await GET(makeGet("viewer_002"));
+    const data = await res.json();
+    expect(data.enabled).toBe(true);
+  });
+});

--- a/app/api/routes-f/__tests__/notifications-mark-read-edge.test.ts
+++ b/app/api/routes-f/__tests__/notifications-mark-read-edge.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../notifications/mark-read/route";
+import { resetStore } from "../notifications/mark-read/store";
+
+function makeReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/notifications/mark-read",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => resetStore());
+
+describe("POST /api/routes-f/notifications/mark-read — edge cases", () => {
+  it("returns 400 when viewer_id is missing", async () => {
+    const res = await POST(makeReq({ ids: ["n_001"] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when neither ids nor all is provided", async () => {
+    const res = await POST(makeReq({ viewer_id: "viewer_001" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when ids is an empty array", async () => {
+    const res = await POST(makeReq({ viewer_id: "viewer_001", ids: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/notifications/mark-read",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 0 updated_count for unknown ids", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer_001", ids: ["n_999", "n_000"] })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(0);
+  });
+
+  it("returns 0 updated_count for unknown viewer_id with all=true", async () => {
+    const res = await POST(makeReq({ viewer_id: "unknown_viewer", all: true }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(0);
+  });
+
+  it("does not mark notifications belonging to another viewer", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer_002", ids: ["n_001"] })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(0);
+  });
+});

--- a/app/api/routes-f/__tests__/notifications-mark-read.test.ts
+++ b/app/api/routes-f/__tests__/notifications-mark-read.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../notifications/mark-read/route";
+import { resetStore, getStore } from "../notifications/mark-read/store";
+
+function makeReq(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/routes-f/notifications/mark-read",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => resetStore());
+
+describe("POST /api/routes-f/notifications/mark-read", () => {
+  it("marks a single notification as read", async () => {
+    const res = await POST(makeReq({ viewer_id: "viewer_001", ids: ["n_001"] }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(1);
+    const n = getStore().find((x) => x.id === "n_001");
+    expect(n?.read).toBe(true);
+  });
+
+  it("marks multiple notifications as read", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer_001", ids: ["n_001", "n_002", "n_004"] })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(3);
+  });
+
+  it("does not double-count already-read notifications", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer_001", ids: ["n_003"] })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(0);
+  });
+
+  it("marks all notifications read with all=true", async () => {
+    const res = await POST(makeReq({ viewer_id: "viewer_001", all: true }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.updated_count).toBe(3);
+    const remaining = getStore().filter(
+      (n) => n.viewer_id === "viewer_001" && !n.read
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("scopes all=true to the given viewer_id", async () => {
+    await POST(makeReq({ viewer_id: "viewer_001", all: true }));
+    const viewer2unread = getStore().filter(
+      (n) => n.viewer_id === "viewer_002" && !n.read
+    );
+    expect(viewer2unread.length).toBeGreaterThan(0);
+  });
+});

--- a/app/api/routes-f/__tests__/retention-curve-compute.test.ts
+++ b/app/api/routes-f/__tests__/retention-curve-compute.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+import { normalizeRetention } from "../retention-curve/compute";
+
+describe("normalizeRetention", () => {
+  it("returns empty array for empty input", () => {
+    expect(normalizeRetention([])).toEqual([]);
+  });
+
+  it("sets percent_of_peak to 100 for peak sample", () => {
+    const result = normalizeRetention([
+      { minute: 0, viewer_count: 1000 },
+      { minute: 10, viewer_count: 500 },
+    ]);
+    expect(result[0].percent_of_peak).toBe(100);
+  });
+
+  it("correctly normalises to 50% at half peak", () => {
+    const result = normalizeRetention([
+      { minute: 0, viewer_count: 1000 },
+      { minute: 10, viewer_count: 500 },
+    ]);
+    expect(result[1].percent_of_peak).toBe(50);
+  });
+
+  it("returns percent_of_peak rounded to 2 decimal places", () => {
+    const result = normalizeRetention([
+      { minute: 0, viewer_count: 3 },
+      { minute: 1, viewer_count: 1 },
+    ]);
+    expect(result[1].percent_of_peak).toBe(33.33);
+  });
+
+  it("preserves minute and viewer_count fields unchanged", () => {
+    const result = normalizeRetention([{ minute: 5, viewer_count: 200 }]);
+    expect(result[0].minute).toBe(5);
+    expect(result[0].viewer_count).toBe(200);
+  });
+
+  it("returns 0 percent_of_peak for all samples when peak is 0", () => {
+    const result = normalizeRetention([
+      { minute: 0, viewer_count: 0 },
+      { minute: 1, viewer_count: 0 },
+    ]);
+    for (const p of result) {
+      expect(p.percent_of_peak).toBe(0);
+    }
+  });
+});

--- a/app/api/routes-f/__tests__/retention-curve-steady.test.ts
+++ b/app/api/routes-f/__tests__/retention-curve-steady.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../retention-curve/route";
+
+function makeGet(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/retention-curve?stream_id=${streamId}`
+  );
+}
+
+describe("GET /api/routes-f/retention-curve — steady stream", () => {
+  it("all points stay above 90% for a steady stream", async () => {
+    const res = await GET(makeGet("stream_steady"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    for (const point of data.points) {
+      expect(point.percent_of_peak).toBeGreaterThanOrEqual(90);
+    }
+  });
+
+  it("first point is 100% for steady stream", async () => {
+    const res = await GET(makeGet("stream_steady"));
+    const data = await res.json();
+    expect(data.points[0].percent_of_peak).toBe(100);
+  });
+});
+
+describe("GET /api/routes-f/retention-curve — edge cases", () => {
+  it("returns 404 for unknown stream_id", async () => {
+    const res = await GET(makeGet("stream_unknown"));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/routes-f/retention-curve")
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("handles single-sample stream without dividing by zero", async () => {
+    const res = await GET(makeGet("stream_single"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.points).toHaveLength(1);
+    expect(data.points[0].percent_of_peak).toBe(100);
+    expect(data.points[0].viewer_count).toBe(500);
+  });
+});

--- a/app/api/routes-f/__tests__/retention-curve.test.ts
+++ b/app/api/routes-f/__tests__/retention-curve.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../retention-curve/route";
+
+function makeGet(streamId: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/retention-curve?stream_id=${streamId}`
+  );
+}
+
+describe("GET /api/routes-f/retention-curve — drop-off stream", () => {
+  it("returns points array with expected shape", async () => {
+    const res = await GET(makeGet("stream_drop"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.points)).toBe(true);
+    expect(data.points.length).toBeGreaterThan(0);
+    const first = data.points[0];
+    expect(typeof first.minute).toBe("number");
+    expect(typeof first.viewer_count).toBe("number");
+    expect(typeof first.percent_of_peak).toBe("number");
+  });
+
+  it("first point has percent_of_peak of 100 (peak viewers at minute 0)", async () => {
+    const res = await GET(makeGet("stream_drop"));
+    const data = await res.json();
+    expect(data.points[0].percent_of_peak).toBe(100);
+  });
+
+  it("percent_of_peak decreases over time for a drop-off stream", async () => {
+    const res = await GET(makeGet("stream_drop"));
+    const data = await res.json();
+    const percents: number[] = data.points.map((p: { percent_of_peak: number }) => p.percent_of_peak);
+    for (let i = 1; i < percents.length; i++) {
+      expect(percents[i]).toBeLessThanOrEqual(percents[i - 1]);
+    }
+  });
+
+  it("last point percent_of_peak is well below 50 for a strong drop-off", async () => {
+    const res = await GET(makeGet("stream_drop"));
+    const data = await res.json();
+    const last = data.points[data.points.length - 1];
+    expect(last.percent_of_peak).toBeLessThan(50);
+  });
+});

--- a/app/api/routes-f/creator-dashboard/aggregators.ts
+++ b/app/api/routes-f/creator-dashboard/aggregators.ts
@@ -1,0 +1,12 @@
+import type { CreatorStats, CreatorDashboardResponse } from "./types";
+import { roundUsdc } from "./currency";
+
+export function buildDashboardResponse(stats: CreatorStats): CreatorDashboardResponse {
+  return {
+    follower_count: stats.follower_count,
+    monthly_recurring_revenue_usdc: roundUsdc(stats.monthly_recurring_revenue_usdc),
+    last_stream_at: stats.last_stream_at,
+    total_tips_lifetime_usdc: roundUsdc(stats.total_tips_lifetime_usdc),
+    active_subs: stats.active_subs,
+  };
+}

--- a/app/api/routes-f/creator-dashboard/currency.ts
+++ b/app/api/routes-f/creator-dashboard/currency.ts
@@ -1,0 +1,3 @@
+export function roundUsdc(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/app/api/routes-f/creator-dashboard/route.ts
+++ b/app/api/routes-f/creator-dashboard/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/routes-f/creator-dashboard?creator_id=
+ *
+ * Returns roll-up metrics for a creator's dashboard home page.
+ *
+ * Query params:
+ *   creator_id — required
+ *
+ * Response:
+ *   {
+ *     follower_count:                  number,
+ *     monthly_recurring_revenue_usdc:  number,  // rounded to 2 decimals
+ *     last_stream_at:                  string | null,
+ *     total_tips_lifetime_usdc:        number,  // rounded to 2 decimals
+ *     active_subs:                     number
+ *   }
+ *
+ * Error responses:
+ *   400 — missing/invalid query params
+ *   404 — creator not found
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { SEED_STATS } from "./seed";
+import { buildDashboardResponse } from "./aggregators";
+
+const querySchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { creator_id } = queryResult.data;
+  const stats = SEED_STATS[creator_id];
+
+  if (!stats) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(buildDashboardResponse(stats));
+}

--- a/app/api/routes-f/creator-dashboard/seed.ts
+++ b/app/api/routes-f/creator-dashboard/seed.ts
@@ -1,0 +1,28 @@
+import type { CreatorStats } from "./types";
+
+export const SEED_STATS: Record<string, CreatorStats> = {
+  creator_001: {
+    creator_id: "creator_001",
+    follower_count: 14_823,
+    monthly_recurring_revenue_usdc: 1_247.5,
+    last_stream_at: "2026-06-25T20:00:00Z",
+    total_tips_lifetime_usdc: 8_934.125,
+    active_subs: 312,
+  },
+  creator_002: {
+    creator_id: "creator_002",
+    follower_count: 3_210,
+    monthly_recurring_revenue_usdc: 198.0,
+    last_stream_at: "2026-06-20T15:30:00Z",
+    total_tips_lifetime_usdc: 420.5,
+    active_subs: 47,
+  },
+  creator_003: {
+    creator_id: "creator_003",
+    follower_count: 501,
+    monthly_recurring_revenue_usdc: 0.0,
+    last_stream_at: null,
+    total_tips_lifetime_usdc: 12.333,
+    active_subs: 0,
+  },
+};

--- a/app/api/routes-f/creator-dashboard/types.ts
+++ b/app/api/routes-f/creator-dashboard/types.ts
@@ -1,0 +1,17 @@
+export interface CreatorStats {
+  creator_id: string;
+  follower_count: number;
+  /** Sum of active subscription amounts in USDC, billed monthly */
+  monthly_recurring_revenue_usdc: number;
+  last_stream_at: string | null;
+  total_tips_lifetime_usdc: number;
+  active_subs: number;
+}
+
+export interface CreatorDashboardResponse {
+  follower_count: number;
+  monthly_recurring_revenue_usdc: number;
+  last_stream_at: string | null;
+  total_tips_lifetime_usdc: number;
+  active_subs: number;
+}

--- a/app/api/routes-f/email-digest/route.ts
+++ b/app/api/routes-f/email-digest/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET  /api/routes-f/email-digest?viewer_id=
+ * PUT  /api/routes-f/email-digest
+ *
+ * GET  — returns current digest preferences for the viewer.
+ *         If no record exists, returns sensible defaults (disabled).
+ * PUT  — partial update: only supplied fields are overwritten.
+ *
+ * GET response:
+ *   { enabled, day_of_week, sections }
+ *
+ * PUT body:
+ *   { viewer_id, enabled?, day_of_week?, sections? }
+ *
+ * PUT response:
+ *   { enabled, day_of_week, sections }
+ *
+ * Error responses:
+ *   400 — missing/invalid params or body
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+import { getQuerySchema, putBodySchema } from "./schema";
+import { getPrefs, upsertPrefs } from "./store";
+import type { DigestPreferences, DayOfWeek, DigestSection } from "./types";
+
+const DEFAULT_PREFS = (viewerId: string): DigestPreferences => ({
+  viewer_id: viewerId,
+  enabled: false,
+  day_of_week: "monday" as DayOfWeek,
+  sections: [] as DigestSection[],
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, getQuerySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { viewer_id } = queryResult.data;
+  const prefs = getPrefs(viewer_id) ?? DEFAULT_PREFS(viewer_id);
+
+  return NextResponse.json({
+    enabled: prefs.enabled,
+    day_of_week: prefs.day_of_week,
+    sections: prefs.sections,
+  });
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, putBodySchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { viewer_id, enabled, day_of_week, sections } = bodyResult.data;
+  const existing = getPrefs(viewer_id) ?? DEFAULT_PREFS(viewer_id);
+
+  const updated: DigestPreferences = {
+    viewer_id,
+    enabled: enabled !== undefined ? enabled : existing.enabled,
+    day_of_week: day_of_week ?? existing.day_of_week,
+    sections: sections !== undefined ? (sections as DigestSection[]) : existing.sections,
+  };
+
+  upsertPrefs(updated);
+
+  return NextResponse.json({
+    enabled: updated.enabled,
+    day_of_week: updated.day_of_week,
+    sections: updated.sections,
+  });
+}

--- a/app/api/routes-f/email-digest/schema.ts
+++ b/app/api/routes-f/email-digest/schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { VALID_SECTIONS } from "./sections";
+
+const DAYS = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const;
+
+export const getQuerySchema = z.object({
+  viewer_id: z.string().min(1, "viewer_id is required"),
+});
+
+export const putBodySchema = z.object({
+  viewer_id: z.string().min(1, "viewer_id is required"),
+  enabled: z.boolean().optional(),
+  day_of_week: z.enum(DAYS).optional(),
+  sections: z
+    .array(z.enum(VALID_SECTIONS as [string, ...string[]]))
+    .optional(),
+});

--- a/app/api/routes-f/email-digest/sections.ts
+++ b/app/api/routes-f/email-digest/sections.ts
@@ -1,0 +1,17 @@
+import type { DigestSection } from "./types";
+
+export const VALID_SECTIONS: DigestSection[] = [
+  "live_alerts",
+  "new_clips",
+  "tip_summary",
+  "recommendations",
+];
+
+export function isValidSection(s: string): s is DigestSection {
+  return (VALID_SECTIONS as string[]).includes(s);
+}
+
+export function validateSections(sections: string[]): DigestSection[] | null {
+  if (!sections.every(isValidSection)) return null;
+  return sections as DigestSection[];
+}

--- a/app/api/routes-f/email-digest/seed.ts
+++ b/app/api/routes-f/email-digest/seed.ts
@@ -1,0 +1,22 @@
+import type { DigestPreferences } from "./types";
+
+export const SEED_PREFS: Record<string, DigestPreferences> = {
+  viewer_001: {
+    viewer_id: "viewer_001",
+    enabled: true,
+    day_of_week: "monday",
+    sections: ["live_alerts", "tip_summary"],
+  },
+  viewer_002: {
+    viewer_id: "viewer_002",
+    enabled: false,
+    day_of_week: "friday",
+    sections: ["new_clips", "recommendations"],
+  },
+  viewer_003: {
+    viewer_id: "viewer_003",
+    enabled: true,
+    day_of_week: "wednesday",
+    sections: ["live_alerts", "new_clips", "tip_summary", "recommendations"],
+  },
+};

--- a/app/api/routes-f/email-digest/store.ts
+++ b/app/api/routes-f/email-digest/store.ts
@@ -1,0 +1,20 @@
+import type { DigestPreferences } from "./types";
+import { SEED_PREFS } from "./seed";
+
+let _store: Map<string, DigestPreferences> = new Map(
+  Object.entries(SEED_PREFS).map(([k, v]) => [k, { ...v, sections: [...v.sections] }])
+);
+
+export function getPrefs(viewerId: string): DigestPreferences | undefined {
+  return _store.get(viewerId);
+}
+
+export function upsertPrefs(prefs: DigestPreferences): void {
+  _store.set(prefs.viewer_id, prefs);
+}
+
+export function resetStore(): void {
+  _store = new Map(
+    Object.entries(SEED_PREFS).map(([k, v]) => [k, { ...v, sections: [...v.sections] }])
+  );
+}

--- a/app/api/routes-f/email-digest/types.ts
+++ b/app/api/routes-f/email-digest/types.ts
@@ -1,0 +1,28 @@
+export type DigestSection =
+  | "live_alerts"
+  | "new_clips"
+  | "tip_summary"
+  | "recommendations";
+
+export type DayOfWeek =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday";
+
+export interface DigestPreferences {
+  viewer_id: string;
+  enabled: boolean;
+  day_of_week: DayOfWeek;
+  sections: DigestSection[];
+}
+
+export interface DigestUpdateRequest {
+  viewer_id: string;
+  enabled?: boolean;
+  day_of_week?: DayOfWeek;
+  sections?: DigestSection[];
+}

--- a/app/api/routes-f/notifications/mark-read/helpers.ts
+++ b/app/api/routes-f/notifications/mark-read/helpers.ts
@@ -1,0 +1,25 @@
+import { getStore } from "./store";
+
+export function markById(viewerId: string, ids: string[]): number {
+  const store = getStore();
+  let count = 0;
+  for (const n of store) {
+    if (n.viewer_id === viewerId && ids.includes(n.id) && !n.read) {
+      n.read = true;
+      count++;
+    }
+  }
+  return count;
+}
+
+export function markAll(viewerId: string): number {
+  const store = getStore();
+  let count = 0;
+  for (const n of store) {
+    if (n.viewer_id === viewerId && !n.read) {
+      n.read = true;
+      count++;
+    }
+  }
+  return count;
+}

--- a/app/api/routes-f/notifications/mark-read/route.ts
+++ b/app/api/routes-f/notifications/mark-read/route.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/routes-f/notifications/mark-read
+ *
+ * Mark one or many notifications as read for a viewer.
+ *
+ * Body:
+ *   { viewer_id, ids?: string[], all?: boolean }
+ *   — Provide ids (non-empty array) OR all=true; not both required.
+ *
+ * Response:
+ *   { updated_count: number }
+ *
+ * Error responses:
+ *   400 — missing/invalid body
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { markReadSchema } from "./schema";
+import { markById, markAll } from "./helpers";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, markReadSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { viewer_id, ids, all } = bodyResult.data;
+
+  const updated_count =
+    all === true ? markAll(viewer_id) : markById(viewer_id, ids ?? []);
+
+  return NextResponse.json({ updated_count });
+}

--- a/app/api/routes-f/notifications/mark-read/schema.ts
+++ b/app/api/routes-f/notifications/mark-read/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const markReadSchema = z
+  .object({
+    viewer_id: z.string().min(1, "viewer_id is required"),
+    ids: z.array(z.string().min(1)).optional(),
+    all: z.boolean().optional(),
+  })
+  .refine(
+    (data) => data.all === true || (Array.isArray(data.ids) && data.ids.length > 0),
+    { message: "Provide ids (non-empty array) or all=true" }
+  );

--- a/app/api/routes-f/notifications/mark-read/store.ts
+++ b/app/api/routes-f/notifications/mark-read/store.ts
@@ -1,0 +1,68 @@
+import type { Notification } from "./types";
+
+const SEED: Notification[] = [
+  {
+    id: "n_001",
+    viewer_id: "viewer_001",
+    type: "tip_received",
+    body: "CryptoKing tipped you 5 XLM during your last stream.",
+    link: "/dashboard/tips",
+    read: false,
+    created_at: "2026-06-26T10:00:00Z",
+  },
+  {
+    id: "n_002",
+    viewer_id: "viewer_001",
+    type: "new_subscriber",
+    body: "stellarfan99 just subscribed to your channel.",
+    link: "/dashboard/subscribers",
+    read: false,
+    created_at: "2026-06-26T09:45:00Z",
+  },
+  {
+    id: "n_003",
+    viewer_id: "viewer_001",
+    type: "stream_live",
+    body: "moonshot_dev went live — 'Building on Stellar'",
+    link: "/watch/moonshot_dev",
+    read: true,
+    created_at: "2026-06-26T09:00:00Z",
+  },
+  {
+    id: "n_004",
+    viewer_id: "viewer_001",
+    type: "clip_featured",
+    body: "Your clip 'Soroban deploy in 60s' was featured on the front page.",
+    link: "/clips/n_featured_01",
+    read: false,
+    created_at: "2026-06-25T22:30:00Z",
+  },
+  {
+    id: "n_005",
+    viewer_id: "viewer_002",
+    type: "payment_confirmed",
+    body: "Your USDC payout of $12.50 was confirmed on-chain.",
+    link: "/dashboard/payouts",
+    read: false,
+    created_at: "2026-06-25T18:00:00Z",
+  },
+  {
+    id: "n_006",
+    viewer_id: "viewer_002",
+    type: "system",
+    body: "Your account was verified successfully.",
+    link: "/settings",
+    read: false,
+    created_at: "2026-06-24T12:00:00Z",
+  },
+];
+
+let _store: Notification[] = SEED.map((n) => ({ ...n }));
+
+export function getStore(): Notification[] {
+  return _store;
+}
+
+export function resetStore(): void {
+  _store = SEED.map((n) => ({ ...n }));
+}

--- a/app/api/routes-f/notifications/mark-read/types.ts
+++ b/app/api/routes-f/notifications/mark-read/types.ts
@@ -1,0 +1,27 @@
+export type NotificationType =
+  | "tip_received"
+  | "new_subscriber"
+  | "stream_live"
+  | "clip_featured"
+  | "payment_confirmed"
+  | "system";
+
+export interface Notification {
+  id: string;
+  viewer_id: string;
+  type: NotificationType;
+  body: string;
+  link: string;
+  read: boolean;
+  created_at: string;
+}
+
+export interface MarkReadRequest {
+  viewer_id: string;
+  ids?: string[];
+  all?: boolean;
+}
+
+export interface MarkReadResponse {
+  updated_count: number;
+}

--- a/app/api/routes-f/retention-curve/compute.ts
+++ b/app/api/routes-f/retention-curve/compute.ts
@@ -1,0 +1,14 @@
+import type { ViewerSample, RetentionPoint } from "./types";
+
+export function normalizeRetention(samples: ViewerSample[]): RetentionPoint[] {
+  if (samples.length === 0) return [];
+
+  const peak = Math.max(...samples.map((s) => s.viewer_count));
+
+  return samples.map((s) => ({
+    minute: s.minute,
+    viewer_count: s.viewer_count,
+    percent_of_peak:
+      peak === 0 ? 0 : Math.round((s.viewer_count / peak) * 10000) / 100,
+  }));
+}

--- a/app/api/routes-f/retention-curve/route.ts
+++ b/app/api/routes-f/retention-curve/route.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /api/routes-f/retention-curve?stream_id=
+ *
+ * Returns a viewer-retention curve for a given stream, normalised against
+ * peak viewer count so each point shows the percentage of the audience
+ * that was still watching at that minute.
+ *
+ * Query params:
+ *   stream_id — required
+ *
+ * Response:
+ *   { points: [{ minute, percent_of_peak, viewer_count }] }
+ *
+ * Error responses:
+ *   400 — missing/invalid query params
+ *   404 — stream not found
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { querySchema } from "./schema";
+import { SEED_SAMPLES } from "./seed";
+import { normalizeRetention } from "./compute";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { stream_id } = queryResult.data;
+  const samples = SEED_SAMPLES[stream_id];
+
+  if (!samples) {
+    return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ points: normalizeRetention(samples) });
+}

--- a/app/api/routes-f/retention-curve/schema.ts
+++ b/app/api/routes-f/retention-curve/schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const querySchema = z.object({
+  stream_id: z.string().min(1, "stream_id is required"),
+});

--- a/app/api/routes-f/retention-curve/seed.ts
+++ b/app/api/routes-f/retention-curve/seed.ts
@@ -1,0 +1,34 @@
+import type { ViewerSample } from "./types";
+
+/** stream_drop: strong audience drop-off after the first 10 minutes */
+const STREAM_DROP: ViewerSample[] = [
+  { minute: 0, viewer_count: 1200 },
+  { minute: 5, viewer_count: 980 },
+  { minute: 10, viewer_count: 850 },
+  { minute: 15, viewer_count: 600 },
+  { minute: 20, viewer_count: 410 },
+  { minute: 25, viewer_count: 280 },
+  { minute: 30, viewer_count: 190 },
+  { minute: 45, viewer_count: 95 },
+  { minute: 60, viewer_count: 40 },
+];
+
+/** stream_steady: audience remains roughly flat throughout */
+const STREAM_STEADY: ViewerSample[] = [
+  { minute: 0, viewer_count: 750 },
+  { minute: 10, viewer_count: 740 },
+  { minute: 20, viewer_count: 730 },
+  { minute: 30, viewer_count: 725 },
+  { minute: 40, viewer_count: 718 },
+  { minute: 50, viewer_count: 710 },
+  { minute: 60, viewer_count: 700 },
+];
+
+/** stream_single: only one data point (edge case) */
+const STREAM_SINGLE: ViewerSample[] = [{ minute: 0, viewer_count: 500 }];
+
+export const SEED_SAMPLES: Record<string, ViewerSample[]> = {
+  stream_drop: STREAM_DROP,
+  stream_steady: STREAM_STEADY,
+  stream_single: STREAM_SINGLE,
+};

--- a/app/api/routes-f/retention-curve/types.ts
+++ b/app/api/routes-f/retention-curve/types.ts
@@ -1,0 +1,14 @@
+export interface ViewerSample {
+  minute: number;
+  viewer_count: number;
+}
+
+export interface RetentionPoint {
+  minute: number;
+  percent_of_peak: number;
+  viewer_count: number;
+}
+
+export interface RetentionCurveResponse {
+  points: RetentionPoint[];
+}


### PR DESCRIPTION
Closes #1020

---

Closes #1021

---

Closes #1015

---

Closes #1017

---

## Summary

All four routes are self-contained under `app/api/routes-f/` with no imports from outside that folder. Each directory carries its own types, seed data, in-memory store, helpers, Zod schema, route handler, and tests.

- **#1015 — Mark notifications read**: `POST /api/routes-f/notifications/mark-read` accepts `{ viewer_id, ids?, all? }` and returns `{ updated_count }`. `all=true` marks every notification for the viewer; `ids` marks a specific subset. Returns 400 if neither is provided or `ids` is empty. Cross-viewer isolation is enforced.

- **#1017 — Email digest opt-in**: `GET /api/routes-f/email-digest?viewer_id=` returns `{ enabled, day_of_week, sections }`; `PUT` with `{ viewer_id, enabled?, day_of_week?, sections? }` performs a partial update. Sections are validated against the `live_alerts | new_clips | tip_summary | recommendations` enum. Unknown viewers receive sensible disabled defaults on GET and are created on PUT.

- **#1020 — Creator dashboard overview**: `GET /api/routes-f/creator-dashboard?creator_id=` returns `{ follower_count, monthly_recurring_revenue_usdc, last_stream_at, total_tips_lifetime_usdc, active_subs }`. All USDC values are rounded to 2 decimal places via a dedicated `roundUsdc` helper. Returns 404 for unknown creators.

- **#1021 — Viewer retention curve**: `GET /api/routes-f/retention-curve?stream_id=` returns `{ points: [{ minute, percent_of_peak, viewer_count }] }`. Viewer counts are normalised against the per-stream peak so `percent_of_peak` is always in `[0, 100]`, rounded to 2 decimal places. Handles zero-peak and single-sample streams safely.

## Test plan

- [ ] `POST /mark-read` with `{ viewer_id: "viewer_001", ids: ["n_001"] }` → `{ updated_count: 1 }`
- [ ] `POST /mark-read` with `{ viewer_id: "viewer_001", all: true }` → marks all 3 unread notifications, returns `{ updated_count: 3 }`
- [ ] `POST /mark-read` with no `ids` or `all` → 400
- [ ] `GET /email-digest?viewer_id=viewer_001` → `{ enabled: true, day_of_week: "monday", sections: [...] }`
- [ ] `PUT /email-digest` with `{ viewer_id: "viewer_001", enabled: false }` → toggles flag, preserves other fields
- [ ] `PUT /email-digest` with an unrecognised section value → 400
- [ ] `GET /creator-dashboard?creator_id=creator_003` → `last_stream_at: null`, `total_tips_lifetime_usdc: 12.33`
- [ ] `GET /creator-dashboard?creator_id=creator_999` → 404
- [ ] `GET /retention-curve?stream_id=stream_drop` → first point 100%, last point < 50%, monotonically decreasing
- [ ] `GET /retention-curve?stream_id=stream_steady` → all points ≥ 90%
- [ ] `GET /retention-curve?stream_id=stream_single` → single point at 100%
- [ ] `GET /retention-curve?stream_id=unknown` → 404