### PR TITLE
feat(routes-f): implement core clipping and streaming engagement endpoints

### DIFF
--- a/app/api/routes-f/clip-embed-metadata/route.test.ts
+++ b/app/api/routes-f/clip-embed-metadata/route.test.ts
@@ -1,0 +1,35 @@
+import { GET, SEED_CLIPS } from "./route";
+import { NextRequest } from "next/server";
+
+describe("GET /api/routes-f/clip-embed-metadata", () => {
+  it("should return clip metadata when valid clip_id is provided", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/clip-embed-metadata?clip_id=clip-1");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.title).toBe(SEED_CLIPS["clip-1"].title);
+    expect(data.thumbnail_url).toBe(SEED_CLIPS["clip-1"].thumbnail_url);
+    expect(data.creator).toBe(SEED_CLIPS["clip-1"].creator);
+    expect(data.duration_seconds).toBe(SEED_CLIPS["clip-1"].duration_seconds);
+    expect(data.oembed_compatible_json).toEqual(SEED_CLIPS["clip-1"].oembed_compatible_json);
+  });
+
+  it("should return 404 for unknown clip_id", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/clip-embed-metadata?clip_id=nonexistent");
+    const res = await GET(req);
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Clip not found");
+  });
+
+  it("should return 400 when clip_id is missing", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/clip-embed-metadata");
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("clip_id is required");
+  });
+});

--- a/app/api/routes-f/clip-embed-metadata/route.ts
+++ b/app/api/routes-f/clip-embed-metadata/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type ClipMetadata = {
+  id: string;
+  title: string;
+  thumbnail_url: string;
+  creator: string;
+  duration_seconds: number;
+  oembed_compatible_json: {
+    type: "video";
+    version: "1.0";
+    title: string;
+    provider_name: "StreamFi";
+    provider_url: string;
+    author_name: string;
+    thumbnail_url: string;
+    thumbnail_width: number;
+    thumbnail_height: number;
+    html: string;
+    width: number;
+    height: number;
+  };
+};
+
+export const SEED_CLIPS: Record<string, ClipMetadata> = {
+  "clip-1": {
+    id: "clip-1",
+    title: "Epic Boss Fight",
+    thumbnail_url: "https://example.com/thumb1.jpg",
+    creator: "GamerBob",
+    duration_seconds: 45,
+    oembed_compatible_json: {
+      type: "video",
+      version: "1.0",
+      title: "Epic Boss Fight",
+      provider_name: "StreamFi",
+      provider_url: "https://streamfi.example",
+      author_name: "GamerBob",
+      thumbnail_url: "https://example.com/thumb1.jpg",
+      thumbnail_width: 1280,
+      thumbnail_height: 720,
+      html: `<iframe src="https://streamfi.example/embed/clip-1" width="1280" height="720" frameborder="0" allowfullscreen></iframe>`,
+      width: 1280,
+      height: 720,
+    },
+  },
+  "clip-2": {
+    id: "clip-2",
+    title: "Funny Glitch",
+    thumbnail_url: "https://example.com/thumb2.jpg",
+    creator: "LaughsAlot",
+    duration_seconds: 15,
+    oembed_compatible_json: {
+      type: "video",
+      version: "1.0",
+      title: "Funny Glitch",
+      provider_name: "StreamFi",
+      provider_url: "https://streamfi.example",
+      author_name: "LaughsAlot",
+      thumbnail_url: "https://example.com/thumb2.jpg",
+      thumbnail_width: 1280,
+      thumbnail_height: 720,
+      html: `<iframe src="https://streamfi.example/embed/clip-2" width="1280" height="720" frameborder="0" allowfullscreen></iframe>`,
+      width: 1280,
+      height: 720,
+    },
+  },
+};
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  const clip = SEED_CLIPS[clipId];
+  if (!clip) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    title: clip.title,
+    thumbnail_url: clip.thumbnail_url,
+    creator: clip.creator,
+    duration_seconds: clip.duration_seconds,
+    oembed_compatible_json: clip.oembed_compatible_json,
+  });
+}

