### PR TITLE
feat(routes-f): highlight reel, content rating, and gift-sub progress

### DIFF
--- a/app/api/routes-f/channel-content-rating/__tests__/route.test.ts
+++ b/app/api/routes-f/channel-content-rating/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET, PUT } from "../route";
+import { POST } from "../viewer-confirm/route";
+import { ratings, matureConfirmations, getRating } from "../store";
+
+function makeGet(query = ""): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-f/channel-content-rating${query}`);
+}
+function makePut(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/channel-content-rating", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function makeConfirm(body: unknown): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/routes-f/channel-content-rating/viewer-confirm",
+    { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }
+  );
+}
+
+afterEach(() => {
+  ratings.set("creator-family", "family");
+  ratings.set("creator-teen", "teen");
+  ratings.set("creator-mature", "mature");
+  matureConfirmations.set("creator-mature", new Set(["viewer-verified-1"]));
+});
+
+// ── GET ──────────────────────────────────────────────────────────────────────
+
+describe("GET /channel-content-rating", () => {
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns seeded family rating", async () => {
+    const res = await GET(makeGet("?creator_id=creator-family"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rating).toBe("family");
+  });
+
+  it("defaults to family for unknown creator", async () => {
+    const res = await GET(makeGet("?creator_id=unknown-creator"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rating).toBe("family");
+  });
+});
+
+// ── PUT ──────────────────────────────────────────────────────────────────────
+
+describe("PUT /channel-content-rating", () => {
+  it("sets a new rating", async () => {
+    const res = await PUT(makePut({ creator_id: "creator-new", rating: "teen" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rating).toBe("teen");
+    expect(getRating("creator-new")).toBe("teen");
+  });
+
+  it("updates an existing rating", async () => {
+    await PUT(makePut({ creator_id: "creator-family", rating: "mature" }));
+    expect(getRating("creator-family")).toBe("mature");
+  });
+
+  it("returns 400 for invalid rating value", async () => {
+    const res = await PUT(makePut({ creator_id: "creator-x", rating: "kids" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when creator_id missing", async () => {
+    const res = await PUT(makePut({ rating: "teen" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rating missing", async () => {
+    const res = await PUT(makePut({ creator_id: "c1" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /viewer-confirm ──────────────────────────────────────────────────────
+
+describe("POST /viewer-confirm", () => {
+  it("records a mature confirmation", async () => {
+    const res = await POST(makeConfirm({
+      viewer_id: "viewer-new",
+      creator_id: "creator-mature",
+      accept_mature: true,
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(matureConfirmations.get("creator-mature")?.has("viewer-new")).toBe(true);
+  });
+
+  it("revokes a mature confirmation when accept_mature=false", async () => {
+    const res = await POST(makeConfirm({
+      viewer_id: "viewer-verified-1",
+      creator_id: "creator-mature",
+      accept_mature: false,
+    }));
+    expect(res.status).toBe(200);
+    expect(matureConfirmations.get("creator-mature")?.has("viewer-verified-1")).toBe(false);
+  });
+
+  it("returns 422 when creator rating is not mature", async () => {
+    const res = await POST(makeConfirm({
+      viewer_id: "viewer-1",
+      creator_id: "creator-family",
+      accept_mature: true,
+    }));
+    expect(res.status).toBe(422);
+  });
+
+  it("returns 400 when viewer_id missing", async () => {
+    const res = await POST(makeConfirm({ creator_id: "creator-mature", accept_mature: true }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when accept_mature is not boolean", async () => {
+    const res = await POST(makeConfirm({
+      viewer_id: "v1", creator_id: "creator-mature", accept_mature: "yes",
+    }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/channel-content-rating/route.ts
+++ b/app/api/routes-f/channel-content-rating/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET  /api/routes-f/channel-content-rating?creator_id=<id>
+ *   Returns { rating: "family" | "teen" | "mature" }
+ *
+ * PUT  /api/routes-f/channel-content-rating
+ *   Body: { creator_id, rating: "family" | "teen" | "mature" }
+ *   Sets the creator's channel rating.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { ratings, VALID_RATINGS, getRating } from "./store";
+import type { Rating } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const creator_id = req.nextUrl.searchParams.get("creator_id");
+  if (!creator_id) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+  return NextResponse.json({ rating: getRating(creator_id) });
+}
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { creator_id, rating } = (body ?? {}) as Record<string, unknown>;
+
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+  if (!rating || !VALID_RATINGS.includes(rating as Rating)) {
+    return NextResponse.json(
+      { error: `rating must be one of: ${VALID_RATINGS.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  ratings.set(creator_id, rating as Rating);
+  return NextResponse.json({ creator_id, rating });
+}

