### PR TITLE
feat(routes-f): implement stinger selection, offline screen, viewing streak, and chat commands

### DIFF
--- a/app/api/routes-f/chat-commands/__tests__/route.test.ts
+++ b/app/api/routes-f/chat-commands/__tests__/route.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for app/api/routes-f/chat-commands/
+ * Covers: GET commands, POST add, execute (with template interpolation), toggle
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { POST as executePost } from "../execute/route";
+import { POST as togglePost } from "../toggle/route";
+import { commandStore } from "../store";
+
+function makeGetReq(creator_id: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/chat-commands?creator_id=${creator_id}`
+  );
+}
+
+function makePost(url: string, body: unknown) {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  delete commandStore["creator_test"];
+});
+
+describe("GET /api/routes-f/chat-commands", () => {
+  it("returns 400 when creator_id missing", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/routes-f/chat-commands"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty array for unknown creator", async () => {
+    const res = await GET(makeGetReq("creator_unknown_xyz"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.commands).toHaveLength(0);
+  });
+
+  it("returns commands for known creator", async () => {
+    const res = await GET(makeGetReq("creator_alice"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.commands.length).toBeGreaterThan(0);
+    expect(body.commands[0]).toHaveProperty("trigger");
+  });
+});
+
+describe("POST /api/routes-f/chat-commands (add)", () => {
+  it("adds a new command", async () => {
+    const res = await POST(
+      makePost("http://localhost/api/routes-f/chat-commands", {
+        creator_id: "creator_test",
+        trigger: "!website",
+        response_template: "Visit us at https://streamfi.io",
+        cooldown_seconds: 15,
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.command.trigger).toBe("!website");
+  });
+
+  it("returns 409 on duplicate trigger", async () => {
+    commandStore["creator_test"] = [
+      {
+        id: "cmd_dup",
+        trigger: "!hello",
+        response_template: "Hello!",
+        cooldown_seconds: 5,
+        enabled: true,
+      },
+    ];
+    const res = await POST(
+      makePost("http://localhost/api/routes-f/chat-commands", {
+        creator_id: "creator_test",
+        trigger: "!hello",
+        response_template: "Hi again!",
+      })
+    );
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("POST /api/routes-f/chat-commands/execute", () => {
+  it("executes command with template interpolation", async () => {
+    const res = await executePost(
+      makePost("http://localhost/api/routes-f/chat-commands/execute", {
+        creator_id: "creator_alice",
+        trigger: "!so",
+        context: { user: "viewer_bob" },
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.response).toContain("viewer_bob");
+  });
+
+  it("returns 404 for unknown trigger", async () => {
+    const res = await executePost(
+      makePost("http://localhost/api/routes-f/chat-commands/execute", {
+        creator_id: "creator_alice",
+        trigger: "!nonexistent",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for disabled command", async () => {
+    const res = await executePost(
+      makePost("http://localhost/api/routes-f/chat-commands/execute", {
+        creator_id: "creator_alice",
+        trigger: "!tip",
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/routes-f/chat-commands/toggle", () => {
+  it("enables a disabled command", async () => {
+    const res = await togglePost(
+      makePost("http://localhost/api/routes-f/chat-commands/toggle", {
+        creator_id: "creator_alice",
+        command_id: "cmd_3",
+        enabled: true,
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.command.enabled).toBe(true);
+  });
+
+  it("returns 404 for unknown command_id", async () => {
+    const res = await togglePost(
+      makePost("http://localhost/api/routes-f/chat-commands/toggle", {
+        creator_id: "creator_alice",
+        command_id: "cmd_nonexistent",
+        enabled: true,
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/routes-f/chat-commands/execute/route.ts
+++ b/app/api/routes-f/chat-commands/execute/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { executeCommandSchema } from "../schema";
+import { commandStore, interpolate } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, executeCommandSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, trigger, context } = bodyResult.data;
+
+  const commands = commandStore[creator_id] ?? [];
+  const command = commands.find((c) => c.trigger === trigger);
+
+  if (!command) {
+    return NextResponse.json(
+      { error: `Command '${trigger}' not found` },
+      { status: 404 }
+    );
+  }
+
+  if (!command.enabled) {
+    return NextResponse.json(
+      { error: `Command '${trigger}' is disabled` },
+      { status: 403 }
+    );
+  }
+
+  const response = interpolate(command.response_template, context);
+
+  return NextResponse.json({
+    response,
+    trigger: command.trigger,
+    cooldown_seconds: command.cooldown_seconds,
+  });
+}

--- a/app/api/routes-f/chat-commands/route.ts
+++ b/app/api/routes-f/chat-commands/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET  /api/routes-f/chat-commands?creator_id=
+ *   Returns [{ id, trigger, response_template, cooldown_seconds, enabled }]
+ *
+ * POST /api/routes-f/chat-commands
+ *   Body: { creator_id, trigger, response_template, cooldown_seconds?, enabled? }
+ *   Adds a new command to a creator's command list.
+ *
+ * POST /api/routes-f/chat-commands/execute
+ *   Body: { creator_id, trigger, context? }
+ *   Executes a command (resolves template variables) and returns the response string.
+ *
+ * POST /api/routes-f/chat-commands/toggle
+ *   Body: { creator_id, command_id, enabled }
+ *   Enables or disables a chat command.
+ *
+ * Scope: all files live inside app/api/routes-f/chat-commands/
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+import { querySchema, addCommandSchema } from "./schema";
+import { commandStore } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { creator_id } = queryResult.data;
+
+  const commands = commandStore[creator_id] ?? [];
+  return NextResponse.json({ commands });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, addCommandSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, trigger, response_template, cooldown_seconds, enabled } =
+    bodyResult.data;
+
+  if (!commandStore[creator_id]) {
+    commandStore[creator_id] = [];
+  }
+
+  const existing = commandStore[creator_id].find((c) => c.trigger === trigger);
+  if (existing) {
+    return NextResponse.json(
+      { error: `Command '${trigger}' already exists` },
+      { status: 409 }
+    );
+  }
+
+  const id = `cmd_${Date.now()}`;
+  const newCommand = {
+    id,
+    trigger,
+    response_template,
+    cooldown_seconds: cooldown_seconds ?? 5,
+    enabled: enabled ?? true,
+  };
+
+  commandStore[creator_id].push(newCommand);
+  return NextResponse.json({ command: newCommand }, { status: 201 });
+}

--- a/app/api/routes-f/chat-commands/schema.ts
+++ b/app/api/routes-f/chat-commands/schema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const querySchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+});
+
+export const addCommandSchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+  trigger: z
+    .string()
+    .min(2, "trigger must be at least 2 chars")
+    .regex(/^![\w-]+$/, "trigger must start with ! and contain only word chars"),
+  response_template: z.string().min(1, "response_template is required"),
+  cooldown_seconds: z.number().int().min(0).default(5),
+  enabled: z.boolean().default(true),
+});
+
+export const executeCommandSchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+  trigger: z.string().min(1, "trigger is required"),
+  context: z.record(z.string()).optional(),
+});
+
+export const toggleCommandSchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+  command_id: z.string().min(1, "command_id is required"),
+  enabled: z.boolean(),
+});

--- a/app/api/routes-f/chat-commands/store.ts
+++ b/app/api/routes-f/chat-commands/store.ts
@@ -1,0 +1,38 @@
+import type { ChatCommand } from "./types";
+
+// Store keyed by creator_id
+export const commandStore: Record<string, ChatCommand[]> = {
+  creator_alice: [
+    {
+      id: "cmd_1",
+      trigger: "!discord",
+      response_template: "Join our Discord at https://discord.gg/streamfi",
+      cooldown_seconds: 30,
+      enabled: true,
+    },
+    {
+      id: "cmd_2",
+      trigger: "!so",
+      response_template: "Shoutout to {{user}}! Go check them out!",
+      cooldown_seconds: 10,
+      enabled: true,
+    },
+    {
+      id: "cmd_3",
+      trigger: "!tip",
+      response_template: "Tip with XLM or USDC via StreamFi — every tip counts!",
+      cooldown_seconds: 60,
+      enabled: false,
+    },
+  ],
+};
+
+/**
+ * Interpolate {{variable}} placeholders in a template string.
+ */
+export function interpolate(
+  template: string,
+  context: Record<string, string> = {}
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => context[key] ?? `{{${key}}}`);
+}

--- a/app/api/routes-f/chat-commands/toggle/route.ts
+++ b/app/api/routes-f/chat-commands/toggle/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { toggleCommandSchema } from "../schema";
+import { commandStore } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, toggleCommandSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, command_id, enabled } = bodyResult.data;
+
+  const commands = commandStore[creator_id] ?? [];
+  const command = commands.find((c) => c.id === command_id);
+
+  if (!command) {
+    return NextResponse.json(
+      { error: `Command '${command_id}' not found` },
+      { status: 404 }
+    );
+  }
+
+  command.enabled = enabled;
+  return NextResponse.json({ command });
+}

--- a/app/api/routes-f/chat-commands/types.ts
+++ b/app/api/routes-f/chat-commands/types.ts
@@ -1,0 +1,19 @@
+export interface ChatCommand {
+  id: string;
+  trigger: string; // e.g. "!discord"
+  response_template: string; // e.g. "Join our Discord at {{url}}"
+  cooldown_seconds: number;
+  enabled: boolean;
+}
+
+export interface ExecuteCommandRequest {
+  creator_id: string;
+  trigger: string;
+  context?: Record<string, string>; // template variable values
+}
+
+export interface ExecuteCommandResponse {
+  response: string;
+  trigger: string;
+  cooldown_seconds: number;
+}

--- a/app/api/routes-f/offline-screen/__tests__/route.test.ts
+++ b/app/api/routes-f/offline-screen/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for app/api/routes-f/offline-screen/
+ * Covers: GET config, POST set config, validation
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { offlineScreenStore } from "../store";
+
+function makeGetReq(creator_id: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/offline-screen?creator_id=${creator_id}`
+  );
+}
+
+function makePostReq(body: unknown) {
+  return new NextRequest(`http://localhost/api/routes-f/offline-screen`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  delete offlineScreenStore["creator_new"];
+});
+
+describe("GET /api/routes-f/offline-screen", () => {
+  it("returns 400 when creator_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/offline-screen");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown creator", async () => {
+    const res = await GET(makeGetReq("creator_unknown_xyz"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns config for known creator", async () => {
+    const res = await GET(makeGetReq("creator_alice"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe("image");
+    expect(body.source_url).toBeDefined();
+  });
+});
+
+describe("POST /api/routes-f/offline-screen", () => {
+  it("sets an image offline screen", async () => {
+    const res = await POST(
+      makePostReq({
+        creator_id: "creator_new",
+        type: "image",
+        source_url: "https://cdn.example.com/banner.png",
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe("image");
+    expect(body.source_url).toBe("https://cdn.example.com/banner.png");
+  });
+
+  it("sets a vod offline screen", async () => {
+    const res = await POST(
+      makePostReq({ creator_id: "creator_new", type: "vod", vod_id: "vod_abc" })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe("vod");
+    expect(body.vod_id).toBe("vod_abc");
+  });
+
+  it("returns 400 when image type lacks source_url", async () => {
+    const res = await POST(
+      makePostReq({ creator_id: "creator_new", type: "image" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when vod type lacks vod_id", async () => {
+    const res = await POST(
+      makePostReq({ creator_id: "creator_new", type: "vod" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("sets type none without extra fields", async () => {
+    const res = await POST(
+      makePostReq({ creator_id: "creator_new", type: "none" })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.type).toBe("none");
+  });
+});

--- a/app/api/routes-f/offline-screen/route.ts
+++ b/app/api/routes-f/offline-screen/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET  /api/routes-f/offline-screen?creator_id=
+ *   Returns { type: image|clip|vod|none, source_url?, vod_id? }
+ *
+ * POST /api/routes-f/offline-screen
+ *   Body: { creator_id, type, source_url?, vod_id? }
+ *   Sets or updates the offline screen configuration for a creator.
+ *   - type=image|clip requires source_url
+ *   - type=vod requires vod_id
+ *
+ * Scope: all files live inside app/api/routes-f/offline-screen/
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+import { querySchema, setSchema } from "./schema";
+import { offlineScreenStore } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { creator_id } = queryResult.data;
+
+  if (!offlineScreenStore[creator_id]) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(offlineScreenStore[creator_id]);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, setSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, type, source_url, vod_id } = bodyResult.data;
+
+  const config: typeof offlineScreenStore[string] = { type };
+  if (source_url) config.source_url = source_url;
+  if (vod_id) config.vod_id = vod_id;
+
+  offlineScreenStore[creator_id] = config;
+
+  return NextResponse.json(offlineScreenStore[creator_id]);
+}

--- a/app/api/routes-f/offline-screen/schema.ts
+++ b/app/api/routes-f/offline-screen/schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const querySchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+});
+
+export const setSchema = z
+  .object({
+    creator_id: z.string().min(1, "creator_id is required"),
+    type: z.enum(["image", "clip", "vod", "none"]),
+    source_url: z.string().url().optional(),
+    vod_id: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if ((data.type === "image" || data.type === "clip") && !data.source_url) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "source_url is required for type image or clip",
+        path: ["source_url"],
+      });
+    }
+    if (data.type === "vod" && !data.vod_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "vod_id is required for type vod",
+        path: ["vod_id"],
+      });
+    }
+  });

--- a/app/api/routes-f/offline-screen/store.ts
+++ b/app/api/routes-f/offline-screen/store.ts
@@ -1,0 +1,16 @@
+import type { OfflineScreen } from "./types";
+
+// In-memory store keyed by creator_id
+export const offlineScreenStore: Record<string, OfflineScreen> = {
+  creator_alice: {
+    type: "image",
+    source_url: "https://cdn.streamfi.io/offline/alice-banner.png",
+  },
+  creator_bob: {
+    type: "vod",
+    vod_id: "vod_xyz123",
+  },
+  creator_carol: {
+    type: "none",
+  },
+};

--- a/app/api/routes-f/offline-screen/types.ts
+++ b/app/api/routes-f/offline-screen/types.ts
@@ -1,0 +1,14 @@
+export type OfflineScreenType = "image" | "clip" | "vod" | "none";
+
+export interface OfflineScreen {
+  type: OfflineScreenType;
+  source_url?: string;
+  vod_id?: string;
+}
+
+export interface SetOfflineScreenRequest {
+  creator_id: string;
+  type: OfflineScreenType;
+  source_url?: string;
+  vod_id?: string;
+}

--- a/app/api/routes-f/stinger/__tests__/route.test.ts
+++ b/app/api/routes-f/stinger/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for app/api/routes-f/stinger/
+ * Covers: GET library, POST /select, POST /add, library cap
+ */
+
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { stingerStore, LIBRARY_CAP } from "../store";
+
+function makeGetReq(creator_id: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/stinger?creator_id=${creator_id}`
+  );
+}
+
+function makePostReq(path: string, body: unknown) {
+  return new NextRequest(`http://localhost/api/routes-f/stinger/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  // Reset store state for creator_test
+  delete stingerStore["creator_test"];
+});
+
+describe("GET /api/routes-f/stinger", () => {
+  it("returns 400 when creator_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/stinger");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("auto-creates a new creator entry with default stinger", async () => {
+    const res = await GET(makeGetReq("creator_test"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.active).toBeNull();
+    expect(body.library).toHaveLength(1);
+    expect(body.library[0].id).toBe("default");
+  });
+
+  it("returns existing library for known creator", async () => {
+    const res = await GET(makeGetReq("creator_alice"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.library.length).toBeGreaterThan(1);
+    expect(body.active).toBe("default");
+  });
+});
+
+describe("POST /api/routes-f/stinger (select)", () => {
+  it("selects a valid stinger from library", async () => {
+    const req = makePostReq("select", {
+      creator_id: "creator_alice",
+      stinger_id: "flash-blue",
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.active).toBe("flash-blue");
+  });
+
+  it("returns 404 when stinger not in library", async () => {
+    const req = makePostReq("select", {
+      creator_id: "creator_alice",
+      stinger_id: "nonexistent-stinger",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/routes-f/stinger (add)", () => {
+  it("adds a new stinger to library", async () => {
+    const req = makePostReq("add", {
+      creator_id: "creator_test",
+      name: "My Custom Stinger",
+      url: "https://cdn.example.com/stinger.webm",
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.stinger.name).toBe("My Custom Stinger");
+    expect(body.library.length).toBe(2); // default + new one
+  });
+
+  it("enforces library cap", async () => {
+    stingerStore["creator_capped"] = {
+      active: null,
+      library: Array.from({ length: LIBRARY_CAP }, (_, i) => ({
+        id: `s${i}`,
+        name: `Stinger ${i}`,
+        url: `https://cdn.example.com/s${i}.webm`,
+      })),
+    };
+
+    const req = makePostReq("add", {
+      creator_id: "creator_capped",
+      name: "One Too Many",
+      url: "https://cdn.example.com/extra.webm",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+  });
+});

--- a/app/api/routes-f/stinger/add/route.ts
+++ b/app/api/routes-f/stinger/add/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { addSchema } from "../schema";
+import { stingerStore, DEFAULT_STINGER, LIBRARY_CAP } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, addSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, name, url: stingerUrl } = bodyResult.data;
+
+  if (!stingerStore[creator_id]) {
+    stingerStore[creator_id] = { active: null, library: [DEFAULT_STINGER] };
+  }
+
+  const state = stingerStore[creator_id];
+
+  if (state.library.length >= LIBRARY_CAP) {
+    return NextResponse.json(
+      { error: `Library cap of ${LIBRARY_CAP} stingers reached` },
+      { status: 422 }
+    );
+  }
+
+  const id = `custom-${Date.now()}`;
+  const newStinger = { id, name, url: stingerUrl };
+  state.library.push(newStinger);
+
+  return NextResponse.json({ stinger: newStinger, library: state.library }, { status: 201 });
+}

--- a/app/api/routes-f/stinger/route.ts
+++ b/app/api/routes-f/stinger/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET  /api/routes-f/stinger?creator_id=
+ *   Returns { active: stinger_id | null, library: [{ id, name, url }] }
+ *
+ * POST /api/routes-f/stinger/select
+ *   Body: { creator_id, stinger_id }
+ *   Sets the active stinger for the creator.
+ *
+ * POST /api/routes-f/stinger/add
+ *   Body: { creator_id, name, url }
+ *   Adds a new stinger to the creator's library (cap: 10).
+ *
+ * Scope: all files live inside app/api/routes-f/stinger/
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery, validateBody } from "@/app/api/routes-f/_lib/validate";
+import { querySchema, selectSchema, addSchema } from "./schema";
+import { stingerStore, DEFAULT_STINGER, LIBRARY_CAP } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { creator_id } = queryResult.data;
+
+  if (!stingerStore[creator_id]) {
+    stingerStore[creator_id] = { active: null, library: [DEFAULT_STINGER] };
+  }
+
+  const state = stingerStore[creator_id];
+  return NextResponse.json({ active: state.active, library: state.library });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  const action = url.pathname.split("/").pop();
+
+  if (action === "select") {
+    const bodyResult = await validateBody(req, selectSchema);
+    if (bodyResult instanceof NextResponse) return bodyResult;
+
+    const { creator_id, stinger_id } = bodyResult.data;
+
+    if (!stingerStore[creator_id]) {
+      stingerStore[creator_id] = { active: null, library: [DEFAULT_STINGER] };
+    }
+
+    const state = stingerStore[creator_id];
+    const found = state.library.find((s) => s.id === stinger_id);
+    if (!found) {
+      return NextResponse.json(
+        { error: `Stinger '${stinger_id}' not found in library` },
+        { status: 404 }
+      );
+    }
+
+    state.active = stinger_id;
+    return NextResponse.json({ active: state.active, library: state.library });
+  }
+
+  if (action === "add") {
+    const bodyResult = await validateBody(req, addSchema);
+    if (bodyResult instanceof NextResponse) return bodyResult;
+
+    const { creator_id, name, url: stingerUrl } = bodyResult.data;
+
+    if (!stingerStore[creator_id]) {
+      stingerStore[creator_id] = { active: null, library: [DEFAULT_STINGER] };
+    }
+
+    const state = stingerStore[creator_id];
+
+    if (state.library.length >= LIBRARY_CAP) {
+      return NextResponse.json(
+        { error: `Library cap of ${LIBRARY_CAP} stingers reached` },
+        { status: 422 }
+      );
+    }
+
+    const id = `custom-${Date.now()}`;
+    const newStinger = { id, name, url: stingerUrl };
+    state.library.push(newStinger);
+
+    return NextResponse.json({ stinger: newStinger, library: state.library }, { status: 201 });
+  }
+
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}

--- a/app/api/routes-f/stinger/schema.ts
+++ b/app/api/routes-f/stinger/schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const querySchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+});
+
+export const selectSchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+  stinger_id: z.string().min(1, "stinger_id is required"),
+});
+
+export const addSchema = z.object({
+  creator_id: z.string().min(1, "creator_id is required"),
+  name: z.string().min(1, "name is required"),
+  url: z.string().url("url must be a valid URL"),
+});

--- a/app/api/routes-f/stinger/select/route.ts
+++ b/app/api/routes-f/stinger/select/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { selectSchema } from "../schema";
+import { stingerStore, DEFAULT_STINGER } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, selectSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { creator_id, stinger_id } = bodyResult.data;
+
+  if (!stingerStore[creator_id]) {
+    stingerStore[creator_id] = { active: null, library: [DEFAULT_STINGER] };
+  }
+
+  const state = stingerStore[creator_id];
+  const found = state.library.find((s) => s.id === stinger_id);
+  if (!found) {
+    return NextResponse.json(
+      { error: `Stinger '${stinger_id}' not found in library` },
+      { status: 404 }
+    );
+  }
+
+  state.active = stinger_id;
+  return NextResponse.json({ active: state.active, library: state.library });
+}

--- a/app/api/routes-f/stinger/store.ts
+++ b/app/api/routes-f/stinger/store.ts
@@ -1,0 +1,30 @@
+import type { Stinger } from "./types";
+
+export const DEFAULT_STINGER: Stinger = {
+  id: "default",
+  name: "StreamFi Default",
+  url: "https://cdn.streamfi.io/stingers/default.webm",
+};
+
+export interface CreatorStingerState {
+  active: string | null;
+  library: Stinger[];
+}
+
+// In-memory store keyed by creator_id
+export const stingerStore: Record<string, CreatorStingerState> = {
+  creator_alice: {
+    active: "default",
+    library: [
+      DEFAULT_STINGER,
+      { id: "flash-blue", name: "Flash Blue", url: "https://cdn.streamfi.io/stingers/flash-blue.webm" },
+      { id: "glitch-red", name: "Glitch Red", url: "https://cdn.streamfi.io/stingers/glitch-red.webm" },
+    ],
+  },
+  creator_bob: {
+    active: null,
+    library: [DEFAULT_STINGER],
+  },
+};
+
+export const LIBRARY_CAP = 10;

--- a/app/api/routes-f/stinger/types.ts
+++ b/app/api/routes-f/stinger/types.ts
@@ -1,0 +1,21 @@
+export interface Stinger {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export interface StingerLibraryResponse {
+  active: string | null;
+  library: Stinger[];
+}
+
+export interface SelectStingerRequest {
+  creator_id: string;
+  stinger_id: string;
+}
+
+export interface AddStingerRequest {
+  creator_id: string;
+  name: string;
+  url: string;
+}

--- a/app/api/routes-f/viewing-streak/__tests__/route.test.ts
+++ b/app/api/routes-f/viewing-streak/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for app/api/routes-f/viewing-streak/
+ * Covers: GET streak, POST check-in (extend, reset, duplicate)
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { POST } from "../check-in/route";
+import { streakStore, storeKey } from "../store";
+
+function makeGetReq(viewer_id: string, creator_id: string) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/viewing-streak?viewer_id=${viewer_id}&creator_id=${creator_id}`
+  );
+}
+
+function makeCheckIn(body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/routes-f/viewing-streak/check-in`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => {
+  delete streakStore[storeKey("viewer_test", "creator_test")];
+});
+
+describe("GET /api/routes-f/viewing-streak", () => {
+  it("returns 400 when params are missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/viewing-streak");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown pair", async () => {
+    const res = await GET(makeGetReq("unknown_viewer", "unknown_creator"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns streak for known pair", async () => {
+    const res = await GET(makeGetReq("viewer_jane", "creator_alice"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.current_streak).toBeGreaterThan(0);
+    expect(body.longest_streak).toBeGreaterThanOrEqual(body.current_streak);
+  });
+});
+
+describe("POST /api/routes-f/viewing-streak/check-in", () => {
+  it("starts a new streak on first check-in", async () => {
+    const res = await POST(
+      makeCheckIn({
+        viewer_id: "viewer_test",
+        creator_id: "creator_test",
+        on_date: "2026-06-01",
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.current_streak).toBe(1);
+    expect(body.longest_streak).toBe(1);
+  });
+
+  it("extends streak on consecutive day", async () => {
+    streakStore[storeKey("viewer_test", "creator_test")] = {
+      viewer_id: "viewer_test",
+      creator_id: "creator_test",
+      current_streak: 3,
+      longest_streak: 5,
+      last_check_in: "2026-06-10",
+    };
+
+    const res = await POST(
+      makeCheckIn({
+        viewer_id: "viewer_test",
+        creator_id: "creator_test",
+        on_date: "2026-06-11",
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.current_streak).toBe(4);
+    expect(body.longest_streak).toBe(5); // still old record
+  });
+
+  it("resets streak when gap > 1 day", async () => {
+    streakStore[storeKey("viewer_test", "creator_test")] = {
+      viewer_id: "viewer_test",
+      creator_id: "creator_test",
+      current_streak: 10,
+      longest_streak: 10,
+      last_check_in: "2026-06-05",
+    };
+
+    const res = await POST(
+      makeCheckIn({
+        viewer_id: "viewer_test",
+        creator_id: "creator_test",
+        on_date: "2026-06-10",
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.current_streak).toBe(1);
+    expect(body.longest_streak).toBe(10); // preserved
+  });
+
+  it("does not double-count same-day check-in", async () => {
+    streakStore[storeKey("viewer_test", "creator_test")] = {
+      viewer_id: "viewer_test",
+      creator_id: "creator_test",
+      current_streak: 3,
+      longest_streak: 3,
+      last_check_in: "2026-06-11",
+    };
+
+    const res = await POST(
+      makeCheckIn({
+        viewer_id: "viewer_test",
+        creator_id: "creator_test",
+        on_date: "2026-06-11",
+      })
+    );
+    const body = await res.json();
+    expect(body.current_streak).toBe(3); // unchanged
+  });
+});

--- a/app/api/routes-f/viewing-streak/check-in/route.ts
+++ b/app/api/routes-f/viewing-streak/check-in/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateBody } from "@/app/api/routes-f/_lib/validate";
+import { checkInSchema } from "../schema";
+import { streakStore, storeKey, todayISO, daysDiff } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const bodyResult = await validateBody(req, checkInSchema);
+  if (bodyResult instanceof NextResponse) return bodyResult;
+
+  const { viewer_id, creator_id, on_date } = bodyResult.data;
+  const checkInDate = on_date ?? todayISO();
+  const key = storeKey(viewer_id, creator_id);
+
+  if (!streakStore[key]) {
+    // First ever check-in
+    streakStore[key] = {
+      viewer_id,
+      creator_id,
+      current_streak: 1,
+      longest_streak: 1,
+      last_check_in: checkInDate,
+    };
+    return NextResponse.json({
+      ...streakStore[key],
+      message: "Streak started! 🔥",
+    });
+  }
+
+  const record = streakStore[key];
+
+  if (record.last_check_in === checkInDate) {
+    return NextResponse.json({
+      ...record,
+      message: "Already checked in today.",
+    });
+  }
+
+  const diff = daysDiff(record.last_check_in, checkInDate);
+
+  if (diff === 1) {
+    record.current_streak += 1;
+    record.longest_streak = Math.max(record.longest_streak, record.current_streak);
+    record.last_check_in = checkInDate;
+    return NextResponse.json({
+      ...record,
+      message: `Streak extended to ${record.current_streak} days! 🔥`,
+    });
+  } else {
+    record.current_streak = 1;
+    record.last_check_in = checkInDate;
+    return NextResponse.json({
+      ...record,
+      message: "Streak reset. Starting fresh!",
+    });
+  }
+}

--- a/app/api/routes-f/viewing-streak/route.ts
+++ b/app/api/routes-f/viewing-streak/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET  /api/routes-f/viewing-streak?viewer_id=&creator_id=
+ *   Returns the current streak record for a (viewer, creator) pair.
+ *
+ * POST /api/routes-f/viewing-streak/check-in
+ *   Body: { viewer_id, creator_id, on_date?: "YYYY-MM-DD" }
+ *   Records a viewing check-in. Increments streak if check-in is consecutive
+ *   (within 1 day of last check-in), resets streak to 1 otherwise. Updates
+ *   longest_streak if needed.
+ *
+ * Scope: all files live inside app/api/routes-f/viewing-streak/
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { validateQuery } from "@/app/api/routes-f/_lib/validate";
+import { querySchema } from "./schema";
+import { streakStore, storeKey } from "./store";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const queryResult = validateQuery(searchParams, querySchema);
+  if (queryResult instanceof NextResponse) return queryResult;
+
+  const { viewer_id, creator_id } = queryResult.data;
+  const key = storeKey(viewer_id, creator_id);
+
+  if (!streakStore[key]) {
+    return NextResponse.json({ error: "Streak record not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(streakStore[key]);
+}

--- a/app/api/routes-f/viewing-streak/schema.ts
+++ b/app/api/routes-f/viewing-streak/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const querySchema = z.object({
+  viewer_id: z.string().min(1, "viewer_id is required"),
+  creator_id: z.string().min(1, "creator_id is required"),
+});
+
+export const checkInSchema = z.object({
+  viewer_id: z.string().min(1, "viewer_id is required"),
+  creator_id: z.string().min(1, "creator_id is required"),
+  on_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "on_date must be in YYYY-MM-DD format")
+    .optional(),
+});

--- a/app/api/routes-f/viewing-streak/store.ts
+++ b/app/api/routes-f/viewing-streak/store.ts
@@ -1,0 +1,36 @@
+import type { StreakRecord } from "./types";
+
+// Store key: `${viewer_id}:${creator_id}`
+export const streakStore: Record<string, StreakRecord> = {
+  "viewer_jane:creator_alice": {
+    viewer_id: "viewer_jane",
+    creator_id: "creator_alice",
+    current_streak: 5,
+    longest_streak: 12,
+    last_check_in: "2026-06-27",
+  },
+  "viewer_bob:creator_alice": {
+    viewer_id: "viewer_bob",
+    creator_id: "creator_alice",
+    current_streak: 1,
+    longest_streak: 3,
+    last_check_in: "2026-06-27",
+  },
+};
+
+export function storeKey(viewer_id: string, creator_id: string): string {
+  return `${viewer_id}:${creator_id}`;
+}
+
+export function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+/**
+ * Compute date difference in days between two YYYY-MM-DD strings.
+ */
+export function daysDiff(a: string, b: string): number {
+  const msA = new Date(a).getTime();
+  const msB = new Date(b).getTime();
+  return Math.round(Math.abs(msA - msB) / (1000 * 60 * 60 * 24));
+}

--- a/app/api/routes-f/viewing-streak/types.ts
+++ b/app/api/routes-f/viewing-streak/types.ts
@@ -1,0 +1,20 @@
+export interface StreakRecord {
+  viewer_id: string;
+  creator_id: string;
+  current_streak: number;
+  longest_streak: number;
+  last_check_in: string; // ISO date string YYYY-MM-DD
+}
+
+export interface CheckInRequest {
+  viewer_id: string;
+  creator_id: string;
+  on_date?: string; // optional override, defaults to today
+}
+
+export interface CheckInResponse {
+  current_streak: number;
+  longest_streak: number;
+  last_check_in: string;
+  message: string;
+}


### PR DESCRIPTION
This PR implements four new route handlers inside `app/api/routes-f/` — all files are scoped strictly to their respective subfolders.

### Proposed Changes

#### 1. Stream Stinger & Transition Selection (Closes #1103)
- **`GET /api/routes-f/stinger?creator_id=`** — returns `{ active: stinger_id | null, library: [{ id, name, url }] }`
- **`POST /api/routes-f/stinger/select`** — sets the active stinger for a creator; 404 if stinger not in library
- **`POST /api/routes-f/stinger/add`** — adds a new stinger to the library (cap: 10, returns 422 when limit is reached)
- Bundled a default stinger (`default`) in the in-memory store
- Tests cover: GET library, select valid/invalid stinger, add new stinger, cap enforcement

#### 2. Offline Screen Configuration (Closes #1104)
- **`GET /api/routes-f/offline-screen?creator_id=`** — returns `{ type: image|clip|vod|none, source_url?, vod_id? }`
- **`POST /api/routes-f/offline-screen`** — sets offline screen config with validation: `image`/`clip` requires `source_url`; `vod` requires `vod_id`
- Tests cover: GET known/unknown creator, set each type, validation failures

#### 3. Consecutive-Day Viewing Streak Tracking (Closes #1105)
- **`GET /api/routes-f/viewing-streak?viewer_id=&creator_id=`** — returns streak record for a (viewer, creator) pair
- **`POST /api/routes-f/viewing-streak/check-in`** — records a check-in (supports optional `on_date` override); extends streak on consecutive day, resets on gap > 1 day, skips duplicate same-day check-ins, tracks `longest_streak`
- Tests cover: first check-in, streak extension, reset, duplicate-day guard

#### 4. Chat Command Management (Closes #1106)
- **`GET /api/routes-f/chat-commands?creator_id=`** — lists all commands with trigger, response template, cooldown, enabled flag
- **`POST /api/routes-f/chat-commands`** — adds a new command (409 on duplicate trigger)
- **`POST /api/routes-f/chat-commands/execute`** — resolves `{{variable}}` placeholders in the response template and returns the rendered response; 404 if unknown trigger, 403 if disabled
- **`POST /api/routes-f/chat-commands/toggle`** — enables/disables a command by ID
- Tests cover: list, add, duplicate check, execute with interpolation, execute disabled, toggle