--- a/app/api/routes-f/clip-share-counter/route.test.ts
+++ b/app/api/routes-f/clip-share-counter/route.test.ts
@@ -1,0 +1,70 @@
+import { GET, POST, CLIP_SHARES } from "./route";
+import { NextRequest } from "next/server";
+
+describe("Clip Share Counter", () => {
+  beforeEach(() => {
+    // Reset in-memory store before each test
+    for (const key in CLIP_SHARES) {
+      delete CLIP_SHARES[key];
+    }
+  });
+
+  describe("POST /api/routes-f/clip-share-counter", () => {
+    it("should increment share counter for valid destination", async () => {
+      const req = new NextRequest("http://localhost/api/routes-f/clip-share-counter", {
+        method: "POST",
+        body: JSON.stringify({ clip_id: "clip-123", destination: "twitter" }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(CLIP_SHARES["clip-123"].twitter).toBe(1);
+    });
+
+    it("should return 400 for invalid destination", async () => {
+      const req = new NextRequest("http://localhost/api/routes-f/clip-share-counter", {
+        method: "POST",
+        body: JSON.stringify({ clip_id: "clip-123", destination: "facebook" }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Invalid destination");
+    });
+  });
+
+  describe("GET /api/routes-f/clip-share-counter", () => {
+    it("should return correct totals and by_destination aggregations", async () => {
+      // Simulate some shares
+      CLIP_SHARES["clip-456"] = {
+        twitter: 2,
+        telegram: 1,
+        copy_link: 0,
+        other: 3,
+      };
+
+      const req = new NextRequest("http://localhost/api/routes-f/clip-share-counter?clip_id=clip-456");
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.total).toBe(6);
+      expect(data.by_destination.twitter).toBe(2);
+      expect(data.by_destination.telegram).toBe(1);
+      expect(data.by_destination.other).toBe(3);
+    });
+
+    it("should return zeros for unknown clip_id", async () => {
+      const req = new NextRequest("http://localhost/api/routes-f/clip-share-counter?clip_id=unknown");
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.total).toBe(0);
+      expect(data.by_destination.twitter).toBe(0);
+    });
+  });
+});

--- a/app/api/routes-f/clip-share-counter/route.ts
+++ b/app/api/routes-f/clip-share-counter/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store for shares
+// Format: clip_id -> destination -> count
+export const CLIP_SHARES: Record<string, Record<string, number>> = {};
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { clip_id, destination } = body;
+
+    if (!clip_id || !destination) {
+      return NextResponse.json({ error: "clip_id and destination are required" }, { status: 400 });
+    }
+
+    const validDestinations = ["twitter", "telegram", "copy_link", "other"];
+    if (!validDestinations.includes(destination)) {
+      return NextResponse.json({ error: "Invalid destination" }, { status: 400 });
+    }
+
+    if (!CLIP_SHARES[clip_id]) {
+      CLIP_SHARES[clip_id] = {
+        twitter: 0,
+        telegram: 0,
+        copy_link: 0,
+        other: 0,
+      };
+    }
+
+    CLIP_SHARES[clip_id][destination] += 1;
+
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  const shares = CLIP_SHARES[clipId] || {
+    twitter: 0,
+    telegram: 0,
+    copy_link: 0,
+    other: 0,
+  };
+
+  const total = Object.values(shares).reduce((sum, count) => sum + count, 0);
+
+  return NextResponse.json({
+    total,
+    by_destination: shares,
+  });
+}

--- a/app/api/routes-f/create-clip/route.test.ts
+++ b/app/api/routes-f/create-clip/route.test.ts
@@ -1,0 +1,87 @@
+import { POST, CREATED_CLIPS } from "./route";
+import { NextRequest } from "next/server";
+
+describe("POST /api/routes-f/create-clip", () => {
+  beforeEach(() => {
+    // Clear the in-memory array before each test
+    CREATED_CLIPS.length = 0;
+  });
+
+  it("should create a clip successfully with valid payload", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/create-clip", {
+      method: "POST",
+      body: JSON.stringify({
+        stream_id: "stream-123",
+        playback_id: "playback-456",
+      }),
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    
+    expect(data.clip_id).toBeDefined();
+    expect(data.clip_id).toMatch(/^clip_/);
+    expect(data.mux_url_pattern).toContain("playback-456.m3u8");
+    expect(data.mux_url_pattern).toContain("duration=30"); // default
+
+    expect(CREATED_CLIPS.length).toBe(1);
+    expect(CREATED_CLIPS[0].clip_id).toBe(data.clip_id);
+    expect(CREATED_CLIPS[0].duration_seconds).toBe(30);
+    expect(CREATED_CLIPS[0].title).toBe("Untitled Clip");
+  });
+
+  it("should validate duration boundaries (too short)", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/create-clip", {
+      method: "POST",
+      body: JSON.stringify({
+        stream_id: "stream-123",
+        playback_id: "playback-456",
+        duration_seconds: 4,
+      }),
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("duration_seconds must be between 5 and 90");
+    expect(CREATED_CLIPS.length).toBe(0);
+  });
+
+  it("should validate duration boundaries (too long)", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/create-clip", {
+      method: "POST",
+      body: JSON.stringify({
+        stream_id: "stream-123",
+        playback_id: "playback-456",
+        duration_seconds: 91,
+      }),
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("duration_seconds must be between 5 and 90");
+    expect(CREATED_CLIPS.length).toBe(0);
+  });
+
+  it("should generate unique clip IDs", async () => {
+    const req1 = new NextRequest("http://localhost/api/routes-f/create-clip", {
+      method: "POST",
+      body: JSON.stringify({ stream_id: "s1", playback_id: "p1" }),
+    });
+    const req2 = new NextRequest("http://localhost/api/routes-f/create-clip", {
+      method: "POST",
+      body: JSON.stringify({ stream_id: "s2", playback_id: "p2" }),
+    });
+
+    const res1 = await POST(req1);
+    const res2 = await POST(req2);
+
+    const data1 = await res1.json();
+    const data2 = await res2.json();
+
+    expect(data1.clip_id).not.toBe(data2.clip_id);
+    expect(CREATED_CLIPS.length).toBe(2);
+  });
+});