--- a/app/api/routes-f/channel-content-rating/store.ts
+++ b/app/api/routes-f/channel-content-rating/store.ts
@@ -1,0 +1,23 @@
+import type { Rating } from "./types";
+
+// creator_id -> rating
+export const ratings = new Map<string, Rating>([
+  ["creator-family", "family"],
+  ["creator-teen", "teen"],
+  ["creator-mature", "mature"],
+]);
+
+// creator_id -> Set<viewer_id> who confirmed mature content
+export const matureConfirmations = new Map<string, Set<string>>([
+  ["creator-mature", new Set(["viewer-verified-1"])],
+]);
+
+export const VALID_RATINGS: Rating[] = ["family", "teen", "mature"];
+
+export function getRating(creatorId: string): Rating {
+  return ratings.get(creatorId) ?? "family";
+}
+
+export function hasConfirmedMature(viewerId: string, creatorId: string): boolean {
+  return matureConfirmations.get(creatorId)?.has(viewerId) ?? false;
+}

--- a/app/api/routes-f/channel-content-rating/types.ts
+++ b/app/api/routes-f/channel-content-rating/types.ts
@@ -1,0 +1,12 @@
+export type Rating = "family" | "teen" | "mature";
+
+export interface ContentRatingRecord {
+  creator_id: string;
+  rating: Rating;
+}
+
+export interface ViewerConfirmation {
+  viewer_id: string;
+  creator_id: string;
+  confirmed_at: string;
+}

