### PR TITLE
feat(routes-f): clip comments, cover image, language metadata, duration filter

### DIFF
--- a/app/api/routes-f/clip-comments/route.test.ts
+++ b/app/api/routes-f/clip-comments/route.test.ts
@@ -1,0 +1,222 @@
+import { GET, POST, CLIP_COMMENTS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-comments";
+
+function postReq(body: unknown) {
+  return new NextRequest(BASE, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function createComment(
+  clip_id: string,
+  author: string,
+  text: string,
+  parent_comment_id?: string
+): Promise<string> {
+  const res = await POST(postReq({ clip_id, author, text, parent_comment_id }));
+  const data = await res.json();
+  return data.comment_id;
+}
+
+describe("Clip Comments Thread", () => {
+  beforeEach(() => {
+    for (const key in CLIP_COMMENTS) {
+      delete CLIP_COMMENTS[key];
+    }
+  });
+
+  describe("POST /api/routes-f/clip-comments", () => {
+    it("should create a top-level comment and return comment_id", async () => {
+      const res = await POST(
+        postReq({ clip_id: "clip-1", author: "alice", text: "Great clip!" })
+      );
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.comment_id).toBeDefined();
+      expect(CLIP_COMMENTS[data.comment_id].clip_id).toBe("clip-1");
+      expect(CLIP_COMMENTS[data.comment_id].parent_comment_id).toBeNull();
+    });
+
+    it("should create a reply to a top-level comment", async () => {
+      const parentId = await createComment("clip-1", "alice", "Great clip!");
+      const res = await POST(
+        postReq({
+          clip_id: "clip-1",
+          author: "bob",
+          text: "Agreed!",
+          parent_comment_id: parentId,
+        })
+      );
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(CLIP_COMMENTS[data.comment_id].parent_comment_id).toBe(parentId);
+    });
+
+    it("should reject a reply to a reply (depth capped at 1)", async () => {
+      const parentId = await createComment("clip-1", "alice", "Great clip!");
+      const replyId = await createComment("clip-1", "bob", "Agreed!", parentId);
+
+      const res = await POST(
+        postReq({
+          clip_id: "clip-1",
+          author: "carol",
+          text: "Me too!",
+          parent_comment_id: replyId,
+        })
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Cannot reply to a reply (max depth is 1)");
+    });
+
+    it("should return 404 for an unknown parent_comment_id", async () => {
+      const res = await POST(
+        postReq({
+          clip_id: "clip-1",
+          author: "bob",
+          text: "hi",
+          parent_comment_id: "comment-999",
+        })
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should reject a parent comment from a different clip", async () => {
+      const parentId = await createComment("clip-1", "alice", "Great clip!");
+      const res = await POST(
+        postReq({
+          clip_id: "clip-2",
+          author: "bob",
+          text: "hi",
+          parent_comment_id: parentId,
+        })
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("parent_comment_id belongs to a different clip");
+    });
+
+    it("should return 400 when required fields are missing", async () => {
+      const missingClip = await POST(postReq({ author: "alice", text: "hi" }));
+      expect(missingClip.status).toBe(400);
+
+      const missingAuthor = await POST(postReq({ clip_id: "clip-1", text: "hi" }));
+      expect(missingAuthor.status).toBe(400);
+
+      const missingText = await POST(postReq({ clip_id: "clip-1", author: "alice" }));
+      expect(missingText.status).toBe(400);
+
+      const blankText = await POST(
+        postReq({ clip_id: "clip-1", author: "alice", text: "   " })
+      );
+      expect(blankText.status).toBe(400);
+    });
+
+    it("should return 400 for invalid JSON", async () => {
+      const req = new NextRequest(BASE, { method: "POST", body: "not-json" });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/routes-f/clip-comments", () => {
+    it("should return 400 when clip_id is missing", async () => {
+      const res = await GET(new NextRequest(BASE));
+      expect(res.status).toBe(400);
+    });
+
+    it("should list top-level comments with reply counts", async () => {
+      const c1 = await createComment("clip-1", "alice", "First!");
+      await createComment("clip-1", "bob", "Reply A", c1);
+      await createComment("clip-1", "carol", "Reply B", c1);
+      await createComment("clip-1", "dan", "Second!");
+      await createComment("clip-other", "eve", "Different clip");
+
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-1`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.comments).toHaveLength(2);
+      expect(data.comments[0].text).toBe("First!");
+      expect(data.comments[0].reply_count).toBe(2);
+      expect(data.comments[1].text).toBe("Second!");
+      expect(data.comments[1].reply_count).toBe(0);
+      expect(data.has_more).toBe(false);
+      expect(data.next_cursor).toBeNull();
+    });
+
+    it("should not include replies as top-level comments", async () => {
+      const c1 = await createComment("clip-1", "alice", "Top");
+      await createComment("clip-1", "bob", "Reply", c1);
+
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-1`));
+      const data = await res.json();
+      expect(data.comments).toHaveLength(1);
+      expect(data.comments[0].text).toBe("Top");
+    });
+
+    it("should paginate with cursor", async () => {
+      const ids: string[] = [];
+      for (let i = 1; i <= 5; i++) {
+        ids.push(await createComment("clip-1", "alice", `Comment ${i}`));
+      }
+
+      const page1 = await GET(new NextRequest(`${BASE}?clip_id=clip-1&limit=2`));
+      const data1 = await page1.json();
+      expect(data1.comments.map((c: { text: string }) => c.text)).toEqual([
+        "Comment 1",
+        "Comment 2",
+      ]);
+      expect(data1.has_more).toBe(true);
+      expect(data1.next_cursor).toBe(ids[1]);
+
+      const page2 = await GET(
+        new NextRequest(`${BASE}?clip_id=clip-1&limit=2&cursor=${data1.next_cursor}`)
+      );
+      const data2 = await page2.json();
+      expect(data2.comments.map((c: { text: string }) => c.text)).toEqual([
+        "Comment 3",
+        "Comment 4",
+      ]);
+      expect(data2.has_more).toBe(true);
+
+      const page3 = await GET(
+        new NextRequest(`${BASE}?clip_id=clip-1&limit=2&cursor=${data2.next_cursor}`)
+      );
+      const data3 = await page3.json();
+      expect(data3.comments.map((c: { text: string }) => c.text)).toEqual(["Comment 5"]);
+      expect(data3.has_more).toBe(false);
+      expect(data3.next_cursor).toBeNull();
+    });
+
+    it("should return 400 for an invalid cursor", async () => {
+      await createComment("clip-1", "alice", "Only comment");
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-1&cursor=comment-999`));
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 for an invalid limit", async () => {
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-1&limit=0`));
+      expect(res.status).toBe(400);
+
+      const res2 = await GET(new NextRequest(`${BASE}?clip_id=clip-1&limit=abc`));
+      expect(res2.status).toBe(400);
+    });
+
+    it("should return an empty list for a clip with no comments", async () => {
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-empty`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.comments).toEqual([]);
+      expect(data.has_more).toBe(false);
+    });
+  });
+});

--- a/app/api/routes-f/clip-comments/route.ts
+++ b/app/api/routes-f/clip-comments/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface ClipComment {
+  comment_id: string;
+  clip_id: string;
+  author: string;
+  text: string;
+  parent_comment_id: string | null;
+  created_at: string;
+}
+
+// In-memory store for clip comments, keyed by comment_id (insertion order preserved)
+export const CLIP_COMMENTS: Record<string, ClipComment> = {};
+
+let commentCounter = 0;
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { clip_id, author, text, parent_comment_id } = body;
+
+    if (!clip_id || typeof clip_id !== "string") {
+      return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+    }
+    if (!author || typeof author !== "string") {
+      return NextResponse.json({ error: "author is required" }, { status: 400 });
+    }
+    if (!text || typeof text !== "string" || text.trim().length === 0) {
+      return NextResponse.json({ error: "text is required" }, { status: 400 });
+    }
+
+    if (parent_comment_id !== undefined && parent_comment_id !== null) {
+      const parent = CLIP_COMMENTS[parent_comment_id];
+      if (!parent) {
+        return NextResponse.json({ error: "parent_comment_id not found" }, { status: 404 });
+      }
+      if (parent.clip_id !== clip_id) {
+        return NextResponse.json(
+          { error: "parent_comment_id belongs to a different clip" },
+          { status: 400 }
+        );
+      }
+      // Depth is capped at 1: replies to replies are rejected
+      if (parent.parent_comment_id !== null) {
+        return NextResponse.json(
+          { error: "Cannot reply to a reply (max depth is 1)" },
+          { status: 400 }
+        );
+      }
+    }
+
+    commentCounter += 1;
+    const comment: ClipComment = {
+      comment_id: `comment-${commentCounter}`,
+      clip_id,
+      author,
+      text: text.trim(),
+      parent_comment_id: parent_comment_id ?? null,
+      created_at: new Date().toISOString(),
+    };
+    CLIP_COMMENTS[comment.comment_id] = comment;
+
+    return NextResponse.json({ comment_id: comment.comment_id }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+  const cursor = searchParams.get("cursor");
+  const limitParam = searchParams.get("limit");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  let limit = DEFAULT_PAGE_SIZE;
+  if (limitParam !== null) {
+    limit = Number(limitParam);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+      return NextResponse.json(
+        { error: "limit must be an integer between 1 and 100" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const all = Object.values(CLIP_COMMENTS);
+  const topLevel = all.filter((c) => c.clip_id === clipId && c.parent_comment_id === null);
+
+  let startIndex = 0;
+  if (cursor !== null) {
+    const cursorIndex = topLevel.findIndex((c) => c.comment_id === cursor);
+    if (cursorIndex === -1) {
+      return NextResponse.json({ error: "Invalid cursor" }, { status: 400 });
+    }
+    startIndex = cursorIndex + 1;
+  }
+
+  const page = topLevel.slice(startIndex, startIndex + limit);
+  const comments = page.map((c) => ({
+    ...c,
+    reply_count: all.filter((r) => r.parent_comment_id === c.comment_id).length,
+  }));
+
+  const hasMore = startIndex + limit < topLevel.length;
+  const nextCursor = hasMore ? page[page.length - 1].comment_id : null;
+
+  return NextResponse.json({
+    comments,
+    next_cursor: nextCursor,
+    has_more: hasMore,
+  });
+}

--- a/app/api/routes-f/clip-cover-image/route.test.ts
+++ b/app/api/routes-f/clip-cover-image/route.test.ts
@@ -1,0 +1,100 @@
+import { GET, PUT, CLIP_COVERS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-cover-image";
+
+function putReq(body: unknown) {
+  return new NextRequest(BASE, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Clip Cover Image", () => {
+  beforeEach(() => {
+    for (const key in CLIP_COVERS) {
+      delete CLIP_COVERS[key];
+    }
+  });
+
+  describe("PUT /api/routes-f/clip-cover-image", () => {
+    it("should set a custom cover for a clip", async () => {
+      const res = await PUT(
+        putReq({ clip_id: "clip-1", cover_url: "https://cdn.example.com/cover.png" })
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.custom).toBe(true);
+      expect(data.cover_url).toBe("https://cdn.example.com/cover.png");
+      expect(CLIP_COVERS["clip-1"]).toBe("https://cdn.example.com/cover.png");
+    });
+
+    it("should overwrite an existing custom cover", async () => {
+      await PUT(putReq({ clip_id: "clip-1", cover_url: "https://cdn.example.com/a.png" }));
+      await PUT(putReq({ clip_id: "clip-1", cover_url: "https://cdn.example.com/b.png" }));
+
+      expect(CLIP_COVERS["clip-1"]).toBe("https://cdn.example.com/b.png");
+    });
+
+    it("should return 400 for an invalid URL", async () => {
+      const res = await PUT(putReq({ clip_id: "clip-1", cover_url: "not a url" }));
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("cover_url is not a valid URL");
+      expect(CLIP_COVERS["clip-1"]).toBeUndefined();
+    });
+
+    it("should return 400 for a non-http(s) URL", async () => {
+      const res = await PUT(
+        putReq({ clip_id: "clip-1", cover_url: "ftp://example.com/cover.png" })
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("cover_url must use http or https");
+    });
+
+    it("should return 400 when clip_id or cover_url is missing", async () => {
+      const noClip = await PUT(putReq({ cover_url: "https://cdn.example.com/a.png" }));
+      expect(noClip.status).toBe(400);
+
+      const noUrl = await PUT(putReq({ clip_id: "clip-1" }));
+      expect(noUrl.status).toBe(400);
+    });
+
+    it("should return 400 for invalid JSON", async () => {
+      const req = new NextRequest(BASE, { method: "PUT", body: "not-json" });
+      const res = await PUT(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/routes-f/clip-cover-image", () => {
+    it("should return the custom cover when one is set", async () => {
+      await PUT(
+        putReq({ clip_id: "clip-1", cover_url: "https://cdn.example.com/cover.png" })
+      );
+
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-1`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.cover_url).toBe("https://cdn.example.com/cover.png");
+      expect(data.custom).toBe(true);
+    });
+
+    it("should fall back to the auto thumbnail when no custom cover is set", async () => {
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-2`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.custom).toBe(false);
+      expect(data.cover_url).toBe("https://image.mux.com/clip-2/thumbnail.jpg");
+    });
+
+    it("should return 400 when clip_id is missing", async () => {
+      const res = await GET(new NextRequest(BASE));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/clip-cover-image/route.ts
+++ b/app/api/routes-f/clip-cover-image/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// In-memory store for custom cover images: clip_id -> cover_url
+export const CLIP_COVERS: Record<string, string> = {};
+
+// Fallback auto-generated thumbnail (what Mux would produce for the clip)
+function autoThumbnailUrl(clipId: string): string {
+  return `https://image.mux.com/${clipId}/thumbnail.jpg`;
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { clip_id, cover_url } = body;
+
+    if (!clip_id || typeof clip_id !== "string") {
+      return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+    }
+    if (!cover_url || typeof cover_url !== "string") {
+      return NextResponse.json({ error: "cover_url is required" }, { status: 400 });
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(cover_url);
+    } catch {
+      return NextResponse.json({ error: "cover_url is not a valid URL" }, { status: 400 });
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return NextResponse.json(
+        { error: "cover_url must use http or https" },
+        { status: 400 }
+      );
+    }
+
+    CLIP_COVERS[clip_id] = cover_url;
+
+    return NextResponse.json({ clip_id, cover_url, custom: true });
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  const custom = clipId in CLIP_COVERS;
+  const coverUrl = custom ? CLIP_COVERS[clipId] : autoThumbnailUrl(clipId);
+
+  return NextResponse.json({ cover_url: coverUrl, custom });
+}

--- a/app/api/routes-f/clip-duration-filter/route.test.ts
+++ b/app/api/routes-f/clip-duration-filter/route.test.ts
@@ -1,0 +1,84 @@
+import { GET, SEED_CLIPS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-duration-filter";
+
+async function fetchClips(query = "") {
+  const res = await GET(new NextRequest(`${BASE}${query}`));
+  return { res, data: await res.json() };
+}
+
+describe("Clip Duration Filter", () => {
+  describe("GET /api/routes-f/clip-duration-filter", () => {
+    it("should return all seed clips sorted by duration asc when no filters given", async () => {
+      const { res, data } = await fetchClips();
+
+      expect(res.status).toBe(200);
+      expect(data.clips).toHaveLength(SEED_CLIPS.length);
+      const durations = data.clips.map((c: { duration_seconds: number }) => c.duration_seconds);
+      expect(durations).toEqual([...durations].sort((a, b) => a - b));
+    });
+
+    it("should filter by min_seconds (inclusive)", async () => {
+      const { data } = await fetchClips("?min_seconds=95");
+      const durations = data.clips.map((c: { duration_seconds: number }) => c.duration_seconds);
+      expect(durations).toEqual([95, 180, 240]);
+    });
+
+    it("should filter by max_seconds (inclusive)", async () => {
+      const { data } = await fetchClips("?max_seconds=15");
+      const durations = data.clips.map((c: { duration_seconds: number }) => c.duration_seconds);
+      expect(durations).toEqual([8, 12, 15]);
+    });
+
+    it("should filter by a min/max window combined", async () => {
+      const { data } = await fetchClips("?min_seconds=15&max_seconds=95");
+      const durations = data.clips.map((c: { duration_seconds: number }) => c.duration_seconds);
+      expect(durations).toEqual([15, 30, 45, 95]);
+    });
+
+    it("should filter by creator_id", async () => {
+      const { data } = await fetchClips("?creator_id=creator-2");
+      expect(data.clips).toHaveLength(3);
+      for (const clip of data.clips) {
+        expect(clip.creator_id).toBe("creator-2");
+      }
+    });
+
+    it("should combine creator_id with a duration window", async () => {
+      const { data } = await fetchClips("?creator_id=creator-1&max_seconds=50");
+      const ids = data.clips.map((c: { clip_id: string }) => c.clip_id);
+      expect(ids).toEqual(["clip-1", "clip-2"]);
+    });
+
+    it("should respect the limit parameter", async () => {
+      const { data } = await fetchClips("?limit=2");
+      expect(data.clips).toHaveLength(2);
+      const durations = data.clips.map((c: { duration_seconds: number }) => c.duration_seconds);
+      expect(durations).toEqual([8, 12]);
+    });
+
+    it("should return an empty list when the window matches nothing", async () => {
+      const { res, data } = await fetchClips("?min_seconds=1000");
+      expect(res.status).toBe(200);
+      expect(data.clips).toEqual([]);
+      expect(data.total).toBe(0);
+    });
+
+    it("should return 400 when min_seconds is greater than max_seconds", async () => {
+      const { res } = await fetchClips("?min_seconds=100&max_seconds=10");
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 for non-numeric or negative bounds", async () => {
+      expect((await fetchClips("?min_seconds=abc")).res.status).toBe(400);
+      expect((await fetchClips("?max_seconds=-5")).res.status).toBe(400);
+    });
+
+    it("should return 400 for an invalid limit", async () => {
+      expect((await fetchClips("?limit=0")).res.status).toBe(400);
+      expect((await fetchClips("?limit=abc")).res.status).toBe(400);
+      expect((await fetchClips("?limit=101")).res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/clip-duration-filter/route.ts
+++ b/app/api/routes-f/clip-duration-filter/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface SeedClip {
+  clip_id: string;
+  creator_id: string;
+  title: string;
+  duration_seconds: number;
+}
+
+// Seed clips with varied durations, bundled per the routes-f scope constraint
+export const SEED_CLIPS: SeedClip[] = [
+  { clip_id: "clip-1", creator_id: "creator-1", title: "Insane clutch round", duration_seconds: 12 },
+  { clip_id: "clip-2", creator_id: "creator-1", title: "Boss fight highlight", duration_seconds: 45 },
+  { clip_id: "clip-3", creator_id: "creator-1", title: "Full raid recap", duration_seconds: 180 },
+  { clip_id: "clip-4", creator_id: "creator-2", title: "Funny chat moment", duration_seconds: 8 },
+  { clip_id: "clip-5", creator_id: "creator-2", title: "Speedrun world record", duration_seconds: 95 },
+  { clip_id: "clip-6", creator_id: "creator-2", title: "XLM tip rain reaction", duration_seconds: 30 },
+  { clip_id: "clip-7", creator_id: "creator-3", title: "Tutorial: wallet setup", duration_seconds: 240 },
+  { clip_id: "clip-8", creator_id: "creator-3", title: "Stream intro", duration_seconds: 15 },
+];
+
+const DEFAULT_LIMIT = 20;
+
+function parseNonNegativeNumber(value: string): number | null {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return num;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+  const minParam = searchParams.get("min_seconds");
+  const maxParam = searchParams.get("max_seconds");
+  const limitParam = searchParams.get("limit");
+
+  let minSeconds: number | null = null;
+  if (minParam !== null) {
+    minSeconds = parseNonNegativeNumber(minParam);
+    if (minSeconds === null) {
+      return NextResponse.json(
+        { error: "min_seconds must be a non-negative number" },
+        { status: 400 }
+      );
+    }
+  }
+
+  let maxSeconds: number | null = null;
+  if (maxParam !== null) {
+    maxSeconds = parseNonNegativeNumber(maxParam);
+    if (maxSeconds === null) {
+      return NextResponse.json(
+        { error: "max_seconds must be a non-negative number" },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (minSeconds !== null && maxSeconds !== null && minSeconds > maxSeconds) {
+    return NextResponse.json(
+      { error: "min_seconds cannot be greater than max_seconds" },
+      { status: 400 }
+    );
+  }
+
+  let limit = DEFAULT_LIMIT;
+  if (limitParam !== null) {
+    const parsed = Number(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+      return NextResponse.json(
+        { error: "limit must be an integer between 1 and 100" },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  const clips = SEED_CLIPS.filter((clip) => {
+    if (creatorId !== null && clip.creator_id !== creatorId) return false;
+    if (minSeconds !== null && clip.duration_seconds < minSeconds) return false;
+    if (maxSeconds !== null && clip.duration_seconds > maxSeconds) return false;
+    return true;
+  })
+    .sort((a, b) => a.duration_seconds - b.duration_seconds)
+    .slice(0, limit);
+
+  return NextResponse.json({ clips, total: clips.length });
+}

--- a/app/api/routes-f/clip-language/detectLanguage.ts
+++ b/app/api/routes-f/clip-language/detectLanguage.ts
@@ -1,0 +1,47 @@
+// Charset-range language detection heuristic, bundled inside this folder per
+// the routes-f scope constraint. Counts characters per Unicode script block and
+// returns the language whose script dominates; Latin text defaults to English.
+
+interface ScriptRange {
+  language: string;
+  start: number;
+  end: number;
+}
+
+const SCRIPT_RANGES: ScriptRange[] = [
+  { language: "ja", start: 0x3040, end: 0x30ff }, // Hiragana + Katakana
+  { language: "ko", start: 0xac00, end: 0xd7af }, // Hangul syllables
+  { language: "zh", start: 0x4e00, end: 0x9fff }, // CJK unified ideographs
+  { language: "ar", start: 0x0600, end: 0x06ff }, // Arabic
+  { language: "ru", start: 0x0400, end: 0x04ff }, // Cyrillic
+  { language: "hi", start: 0x0900, end: 0x097f }, // Devanagari
+  { language: "en", start: 0x0041, end: 0x024f }, // Latin (incl. extended)
+];
+
+export const SUPPORTED_LANGUAGES = ["en", "es", "fr", "de", "pt", "ru", "zh", "ja", "ko", "ar", "hi"];
+
+export function detectLanguage(text: string): string {
+  const counts: Record<string, number> = {};
+
+  for (const char of text) {
+    const code = char.codePointAt(0);
+    if (code === undefined) continue;
+    for (const range of SCRIPT_RANGES) {
+      if (code >= range.start && code <= range.end) {
+        counts[range.language] = (counts[range.language] || 0) + 1;
+        break;
+      }
+    }
+  }
+
+  let best = "en";
+  let bestCount = 0;
+  for (const [language, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = language;
+      bestCount = count;
+    }
+  }
+
+  return best;
+}

--- a/app/api/routes-f/clip-language/route.test.ts
+++ b/app/api/routes-f/clip-language/route.test.ts
@@ -1,0 +1,118 @@
+import { GET, PUT, MANUAL_LANGUAGES } from "./route";
+import { detectLanguage } from "./detectLanguage";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-language";
+
+function putReq(body: unknown) {
+  return new NextRequest(BASE, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Clip Language Metadata", () => {
+  beforeEach(() => {
+    for (const key in MANUAL_LANGUAGES) {
+      delete MANUAL_LANGUAGES[key];
+    }
+  });
+
+  describe("detectLanguage heuristic", () => {
+    it("should detect English from Latin text", () => {
+      expect(detectLanguage("Hello there, welcome to the stream")).toBe("en");
+    });
+
+    it("should detect Russian from Cyrillic text", () => {
+      expect(detectLanguage("Привет, как дела?")).toBe("ru");
+    });
+
+    it("should detect Japanese from kana text", () => {
+      expect(detectLanguage("こんにちは、元気ですか")).toBe("ja");
+    });
+
+    it("should detect Chinese from ideographic text", () => {
+      expect(detectLanguage("你好，欢迎来到直播间")).toBe("zh");
+    });
+
+    it("should detect Arabic from Arabic script", () => {
+      expect(detectLanguage("مرحبا بكم في البث المباشر")).toBe("ar");
+    });
+
+    it("should default to English for empty or symbol-only text", () => {
+      expect(detectLanguage("")).toBe("en");
+      expect(detectLanguage("123 !!! ???")).toBe("en");
+    });
+  });
+
+  describe("GET /api/routes-f/clip-language", () => {
+    it("should return detected language for a seeded English clip", async () => {
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-en`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({ language: "en", source: "detected" });
+    });
+
+    it("should return detected language for non-Latin transcripts", async () => {
+      const ru = await (await GET(new NextRequest(`${BASE}?clip_id=clip-ru`))).json();
+      expect(ru).toEqual({ language: "ru", source: "detected" });
+
+      const ja = await (await GET(new NextRequest(`${BASE}?clip_id=clip-ja`))).json();
+      expect(ja).toEqual({ language: "ja", source: "detected" });
+
+      const zh = await (await GET(new NextRequest(`${BASE}?clip_id=clip-zh`))).json();
+      expect(zh).toEqual({ language: "zh", source: "detected" });
+    });
+
+    it("should return 404 for an unknown clip", async () => {
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-unknown`));
+      expect(res.status).toBe(404);
+    });
+
+    it("should return 400 when clip_id is missing", async () => {
+      const res = await GET(new NextRequest(BASE));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("PUT /api/routes-f/clip-language (manual override)", () => {
+    it("should set a manual language and prefer it over detection", async () => {
+      const putRes = await PUT(putReq({ clip_id: "clip-en", language: "es" }));
+      expect(putRes.status).toBe(200);
+      const putData = await putRes.json();
+      expect(putData).toEqual({ clip_id: "clip-en", language: "es", source: "manual" });
+
+      const getRes = await GET(new NextRequest(`${BASE}?clip_id=clip-en`));
+      const getData = await getRes.json();
+      expect(getData).toEqual({ language: "es", source: "manual" });
+    });
+
+    it("should allow a manual language for a clip without a transcript", async () => {
+      await PUT(putReq({ clip_id: "clip-no-transcript", language: "fr" }));
+
+      const res = await GET(new NextRequest(`${BASE}?clip_id=clip-no-transcript`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({ language: "fr", source: "manual" });
+    });
+
+    it("should reject an unsupported language code", async () => {
+      const res = await PUT(putReq({ clip_id: "clip-en", language: "xx" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 when clip_id or language is missing", async () => {
+      const noClip = await PUT(putReq({ language: "en" }));
+      expect(noClip.status).toBe(400);
+
+      const noLang = await PUT(putReq({ clip_id: "clip-en" }));
+      expect(noLang.status).toBe(400);
+    });
+
+    it("should return 400 for invalid JSON", async () => {
+      const req = new NextRequest(BASE, { method: "PUT", body: "not-json" });
+      const res = await PUT(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routes-f/clip-language/route.ts
+++ b/app/api/routes-f/clip-language/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { detectLanguage, SUPPORTED_LANGUAGES } from "./detectLanguage";
+
+// Seed transcripts (what the platform's transcription step would produce)
+export const CLIP_TRANSCRIPTS: Record<string, string> = {
+  "clip-en": "Welcome back everyone, today we are speedrunning the new dungeon!",
+  "clip-ru": "Всем привет, сегодня мы проходим новое подземелье!",
+  "clip-ja": "みなさんこんにちは、今日は新しいダンジョンに挑戦します！",
+  "clip-zh": "大家好，今天我们挑战新的地下城！",
+  "clip-ar": "مرحبا بالجميع، اليوم سوف نستكشف الزنزانة الجديدة",
+};
+
+// Manual overrides: clip_id -> language code
+export const MANUAL_LANGUAGES: Record<string, string> = {};
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  if (clipId in MANUAL_LANGUAGES) {
+    return NextResponse.json({ language: MANUAL_LANGUAGES[clipId], source: "manual" });
+  }
+
+  const transcript = CLIP_TRANSCRIPTS[clipId];
+  if (transcript === undefined) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ language: detectLanguage(transcript), source: "detected" });
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { clip_id, language } = body;
+
+    if (!clip_id || typeof clip_id !== "string") {
+      return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+    }
+    if (!language || typeof language !== "string") {
+      return NextResponse.json({ error: "language is required" }, { status: 400 });
+    }
+    if (!SUPPORTED_LANGUAGES.includes(language)) {
+      return NextResponse.json(
+        { error: `language must be one of: ${SUPPORTED_LANGUAGES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    MANUAL_LANGUAGES[clip_id] = language;
+
+    return NextResponse.json({ clip_id, language, source: "manual" });
+  } catch (e) {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+}


### PR DESCRIPTION
# Description

Closes #1215
Closes #1217
Closes #1219
Closes #1220

This PR implements four self-contained `routes-f` clip endpoints. Per the scope constraint on each issue, every file (handlers, helpers, seed data, tests) lives inside its own `app/api/routes-f/<route>/` folder — nothing outside `app/api/routes-f/` is imported or modified.

# Changes proposed

## What were you told to do?

- #1215 — feat(routes-f): clip comments thread
- #1217 — feat(routes-f): custom clip cover image
- #1219 — feat(routes-f): clip language metadata
- #1220 — feat(routes-f): filter clips by duration

## What did you do?

- **#1215 — clip comments thread** (`app/api/routes-f/clip-comments/`): `POST` accepts `{ clip_id, author, text, parent_comment_id? }`, validates required fields, and returns `{ comment_id }` with 201. Replies are capped at depth 1 — replying to a reply returns 400, an unknown parent returns 404, and a parent belonging to a different clip returns 400. `GET ?clip_id&cursor?&limit?` returns top-level comments in insertion order with a `reply_count` per comment, plus `next_cursor`/`has_more` cursor pagination (default page size 10, limit capped at 100; unknown cursor returns 400).
- **#1217 — custom clip cover image** (`app/api/routes-f/clip-cover-image/`): `PUT { clip_id, cover_url }` validates the URL with `new URL()` (and restricts to http/https, so strings like `ftp://…` or `not a url` are rejected with 400) and stores the override. `GET ?clip_id` returns `{ cover_url, custom }` — the custom URL when set, otherwise a Mux-style auto-thumbnail fallback with `custom: false`.
- **#1219 — clip language metadata** (`app/api/routes-f/clip-language/`): `GET ?clip_id` returns `{ language, source: "detected" | "manual" }`. Detection uses a bundled charset-range heuristic (`detectLanguage.ts`) that counts characters per Unicode script block (Hiragana/Katakana, Hangul, CJK, Arabic, Cyrillic, Devanagari, Latin) and picks the dominant script, defaulting to `en`. Seed transcripts cover en/ru/ja/zh/ar. `PUT { clip_id, language }` sets a manual override (validated against a supported-language list) which then takes precedence over detection.
- **#1220 — filter clips by duration** (`app/api/routes-f/clip-duration-filter/`): `GET ?creator_id?&min_seconds?&max_seconds?&limit?` filters bundled seed clips (8 clips, 8–240s, 3 creators) by an inclusive duration window and optional creator, sorted by duration ascending, default limit 20. Rejects negative/non-numeric bounds, `min > max`, and out-of-range limits with 400.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [ ] I am making a pull request against the _main branch_ (left side). (Targeting `dev`, the repo default branch.)
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

API-only change; behavior is covered by the colocated jest suites below.

## Test plan

- `npx jest app/api/routes-f/clip-comments app/api/routes-f/clip-cover-image app/api/routes-f/clip-language app/api/routes-f/clip-duration-filter` — 4 suites, 49 tests, all passing locally. Coverage includes: post/reply/depth-cap/pagination and invalid-cursor cases (#1215); set, retrieve, fallback, and invalid/non-http URL cases (#1217); per-script detection, default-to-English, manual override precedence (#1219); each bound individually, combined window, creator filter, no-filter, and empty-result cases (#1220).
- `tsc --noEmit` reports no errors in any of the added files.

---

Note: `dev` currently has pre-existing type errors in `app/api/routes-f/featured-stream/mock-data.ts` (unrelated to this PR), which cause the husky pre-commit type-check to fail on any commit; this PR does not touch that file.