--- a/app/api/routes-f/create-clip/route.ts
+++ b/app/api/routes-f/create-clip/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type ClipRecord = {
+  clip_id: string;
+  stream_id: string;
+  playback_id: string;
+  duration_seconds: number;
+  title: string;
+  mux_url_pattern: string;
+  created_at: string;
+};
+
+export const CREATED_CLIPS: ClipRecord[] = [];
+
+// Simple nanoid-style generator since we cannot import external libraries easily
+const generateId = () => {
+  return Math.random().toString(36).substring(2, 10) + Math.random().toString(36).substring(2, 10);
+};
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { stream_id, playback_id, duration_seconds = 30, title = "Untitled Clip" } = body;
+
+    if (!stream_id || !playback_id) {
+      return NextResponse.json({ error: "stream_id and playback_id are required" }, { status: 400 });
+    }
+
+    if (typeof duration_seconds !== "number" || duration_seconds < 5 || duration_seconds > 90) {
+      return NextResponse.json({ error: "duration_seconds must be between 5 and 90" }, { status: 400 });
+    }
+
+    const clip_id = `clip_${generateId()}`;
+    const mux_url_pattern = `https://stream.mux.com/${playback_id}.m3u8?end=${Math.floor(Date.now() / 1000)}&duration=${duration_seconds}`;
+
+    const newClip: ClipRecord = {
+      clip_id,
+      stream_id,
+      playback_id,
+      duration_seconds,
+      title,
+      mux_url_pattern,
+      created_at: new Date().toISOString(),
+    };
+
+    CREATED_CLIPS.push(newClip);
+
+    return NextResponse.json({
+      clip_id,
+      mux_url_pattern,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+}

--- a/app/api/routes-f/trending-streams/route.test.ts
+++ b/app/api/routes-f/trending-streams/route.test.ts
@@ -1,0 +1,33 @@
+import { GET, SEED_STREAMS } from "./route";
+import { NextRequest } from "next/server";
+
+describe("GET /api/routes-f/trending-streams", () => {
+  it("should rank trending streams correctly", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/trending-streams");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    
+    // CreatorB: score = 150 * 0.6 + 100 * 0.4 = 90 + 40 = 130
+    // CreatorA: score = 100 * 0.6 + 0 * 0.4 = 60
+    // CreatorC: score = 120 * 0.6 + (-80) * 0.4 = 72 - 32 = 40
+    // Expected order: CreatorB, CreatorA, CreatorC
+    
+    expect(data.streams[0].id).toBe("stream-2");
+    expect(data.streams[1].id).toBe("stream-1");
+    expect(data.streams[2].id).toBe("stream-3");
+  });
+
+  it("should respect limit query parameter", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/trending-streams?limit=2");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    
+    expect(data.streams.length).toBe(2);
+    expect(data.streams[0].id).toBe("stream-2");
+    expect(data.streams[1].id).toBe("stream-1");
+  });
+});