--- a/app/api/routes-f/channel-content-rating/viewer-confirm/route.ts
+++ b/app/api/routes-f/channel-content-rating/viewer-confirm/route.ts
@@ -1,0 +1,56 @@
+/**
+ * POST /api/routes-f/channel-content-rating/viewer-confirm
+ * Body: { viewer_id, creator_id, accept_mature: boolean }
+ *
+ * Records (or revokes) a viewer's confirmation that they accept mature content
+ * for a given creator. Gating: only meaningful when creator's rating is "mature".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { matureConfirmations, getRating } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { viewer_id, creator_id, accept_mature } = (body ?? {}) as Record<string, unknown>;
+
+  if (!viewer_id || typeof viewer_id !== "string") {
+    return NextResponse.json({ error: "viewer_id is required" }, { status: 400 });
+  }
+  if (!creator_id || typeof creator_id !== "string") {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+  if (typeof accept_mature !== "boolean") {
+    return NextResponse.json({ error: "accept_mature must be a boolean" }, { status: 400 });
+  }
+
+  const rating = getRating(creator_id);
+  if (rating !== "mature") {
+    return NextResponse.json(
+      { error: "creator channel is not rated mature; confirmation not required" },
+      { status: 422 }
+    );
+  }
+
+  if (!matureConfirmations.has(creator_id)) {
+    matureConfirmations.set(creator_id, new Set());
+  }
+  const set = matureConfirmations.get(creator_id)!;
+
+  if (accept_mature) {
+    set.add(viewer_id);
+  } else {
+    set.delete(viewer_id);
+  }
+
+  return NextResponse.json({
+    viewer_id,
+    creator_id,
+    accepted: accept_mature,
+    confirmed_at: new Date().toISOString(),
+  });
+}

--- a/app/api/routes-f/gift-sub-progress/__tests__/route.test.ts
+++ b/app/api/routes-f/gift-sub-progress/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { POST } from "../increment/route";
+import { giftCounts, computeProgress, MILESTONES } from "../store";
+
+function makeGet(query = ""): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-f/gift-sub-progress${query}`);
+}
+function makePost(body: unknown): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/routes-f/gift-sub-progress/increment",
+    { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) }
+  );
+}
+
+beforeEach(() => {
+  giftCounts.set("stream-gs-1", 7);
+  giftCounts.set("stream-gs-2", 0);
+  giftCounts.set("stream-gs-3", 100);
+});
+
+// ── computeProgress ──────────────────────────────────────────────────────────
+
+describe("computeProgress", () => {
+  it("returns null milestones and 0 percent at count=0", () => {
+    const p = computeProgress(0);
+    expect(p.current_milestone).toBeNull();
+    expect(p.next_milestone).toBe(MILESTONES[0]);
+    expect(p.percent_to_next).toBe(0);
+  });
+
+  it("recognizes milestone crossing at each tier", () => {
+    for (const m of MILESTONES) {
+      const p = computeProgress(m);
+      expect(p.current_milestone).toBe(m);
+    }
+  });
+
+  it("computes partial progress between milestones", () => {
+    // Between 5 and 10 (distance=5): at 7 → (7-5)/(10-5) = 40%
+    const p = computeProgress(7);
+    expect(p.current_milestone).toBe(5);
+    expect(p.next_milestone).toBe(10);
+    expect(p.percent_to_next).toBeCloseTo(40, 1);
+  });
+
+  it("returns 100% when all milestones are reached", () => {
+    const p = computeProgress(100);
+    expect(p.current_milestone).toBe(100);
+    expect(p.next_milestone).toBeNull();
+    expect(p.percent_to_next).toBe(100);
+  });
+});
+
+// ── GET ──────────────────────────────────────────────────────────────────────
+
+describe("GET /gift-sub-progress", () => {
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown stream", async () => {
+    const res = await GET(makeGet("?stream_id=nope"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns progress for stream-gs-1 (count=7, milestone=5)", async () => {
+    const res = await GET(makeGet("?stream_id=stream-gs-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.gifts_received).toBe(7);
+    expect(body.current_milestone).toBe(5);
+    expect(body.next_milestone).toBe(10);
+    expect(body.percent_to_next).toBeCloseTo(40, 1);
+  });
+
+  it("returns all-null progress for a stream at zero gifts", async () => {
+    const res = await GET(makeGet("?stream_id=stream-gs-2"));
+    const body = await res.json();
+    expect(body.current_milestone).toBeNull();
+    expect(body.gifts_received).toBe(0);
+  });
+});
+
+// ── POST /increment ──────────────────────────────────────────────────────────
+
+describe("POST /increment", () => {
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await POST(makePost({ by: 1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown stream", async () => {
+    const res = await POST(makePost({ stream_id: "nope", by: 1 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("defaults to incrementing by 1", async () => {
+    const res = await POST(makePost({ stream_id: "stream-gs-1" }));
+    const body = await res.json();
+    expect(body.gifts_received).toBe(8);
+  });
+
+  it("increments by a custom amount", async () => {
+    const res = await POST(makePost({ stream_id: "stream-gs-2", by: 5 }));
+    const body = await res.json();
+    expect(body.gifts_received).toBe(5);
+    expect(body.current_milestone).toBe(5);
+    expect(body.next_milestone).toBe(10);
+  });
+
+  it("crosses a milestone after enough increments", async () => {
+    // stream-gs-1 starts at 7 (milestone=5); +4 should cross 10
+    await POST(makePost({ stream_id: "stream-gs-1", by: 3 }));
+    const res = await POST(makePost({ stream_id: "stream-gs-1" }));
+    const body = await res.json();
+    expect(body.gifts_received).toBe(11);
+    expect(body.current_milestone).toBe(10);
+    expect(body.next_milestone).toBe(25);
+  });
+
+  it("clamps non-integer or negative by to 1", async () => {
+    const res = await POST(makePost({ stream_id: "stream-gs-2", by: -5 }));
+    const body = await res.json();
+    expect(body.gifts_received).toBe(1);
+  });
+});

--- a/app/api/routes-f/gift-sub-progress/increment/route.ts
+++ b/app/api/routes-f/gift-sub-progress/increment/route.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/routes-f/gift-sub-progress/increment
+ * Body: { stream_id: string; by?: number }
+ * Increments the gift-sub counter and returns updated progress.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { giftCounts, computeProgress } from "../store";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id, by } = (body ?? {}) as Record<string, unknown>;
+
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  if (!giftCounts.has(stream_id)) {
+    return NextResponse.json({ error: `unknown stream_id: ${stream_id}` }, { status: 404 });
+  }
+
+  const increment = typeof by === "number" && Number.isInteger(by) && by > 0 ? by : 1;
+  const newCount = giftCounts.get(stream_id)! + increment;
+  giftCounts.set(stream_id, newCount);
+
+  return NextResponse.json(computeProgress(newCount));
+}

--- a/app/api/routes-f/gift-sub-progress/route.ts
+++ b/app/api/routes-f/gift-sub-progress/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /api/routes-f/gift-sub-progress?stream_id=<id>
+ * Returns gift-sub milestone progress for an active stream.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { giftCounts, computeProgress } from "./store";
+import type { GiftSubProgress } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const stream_id = req.nextUrl.searchParams.get("stream_id");
+  if (!stream_id) {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  if (!giftCounts.has(stream_id)) {
+    return NextResponse.json({ error: `unknown stream_id: ${stream_id}` }, { status: 404 });
+  }
+
+  const count = giftCounts.get(stream_id)!;
+  const progress: GiftSubProgress = computeProgress(count);
+  return NextResponse.json(progress);
+}

--- a/app/api/routes-f/gift-sub-progress/store.ts
+++ b/app/api/routes-f/gift-sub-progress/store.ts
@@ -1,0 +1,33 @@
+import type { GiftSubProgress } from "./types";
+
+export const MILESTONES = [5, 10, 25, 50, 100] as const;
+
+// stream_id -> total gift subs received during stream
+export const giftCounts = new Map<string, number>([
+  ["stream-gs-1", 7],
+  ["stream-gs-2", 0],
+  ["stream-gs-3", 100],
+]);
+
+export function computeProgress(count: number): GiftSubProgress {
+  let current_milestone: number | null = null;
+  let next_milestone: number | null = null;
+
+  for (const m of MILESTONES) {
+    if (count >= m) {
+      current_milestone = m;
+    } else {
+      next_milestone = m;
+      break;
+    }
+  }
+
+  const prev = current_milestone ?? 0;
+  const next = next_milestone;
+  const percent_to_next =
+    next === null
+      ? 100
+      : Math.min(100, Math.round(((count - prev) / (next - prev)) * 10000) / 100);
+
+  return { gifts_received: count, current_milestone, next_milestone, percent_to_next };
+}

--- a/app/api/routes-f/gift-sub-progress/types.ts
+++ b/app/api/routes-f/gift-sub-progress/types.ts
@@ -1,0 +1,6 @@
+export interface GiftSubProgress {
+  gifts_received: number;
+  current_milestone: number | null;
+  next_milestone: number | null;
+  percent_to_next: number;
+}

--- a/app/api/routes-f/highlight-reel/__tests__/route.test.ts
+++ b/app/api/routes-f/highlight-reel/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import { scoreWindows, pickTopHighlights } from "../highlights";
+import { getStream } from "../seed";
+import type { StreamSample } from "../types";
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/routes-f/highlight-reel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("scoreWindows", () => {
+  it("scores zero for an empty stream", () => {
+    const empty: StreamSample = {
+      stream_id: "empty",
+      duration_seconds: 120,
+      chat_events: [],
+      tip_events: [],
+    };
+    expect(scoreWindows(empty)).toHaveLength(0);
+  });
+
+  it("weights tips higher than chat messages", () => {
+    const stream: StreamSample = {
+      stream_id: "test",
+      duration_seconds: 60,
+      chat_events: [{ offset_seconds: 5 }],
+      tip_events: [{ offset_seconds: 5, amount_usdc: 10 }],
+    };
+    const windows = scoreWindows(stream);
+    expect(windows[0].score).toBeGreaterThan(windows[0].chat_count);
+  });
+});
+
+describe("pickTopHighlights with known spike in stream-hl-1", () => {
+  const stream = getStream("stream-hl-1")!;
+
+  it("returns at most 5 highlights", () => {
+    const highlights = pickTopHighlights(stream);
+    expect(highlights.length).toBeLessThanOrEqual(5);
+  });
+
+  it("all windows are 30 seconds wide", () => {
+    const highlights = pickTopHighlights(stream);
+    for (const h of highlights) {
+      expect(h.end_seconds - h.start_seconds).toBe(30);
+    }
+  });
+
+  it("highest-scored window covers the 60-90s chat+tip spike", () => {
+    const highlights = pickTopHighlights(stream);
+    const topByScore = [...highlights].sort((a, b) => b.score - a.score)[0];
+    // The dense chat+tip cluster at 62-90s should be in the top window
+    expect(topByScore.start_seconds).toBeLessThanOrEqual(65);
+    expect(topByScore.end_seconds).toBeGreaterThanOrEqual(90);
+  });
+
+  it("selected windows do not overlap", () => {
+    const highlights = pickTopHighlights(stream);
+    for (let i = 0; i < highlights.length - 1; i++) {
+      for (let j = i + 1; j < highlights.length; j++) {
+        const a = highlights[i];
+        const b = highlights[j];
+        const overlap = a.start_seconds < b.end_seconds && b.start_seconds < a.end_seconds;
+        expect(overlap).toBe(false);
+      }
+    }
+  });
+
+  it("reasons are one of the expected labels", () => {
+    const highlights = pickTopHighlights(stream);
+    const valid = new Set(["chat burst", "tip spike", "chat and tip spike"]);
+    for (const h of highlights) {
+      expect(valid.has(h.reason)).toBe(true);
+    }
+  });
+});
+
+describe("POST /api/routes-f/highlight-reel", () => {
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown stream", async () => {
+    const res = await POST(makeReq({ stream_id: "nope" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns highlights array for a known stream", async () => {
+    const res = await POST(makeReq({ stream_id: "stream-hl-1" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stream_id).toBe("stream-hl-1");
+    expect(Array.isArray(body.highlights)).toBe(true);
+    expect(body.highlights.length).toBeGreaterThan(0);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/highlight-reel", {
+      method: "POST",
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routes-f/highlight-reel/highlights.ts
+++ b/app/api/routes-f/highlight-reel/highlights.ts
@@ -1,0 +1,65 @@
+import type { StreamSample, Highlight } from "./types";
+
+const WINDOW = 30;       // seconds
+const TIP_WEIGHT = 2;    // 1 USDC in a window = TIP_WEIGHT score points
+const TOP_N = 5;
+
+interface ScoredWindow {
+  start: number;
+  chat_count: number;
+  tip_total: number;
+  score: number;
+}
+
+export function scoreWindows(stream: StreamSample): ScoredWindow[] {
+  const step = 5;
+  const maxStart = Math.max(0, stream.duration_seconds - WINDOW);
+  const windows: ScoredWindow[] = [];
+
+  for (let start = 0; start <= maxStart; start += step) {
+    const end = start + WINDOW;
+    const chat_count = stream.chat_events.filter(
+      e => e.offset_seconds >= start && e.offset_seconds < end
+    ).length;
+    const tip_total = stream.tip_events
+      .filter(e => e.offset_seconds >= start && e.offset_seconds < end)
+      .reduce((sum, e) => sum + e.amount_usdc, 0);
+
+    if (chat_count > 0 || tip_total > 0) {
+      windows.push({ start, chat_count, tip_total, score: chat_count + tip_total * TIP_WEIGHT });
+    }
+  }
+
+  return windows;
+}
+
+function overlaps(a: { start: number }, b: { start: number }): boolean {
+  return Math.abs(a.start - b.start) < WINDOW;
+}
+
+function reason(w: ScoredWindow): string {
+  if (w.tip_total > 0 && w.chat_count > 5) return "chat and tip spike";
+  if (w.tip_total > 0) return "tip spike";
+  return "chat burst";
+}
+
+export function pickTopHighlights(stream: StreamSample): Highlight[] {
+  const ranked = scoreWindows(stream).sort((a, b) => b.score - a.score);
+  const selected: ScoredWindow[] = [];
+
+  for (const w of ranked) {
+    if (selected.length >= TOP_N) break;
+    if (selected.every(s => !overlaps(s, w))) {
+      selected.push(w);
+    }
+  }
+
+  return selected
+    .sort((a, b) => a.start - b.start)
+    .map(w => ({
+      start_seconds: w.start,
+      end_seconds: w.start + WINDOW,
+      score: Math.round(w.score * 10) / 10,
+      reason: reason(w),
+    }));
+}

--- a/app/api/routes-f/highlight-reel/route.ts
+++ b/app/api/routes-f/highlight-reel/route.ts
@@ -1,0 +1,31 @@
+/**
+ * POST /api/routes-f/highlight-reel
+ * Body: { stream_id: string }
+ * Returns: { highlights: Highlight[] }
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getStream } from "./seed";
+import { pickTopHighlights } from "./highlights";
+import type { HighlightReelResponse } from "./types";
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { stream_id } = (body ?? {}) as Record<string, unknown>;
+  if (!stream_id || typeof stream_id !== "string") {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  const stream = getStream(stream_id);
+  if (!stream) {
+    return NextResponse.json({ error: `unknown stream_id: ${stream_id}` }, { status: 404 });
+  }
+
+  const highlights = pickTopHighlights(stream);
+  return NextResponse.json({ stream_id, highlights } satisfies HighlightReelResponse);
+}

--- a/app/api/routes-f/highlight-reel/seed.ts
+++ b/app/api/routes-f/highlight-reel/seed.ts
@@ -1,0 +1,45 @@
+import type { StreamSample } from "./types";
+
+const STREAMS: StreamSample[] = [
+  {
+    stream_id: "stream-hl-1",
+    duration_seconds: 300,
+    chat_events: [
+      // Spike at 60–90s (20 msgs)
+      ...[62,63,65,66,68,70,72,74,75,78,80,81,82,83,85,86,87,88,89,90].map(s => ({ offset_seconds: s })),
+      // Quieter burst at 150–180s (8 msgs)
+      ...[151,155,158,162,167,170,174,178].map(s => ({ offset_seconds: s })),
+      // Scattered noise
+      ...[10,30,210,240,270].map(s => ({ offset_seconds: s })),
+    ],
+    tip_events: [
+      { offset_seconds: 75, amount_usdc: 50 },
+      { offset_seconds: 82, amount_usdc: 20 },
+      // Tip spike at 200–230s
+      { offset_seconds: 205, amount_usdc: 100 },
+      { offset_seconds: 215, amount_usdc: 75 },
+    ],
+  },
+  {
+    stream_id: "stream-hl-2",
+    duration_seconds: 600,
+    chat_events: [
+      ...[5,10,15,20,25,30,35,40,45,50,55,60].map(s => ({ offset_seconds: s })),
+      ...[120,122,125,128,130,132,135,138,140,142,145,148,149].map(s => ({ offset_seconds: s })),
+      ...[300,350,400].map(s => ({ offset_seconds: s })),
+    ],
+    tip_events: [
+      { offset_seconds: 130, amount_usdc: 200 },
+      { offset_seconds: 145, amount_usdc: 50 },
+      { offset_seconds: 10, amount_usdc: 5 },
+    ],
+  },
+];
+
+export function getStream(streamId: string): StreamSample | undefined {
+  return STREAMS.find(s => s.stream_id === streamId);
+}
+
+export function allStreamIds(): string[] {
+  return STREAMS.map(s => s.stream_id);
+}

--- a/app/api/routes-f/highlight-reel/types.ts
+++ b/app/api/routes-f/highlight-reel/types.ts
@@ -1,0 +1,27 @@
+export interface ChatEvent {
+  offset_seconds: number;
+}
+
+export interface TipEvent {
+  offset_seconds: number;
+  amount_usdc: number;
+}
+
+export interface StreamSample {
+  stream_id: string;
+  duration_seconds: number;
+  chat_events: ChatEvent[];
+  tip_events: TipEvent[];
+}
+
+export interface Highlight {
+  start_seconds: number;
+  end_seconds: number;
+  score: number;
+  reason: string;
+}
+
+export interface HighlightReelResponse {
+  stream_id: string;
+  highlights: Highlight[];
+}


### PR DESCRIPTION
Closes #1111

---

Closes #1109

---

Closes #1108

---

## Summary

All files are self-contained inside `app/api/routes-f/`. No imports from outside the respective subfolder.

- **#1108** — `highlight-reel/`: `POST { stream_id }` scores every 30-second sliding window (step 5s) using chat event count + tip total × 2 weight, picks the top-5 non-overlapping windows by greedy score, returns `{ highlights: [{ start_seconds, end_seconds, score, reason }] }`. Bundled seed has two streams with deliberate spike patterns (dense chat + XLM tips at 60–90s in stream-hl-1). Tests verify non-overlap, 30s width, that the highest-score window covers the 62–90s spike, and valid reason labels.

- **#1109** — `channel-content-rating/`: `GET ?creator_id` returns `{ rating }` (defaults to `"family"` for unknown creators); `PUT { creator_id, rating }` sets the rating; `POST /viewer-confirm { viewer_id, creator_id, accept_mature }` records or revokes a viewer's mature-content confirmation and returns 422 when the creator's rating isn't `"mature"`. Shared in-memory state lives in `store.ts`, imported by both `route.ts` and `viewer-confirm/route.ts`. Tests cover GET default, PUT set/update/invalid-rating, and confirm/revoke/422-gating flows.

- **#1111** — `gift-sub-progress/`: `GET ?stream_id` returns `{ gifts_received, current_milestone, next_milestone, percent_to_next }` against the milestone ladder `[5, 10, 25, 50, 100]`; `POST /increment { stream_id, by? }` bumps the counter (defaults to 1, clamps non-positive values). `computeProgress` in `store.ts` handles milestone detection and percent calculation. Tests cover each boundary, milestone crossings, multi-step progression, and the `by` clamp.

## Test plan

- [ ] `cd app/api/routes-f && npx jest highlight-reel` — all scoring, non-overlap, and route tests pass
- [ ] `npx jest channel-content-rating` — GET/PUT/viewer-confirm + gating tests pass
- [ ] `npx jest gift-sub-progress` — computeProgress boundaries, GET, POST /increment, milestone crossing tests pass
- [ ] `GET /api/routes-f/highlight-reel` without body → 400; unknown stream → 404; known stream → 200 with ≤5 highlights
- [ ] `GET /api/routes-f/channel-content-rating?creator_id=unknown` → 200 `{ rating: "family" }`
- [ ] `PUT` with `rating: "kids"` → 400
- [ ] `POST /viewer-confirm` on a family-rated creator → 422
- [ ] `GET /api/routes-f/gift-sub-progress?stream_id=stream-gs-1` → `gifts_received: 7, current_milestone: 5, next_milestone: 10, percent_to_next: 40`
- [ ] `POST /increment { stream_id: "stream-gs-1" }` increments by 1 each call