### PR TITLE
Fix Issue 1107

### DIFF
--- a/app/api/routes-f/now-playing/__tests__/route.test.ts
+++ b/app/api/routes-f/now-playing/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { NextRequest } from "next/server";
+import { POST, GET, DELETE } from "../route";
+
+function makeRequest(method: string, body?: unknown, query?: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost/api/routes-f/now-playing");
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  const init: RequestInit & { headers?: Record<string, string> } = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "Content-Type": "application/json" };
+  }
+  return new NextRequest(url.toString(), init);
+}
+
+describe("POST /now-playing", () => {
+  it("creates the first track for a stream", async () => {
+    const res = await POST(makeRequest("POST", {
+      stream_id: "stream-1",
+      artist: "Artist A",
+      title: "Track 1",
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("updated_at");
+    expect(typeof body.updated_at).toBe("string");
+  });
+
+  it("moves current to history when a new track is posted", async () => {
+    await POST(makeRequest("POST", {
+      stream_id: "stream-2",
+      artist: "Artist A",
+      title: "First",
+    }));
+    await POST(makeRequest("POST", {
+      stream_id: "stream-2",
+      artist: "Artist B",
+      title: "Second",
+      album: "Album",
+      art_url: "https://example.com/art.jpg",
+    }));
+    const res = await GET(makeRequest("GET", undefined, { stream_id: "stream-2" }));
+    const body = await res.json();
+    expect(body.current).toEqual({
+      stream_id: "stream-2",
+      artist: "Artist B",
+      title: "Second",
+      album: "Album",
+      art_url: "https://example.com/art.jpg",
+      played_at: expect.any(String),
+    });
+    expect(body.history).toHaveLength(1);
+    expect(body.history[0].title).toBe("First");
+  });
+
+  it("rejects missing required fields", async () => {
+    const res = await POST(makeRequest("POST", { stream_id: "s-1" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /now-playing", () => {
+  it("returns null current and empty history for a fresh stream", async () => {
+    const res = await GET(makeRequest("GET", undefined, { stream_id: "unknown" }));
+    const body = await res.json();
+    expect(body.current).toBeNull();
+    expect(body.history).toEqual([]);
+  });
+
+  it("returns at most 10 history entries", async () => {
+    for (let i = 0; i < 15; i++) {
+      await POST(makeRequest("POST", {
+        stream_id: "stream-3",
+        artist: "Artist",
+        title: `Track ${i}`,
+      }));
+    }
+    const res = await GET(makeRequest("GET", undefined, { stream_id: "stream-3" }));
+    const body = await res.json();
+    expect(body.history).toHaveLength(10);
+    expect(body.current.title).toBe("Track 14");
+    expect(body.history[0].title).toBe("Track 13");
+  });
+
+  it("rejects missing stream_id", async () => {
+    const res = await GET(makeRequest("GET", undefined, {}));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /now-playing", () => {
+  it("clears all track data for a stream", async () => {
+    await POST(makeRequest("POST", {
+      stream_id: "stream-4",
+      artist: "Artist",
+      title: "Track",
+    }));
+    const before = await GET(makeRequest("GET", undefined, { stream_id: "stream-4" }));
+    expect((await before.json()).current).not.toBeNull();
+
+    const delRes = await DELETE(makeRequest("DELETE", undefined, { stream_id: "stream-4" }));
+    expect(delRes.status).toBe(200);
+    expect((await delRes.json()).message).toBe("Now-playing cleared");
+
+    const after = await GET(makeRequest("GET", undefined, { stream_id: "stream-4" }));
+    const afterBody = await after.json();
+    expect(afterBody.current).toBeNull();
+    expect(afterBody.history).toEqual([]);
+  });
+
+  it("rejects missing stream_id", async () => {
+    const res = await DELETE(makeRequest("DELETE", undefined, {}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/now-playing/route.ts
+++ b/app/api/routes-f/now-playing/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateBody, validateQuery } from "@/app/api/routes-f/_lib/validate";
+
+interface Track {
+  stream_id: string;
+  artist: string;
+  title: string;
+  album?: string;
+  art_url?: string;
+  played_at: string;
+}
+
+interface StreamState {
+  current: Track | null;
+  history: Track[];
+}
+
+const store = new Map<string, StreamState>();
+
+const postSchema = z.object({
+  stream_id: z.string().min(1),
+  artist: z.string().min(1),
+  title: z.string().min(1),
+  album: z.string().optional(),
+  art_url: z.string().url().optional(),
+});
+
+const getSchema = z.object({
+  stream_id: z.string().min(1),
+});
+
+const deleteSchema = z.object({
+  stream_id: z.string().min(1),
+});
+
+function getState(stream_id: string): StreamState {
+  if (!store.has(stream_id)) {
+    store.set(stream_id, { current: null, history: [] });
+  }
+  return store.get(stream_id)!;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const result = await validateBody(req, postSchema);
+  if (result instanceof NextResponse) return result;
+
+  const { stream_id, artist, title, album, art_url } = result.data;
+  const state = getState(stream_id);
+
+  if (state.current) {
+    state.history.unshift({ ...state.current });
+    if (state.history.length > 10) {
+      state.history = state.history.slice(0, 10);
+    }
+  }
+
+  const now = new Date().toISOString();
+  state.current = { stream_id, artist, title, album, art_url, played_at: now };
+
+  return NextResponse.json({ updated_at: now });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const result = validateQuery(new URL(req.url).searchParams, getSchema);
+  if (result instanceof NextResponse) return result;
+
+  const { stream_id } = result.data;
+  const state = getState(stream_id);
+
+  return NextResponse.json({
+    current: state.current,
+    history: state.history,
+  });
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const result = validateQuery(new URL(req.url).searchParams, deleteSchema);
+  if (result instanceof NextResponse) return result;
+
+  const { stream_id } = result.data;
+  store.delete(stream_id);
+
+  return NextResponse.json({ message: "Now-playing cleared" });
+}


### PR DESCRIPTION
# Description

Closes #1107 
Closes #1101 

# Changes proposed

## What were you told to do?

feat(routes-f): now-playing music widget data

Streamer reports current background track for an overlay widget.

**Requirements:**
- POST `{ stream_id, artist, title, album?, art_url? }` → `{ updated_at }`
- GET `?stream_id` returns current track plus last 10 played
- DELETE clears the now-playing
- Tests cover update, history, clear
- All code scoped to `app/api/routes-f/` (no imports from outside)

## What did you do?

Created a new self-contained route at `app/api/routes-f/now-playing/`:

- **`route.ts`** — Three HTTP handlers using in-memory storage:
  - `POST` — Accepts track data, stores as current, pushes previous current to history (capped at 10 entries)
  - `GET` — Returns current track + last 10 history entries for a given `stream_id`
  - `DELETE` — Clears all now-playing state for the stream
  - Uses `zod` validation via `_lib/validate.ts` for request body/query
- **`__tests__/route.test.ts`** — Unit tests covering:
  - POST: first track creation, current→history promotion on update, validation rejection for missing fields
  - GET: empty stream state, 10-entry history cap, missing `stream_id` rejection
  - DELETE: clearing stream data, missing `stream_id` rejection

**Scope:** All code lives under `app/api/routes-f/now-playing/`. No files outside `routes-f/` were created or modified.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the _main branch_ (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.