--- a/app/api/routes-f/trending-streams/route.ts
+++ b/app/api/routes-f/trending-streams/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type StreamData = {
+  id: string;
+  title: string;
+  creator: string;
+  current_viewers: number;
+  past_viewers: number; // Viewers at previous timestamp for velocity
+};
+
+export const SEED_STREAMS: StreamData[] = [
+  {
+    id: "stream-1",
+    title: "Flat Stream",
+    creator: "CreatorA",
+    current_viewers: 100,
+    past_viewers: 100,
+  },
+  {
+    id: "stream-2",
+    title: "Trending Stream",
+    creator: "CreatorB",
+    current_viewers: 150,
+    past_viewers: 50, // Velocity = 100
+  },
+  {
+    id: "stream-3",
+    title: "Declining Stream",
+    creator: "CreatorC",
+    current_viewers: 120,
+    past_viewers: 200, // Velocity = -80
+  },
+];
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam ? parseInt(limitParam, 10) : 20;
+
+  const scoredStreams = SEED_STREAMS.map((stream) => {
+    const viewer_velocity = stream.current_viewers - stream.past_viewers;
+    const score = stream.current_viewers * 0.6 + viewer_velocity * 0.4;
+    return {
+      ...stream,
+      score,
+      viewer_velocity,
+    };
+  });
+
+  scoredStreams.sort((a, b) => b.score - a.score);
+
+  return NextResponse.json({
+    streams: scoredStreams.slice(0, limit),
+  });
+}


### PR DESCRIPTION
# Description

This PR introduces four independent modules to the `app/api/routes-f/` directory, aimed at enhancing the core live streaming and clipping functionality on StreamFi.

### Key Changes:

1. **Clip Embed Metadata**: 
   - Added a `GET` handler in `clip-embed-metadata` to return detailed metadata for a given `clip_id`.
   - Supports `oembed_compatible_json` for native integrations.
   - Handles `404` responses gracefully for unknown clips.

2. **Trending Streams Algorithm**:
   - Added a `GET` handler in `trending-streams` that ranks streams by a trending score.
   - The algorithm combines current viewership (60% weight) and viewer growth velocity (40% weight).
   - Supports a `?limit` query parameter.

3. **Clip Share Counter**:
   - Added `POST` and `GET` handlers in `clip-share-counter`.
   - `POST` accurately increments per-destination (e.g., twitter, telegram) outbound shares.
   - `GET` returns a combined total and `by_destination` aggregation.

4. **Create Clip from Live Stream**:
   - Added a `POST` handler in `create-clip`.
   - Captures the last N seconds of a live stream (validating duration between 5 and 90 seconds).
   - Dynamically generates a nanoid-style `clip_id` and constructs the appropriate `mux_url_pattern` leveraging the provided `playback_id`.

### Scope
All implementations, helpers, data, and tests are entirely confined within `app/api/routes-f/` (and their respective task folders) to ensure complete independence and prevent crossover side-effects with existing core platform code.


Closes #998 
Closes #1001
Closes #1002 
Closes #1005 
