### PR TITLE
feat(routesF): wallet balance cache, preferences export, 2FA recovery codes, debug echo

### DIFF
--- a/app/api/routesF/debug-echo/route.test.ts
+++ b/app/api/routesF/debug-echo/route.test.ts
@@ -1,0 +1,77 @@
+import { POST, MAX_PAYLOAD_BYTES } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/debug-echo';
+
+function echoReq(body: string, headers?: Record<string, string>) {
+  return new NextRequest(BASE, { method: 'POST', body, headers });
+}
+
+describe('Debug Echo Endpoint', () => {
+  describe('POST /api/routesF/debug-echo', () => {
+    it('should echo the JSON payload back with a timestamp', async () => {
+      const payload = { hello: 'world', nested: { count: 3 }, list: [1, 2, 3] };
+      const res = await POST(echoReq(JSON.stringify(payload)));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.received).toEqual(payload);
+      expect(Number.isNaN(new Date(data.timestamp).getTime())).toBe(false);
+    });
+
+    it('should include only allow-listed headers', async () => {
+      const res = await POST(
+        echoReq(JSON.stringify({ ping: true }), {
+          'content-type': 'application/json',
+          'user-agent': 'streamfi-test/1.0',
+          'x-request-id': 'req-42',
+          authorization: 'Bearer super-secret',
+          cookie: 'session=abc123',
+        })
+      );
+
+      const data = await res.json();
+      expect(data.headers['content-type']).toBe('application/json');
+      expect(data.headers['user-agent']).toBe('streamfi-test/1.0');
+      expect(data.headers['x-request-id']).toBe('req-42');
+      expect(data.headers.authorization).toBeUndefined();
+      expect(data.headers.cookie).toBeUndefined();
+    });
+
+    it('should omit allow-listed headers that were not sent', async () => {
+      const res = await POST(echoReq(JSON.stringify({}), {}));
+      const data = await res.json();
+      expect(data.headers['x-request-id']).toBeUndefined();
+    });
+
+    it('should echo primitive JSON payloads', async () => {
+      const res = await POST(echoReq('"just a string"'));
+      const data = await res.json();
+      expect(data.received).toBe('just a string');
+    });
+
+    it('should treat an empty body as null', async () => {
+      const res = await POST(echoReq(''));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.received).toBeNull();
+    });
+
+    it('should reject a payload over 100KB with 413', async () => {
+      const big = JSON.stringify({ blob: 'x'.repeat(MAX_PAYLOAD_BYTES) });
+      const res = await POST(echoReq(big));
+      expect(res.status).toBe(413);
+    });
+
+    it('should accept a payload just under the cap', async () => {
+      const padding = MAX_PAYLOAD_BYTES - JSON.stringify({ blob: '' }).length - 100;
+      const res = await POST(echoReq(JSON.stringify({ blob: 'x'.repeat(padding) })));
+      expect(res.status).toBe(200);
+    });
+
+    it('should return 400 for invalid JSON', async () => {
+      const res = await POST(echoReq('{not json'));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/debug-echo/route.ts
+++ b/app/api/routesF/debug-echo/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Only these request headers are echoed back, to avoid reflecting
+// authorization tokens or cookies
+export const HEADER_ALLOW_LIST = [
+  'content-type',
+  'user-agent',
+  'accept',
+  'accept-language',
+  'x-request-id',
+];
+
+export const MAX_PAYLOAD_BYTES = 100 * 1024; // 100KB
+
+export async function POST(req: NextRequest) {
+  const raw = await req.text();
+
+  if (Buffer.byteLength(raw, 'utf8') > MAX_PAYLOAD_BYTES) {
+    return NextResponse.json(
+      { error: `Payload exceeds ${MAX_PAYLOAD_BYTES} bytes` },
+      { status: 413 }
+    );
+  }
+
+  let received: unknown;
+  try {
+    received = raw.length === 0 ? null : JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON' }, { status: 400 });
+  }
+
+  const headers: Record<string, string> = {};
+  for (const name of HEADER_ALLOW_LIST) {
+    const value = req.headers.get(name);
+    if (value !== null) {
+      headers[name] = value;
+    }
+  }
+
+  return NextResponse.json({
+    received,
+    headers,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/routesF/two-factor-recovery-codes/generate/route.ts
+++ b/app/api/routesF/two-factor-recovery-codes/generate/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateCodes } from '../store';
+
+const DEFAULT_COUNT = 10;
+const MAX_COUNT = 20;
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { user_id, count } = body;
+
+    if (!user_id || typeof user_id !== 'string') {
+      return NextResponse.json({ error: 'user_id is required' }, { status: 400 });
+    }
+
+    let codeCount = DEFAULT_COUNT;
+    if (count !== undefined) {
+      if (!Number.isInteger(count) || count < 1 || count > MAX_COUNT) {
+        return NextResponse.json(
+          { error: `count must be an integer between 1 and ${MAX_COUNT}` },
+          { status: 400 }
+        );
+      }
+      codeCount = count;
+    }
+
+    const codes = generateCodes(user_id, codeCount);
+
+    return NextResponse.json({ codes }, { status: 201 });
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/two-factor-recovery-codes/route.test.ts
+++ b/app/api/routesF/two-factor-recovery-codes/route.test.ts
@@ -1,0 +1,128 @@
+import { POST as GENERATE } from './generate/route';
+import { POST as USE } from './use/route';
+import { RECOVERY_CODES } from './store';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/two-factor-recovery-codes';
+
+function generateReq(body: unknown) {
+  return new NextRequest(`${BASE}/generate`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function useReq(body: unknown) {
+  return new NextRequest(`${BASE}/use`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('2FA Recovery Codes', () => {
+  beforeEach(() => {
+    for (const key in RECOVERY_CODES) {
+      delete RECOVERY_CODES[key];
+    }
+  });
+
+  describe('POST /api/routesF/two-factor-recovery-codes/generate', () => {
+    it('should generate 10 unique codes by default', async () => {
+      const res = await GENERATE(generateReq({ user_id: 'user-1' }));
+
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.codes).toHaveLength(10);
+      expect(new Set(data.codes).size).toBe(10);
+      for (const code of data.codes) {
+        expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{4}$/);
+      }
+    });
+
+    it('should respect a custom count', async () => {
+      const res = await GENERATE(generateReq({ user_id: 'user-1', count: 5 }));
+      const data = await res.json();
+      expect(data.codes).toHaveLength(5);
+    });
+
+    it('should invalidate previous codes when regenerating', async () => {
+      const first = await (await GENERATE(generateReq({ user_id: 'user-1' }))).json();
+      await GENERATE(generateReq({ user_id: 'user-1' }));
+
+      const res = await USE(useReq({ user_id: 'user-1', code: first.codes[0] }));
+      const data = await res.json();
+      expect(data.valid).toBe(false);
+      expect(data.codes_remaining).toBe(10);
+    });
+
+    it('should reject an invalid count', async () => {
+      expect((await GENERATE(generateReq({ user_id: 'user-1', count: 0 }))).status).toBe(400);
+      expect((await GENERATE(generateReq({ user_id: 'user-1', count: 21 }))).status).toBe(400);
+      expect((await GENERATE(generateReq({ user_id: 'user-1', count: 2.5 }))).status).toBe(400);
+    });
+
+    it('should return 400 when user_id is missing', async () => {
+      const res = await GENERATE(generateReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for invalid JSON', async () => {
+      const req = new NextRequest(`${BASE}/generate`, { method: 'POST', body: 'not-json' });
+      const res = await GENERATE(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/routesF/two-factor-recovery-codes/use', () => {
+    it('should accept a valid code and decrement codes_remaining', async () => {
+      const { codes } = await (await GENERATE(generateReq({ user_id: 'user-1' }))).json();
+
+      const res = await USE(useReq({ user_id: 'user-1', code: codes[0] }));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.valid).toBe(true);
+      expect(data.codes_remaining).toBe(9);
+    });
+
+    it('should invalidate a code once used', async () => {
+      const { codes } = await (await GENERATE(generateReq({ user_id: 'user-1' }))).json();
+
+      const first = await (await USE(useReq({ user_id: 'user-1', code: codes[0] }))).json();
+      expect(first.valid).toBe(true);
+
+      const second = await (await USE(useReq({ user_id: 'user-1', code: codes[0] }))).json();
+      expect(second.valid).toBe(false);
+      expect(second.codes_remaining).toBe(9);
+    });
+
+    it('should reject an unknown code without changing the remaining count', async () => {
+      await GENERATE(generateReq({ user_id: 'user-1' }));
+
+      const res = await USE(useReq({ user_id: 'user-1', code: 'ZZZZ-ZZZZ' }));
+      const data = await res.json();
+      expect(data.valid).toBe(false);
+      expect(data.codes_remaining).toBe(10);
+    });
+
+    it('should reject a code for a user with no generated codes', async () => {
+      const res = await USE(useReq({ user_id: 'user-none', code: 'ABCD-EFGH' }));
+      const data = await res.json();
+      expect(data.valid).toBe(false);
+      expect(data.codes_remaining).toBe(0);
+    });
+
+    it("should not let one user's code work for another user", async () => {
+      const { codes } = await (await GENERATE(generateReq({ user_id: 'user-1' }))).json();
+      await GENERATE(generateReq({ user_id: 'user-2' }));
+
+      const res = await USE(useReq({ user_id: 'user-2', code: codes[0] }));
+      const data = await res.json();
+      expect(data.valid).toBe(false);
+    });
+
+    it('should return 400 when user_id or code is missing', async () => {
+      expect((await USE(useReq({ code: 'ABCD-EFGH' }))).status).toBe(400);
+      expect((await USE(useReq({ user_id: 'user-1' }))).status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/two-factor-recovery-codes/store.ts
+++ b/app/api/routesF/two-factor-recovery-codes/store.ts
@@ -1,0 +1,33 @@
+// In-memory storage for one-time 2FA recovery codes, bundled inside this
+// folder per the routesF scope constraint. user_id -> set of unused codes.
+
+export const RECOVERY_CODES: Record<string, Set<string>> = {};
+
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no 0/O/1/I lookalikes
+
+function randomSegment(length: number): string {
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+  }
+  return out;
+}
+
+export function generateCodes(userId: string, count: number): string[] {
+  const codes = new Set<string>();
+  while (codes.size < count) {
+    codes.add(`${randomSegment(4)}-${randomSegment(4)}`);
+  }
+  // Regenerating replaces any previous batch: old codes are invalidated
+  RECOVERY_CODES[userId] = new Set(codes);
+  return [...codes];
+}
+
+export function useCode(userId: string, code: string): { valid: boolean; codes_remaining: number } {
+  const codes = RECOVERY_CODES[userId];
+  if (!codes || !codes.has(code)) {
+    return { valid: false, codes_remaining: codes ? codes.size : 0 };
+  }
+  codes.delete(code);
+  return { valid: true, codes_remaining: codes.size };
+}

--- a/app/api/routesF/two-factor-recovery-codes/use/route.ts
+++ b/app/api/routesF/two-factor-recovery-codes/use/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { useCode } from '../store';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { user_id, code } = body;
+
+    if (!user_id || typeof user_id !== 'string') {
+      return NextResponse.json({ error: 'user_id is required' }, { status: 400 });
+    }
+    if (!code || typeof code !== 'string') {
+      return NextResponse.json({ error: 'code is required' }, { status: 400 });
+    }
+
+    const result = useCode(user_id, code);
+
+    return NextResponse.json(result);
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/viewer-preferences-export/route.test.ts
+++ b/app/api/routesF/viewer-preferences-export/route.test.ts
@@ -1,0 +1,74 @@
+import { GET, SEED_PREFERENCES } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/viewer-preferences-export';
+
+describe('Viewer Preferences Export', () => {
+  describe('GET /api/routesF/viewer-preferences-export', () => {
+    it('should export the full preferences shape for a seeded viewer', async () => {
+      const res = await GET(new NextRequest(`${BASE}?viewer_id=viewer-1`));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.viewer_id).toBe('viewer-1');
+      expect(data.theme).toBe('dark');
+      expect(data.language).toBe('en');
+      expect(data.tip_currency).toBe('XLM');
+
+      expect(data.notifications).toEqual({
+        stream_live: true,
+        new_follower: true,
+        tips_received: true,
+        email_digest: 'weekly',
+      });
+
+      expect(data.follows).toHaveLength(2);
+      for (const follow of data.follows) {
+        expect(typeof follow.creator_id).toBe('string');
+        expect(typeof follow.followed_at).toBe('string');
+        expect(typeof follow.notifications_enabled).toBe('boolean');
+      }
+    });
+
+    it('should include every top-level preference key plus export_generated_at', async () => {
+      const res = await GET(new NextRequest(`${BASE}?viewer_id=viewer-1`));
+      const data = await res.json();
+
+      const expectedKeys = [
+        ...Object.keys(SEED_PREFERENCES['viewer-1']),
+        'export_generated_at',
+      ].sort();
+      expect(Object.keys(data).sort()).toEqual(expectedKeys);
+    });
+
+    it('should include a valid ISO export_generated_at timestamp', async () => {
+      const before = Date.now();
+      const res = await GET(new NextRequest(`${BASE}?viewer_id=viewer-2`));
+      const after = Date.now();
+      const data = await res.json();
+
+      const generatedAt = new Date(data.export_generated_at).getTime();
+      expect(Number.isNaN(generatedAt)).toBe(false);
+      expect(generatedAt).toBeGreaterThanOrEqual(before);
+      expect(generatedAt).toBeLessThanOrEqual(after);
+    });
+
+    it('should export a viewer with no follows as an empty array', async () => {
+      const res = await GET(new NextRequest(`${BASE}?viewer_id=viewer-2`));
+      const data = await res.json();
+      expect(data.follows).toEqual([]);
+      expect(data.notifications.email_digest).toBe('off');
+    });
+
+    it('should return 404 for an unknown viewer', async () => {
+      const res = await GET(new NextRequest(`${BASE}?viewer_id=viewer-999`));
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 when viewer_id is missing', async () => {
+      const res = await GET(new NextRequest(BASE));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/viewer-preferences-export/route.ts
+++ b/app/api/routesF/viewer-preferences-export/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface ViewerPreferences {
+  viewer_id: string;
+  theme: 'dark' | 'light' | 'system';
+  notifications: {
+    stream_live: boolean;
+    new_follower: boolean;
+    tips_received: boolean;
+    email_digest: 'daily' | 'weekly' | 'off';
+  };
+  follows: { creator_id: string; followed_at: string; notifications_enabled: boolean }[];
+  language: string;
+  tip_currency: 'XLM' | 'USDC';
+}
+
+// Seed viewer preferences, bundled inside this folder per the routesF scope constraint
+export const SEED_PREFERENCES: Record<string, ViewerPreferences> = {
+  'viewer-1': {
+    viewer_id: 'viewer-1',
+    theme: 'dark',
+    notifications: {
+      stream_live: true,
+      new_follower: true,
+      tips_received: true,
+      email_digest: 'weekly',
+    },
+    follows: [
+      { creator_id: 'creator-1', followed_at: '2025-11-02T10:15:00Z', notifications_enabled: true },
+      { creator_id: 'creator-3', followed_at: '2026-01-18T20:40:00Z', notifications_enabled: false },
+    ],
+    language: 'en',
+    tip_currency: 'XLM',
+  },
+  'viewer-2': {
+    viewer_id: 'viewer-2',
+    theme: 'system',
+    notifications: {
+      stream_live: false,
+      new_follower: false,
+      tips_received: true,
+      email_digest: 'off',
+    },
+    follows: [],
+    language: 'es',
+    tip_currency: 'USDC',
+  },
+};
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const viewerId = searchParams.get('viewer_id');
+
+  if (!viewerId) {
+    return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+  }
+
+  const preferences = SEED_PREFERENCES[viewerId];
+  if (!preferences) {
+    return NextResponse.json({ error: 'Viewer not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ...preferences,
+    export_generated_at: new Date().toISOString(),
+  });
+}

--- a/app/api/routesF/wallet-balance/refresh/route.ts
+++ b/app/api/routesF/wallet-balance/refresh/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cacheBalance, TTL_SECONDS } from '../store';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { wallet } = body;
+
+    if (!wallet || typeof wallet !== 'string') {
+      return NextResponse.json({ error: 'wallet is required' }, { status: 400 });
+    }
+
+    const entry = cacheBalance(wallet);
+    if (!entry) {
+      return NextResponse.json({ error: 'Wallet not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      balance_xlm: entry.balance_xlm,
+      balance_usdc: entry.balance_usdc,
+      cached_at: entry.cached_at,
+      ttl_seconds: TTL_SECONDS,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/wallet-balance/route.test.ts
+++ b/app/api/routesF/wallet-balance/route.test.ts
@@ -1,0 +1,112 @@
+import { GET } from './route';
+import { POST as REFRESH } from './refresh/route';
+import { BALANCE_CACHE, TTL_SECONDS } from './store';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/wallet-balance';
+
+function getReq(wallet?: string) {
+  return new NextRequest(wallet ? `${BASE}?wallet=${wallet}` : BASE);
+}
+
+function refreshReq(body: unknown) {
+  return new NextRequest(`${BASE}/refresh`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Cached Wallet Balance Lookup', () => {
+  let nowSpy: jest.SpyInstance<number, []>;
+  let now: number;
+
+  beforeEach(() => {
+    for (const key in BALANCE_CACHE) {
+      delete BALANCE_CACHE[key];
+    }
+    now = new Date('2026-01-01T12:00:00Z').getTime();
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  describe('GET /api/routesF/wallet-balance', () => {
+    it('should return the seeded balance with full TTL on first lookup', async () => {
+      const res = await GET(getReq('GVIEWERALPHA'));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.balance_xlm).toBe(150.5);
+      expect(data.balance_usdc).toBe(42.1);
+      expect(data.cached_at).toBe('2026-01-01T12:00:00.000Z');
+      expect(data.ttl_seconds).toBe(TTL_SECONDS);
+    });
+
+    it('should serve a cache hit within the TTL (same cached_at, decreasing ttl)', async () => {
+      const first = await (await GET(getReq('GVIEWERALPHA'))).json();
+
+      now += 20_000; // 20s later, still inside the 60s TTL
+      const second = await (await GET(getReq('GVIEWERALPHA'))).json();
+
+      expect(second.cached_at).toBe(first.cached_at);
+      expect(second.ttl_seconds).toBe(TTL_SECONDS - 20);
+    });
+
+    it('should recompute after the TTL expires', async () => {
+      const first = await (await GET(getReq('GVIEWERALPHA'))).json();
+
+      now += (TTL_SECONDS + 5) * 1000;
+      const second = await (await GET(getReq('GVIEWERALPHA'))).json();
+
+      expect(second.cached_at).not.toBe(first.cached_at);
+      expect(second.cached_at).toBe(new Date(now).toISOString());
+      expect(second.ttl_seconds).toBe(TTL_SECONDS);
+    });
+
+    it('should return 404 for an unknown wallet', async () => {
+      const res = await GET(getReq('GUNKNOWN'));
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 when wallet is missing', async () => {
+      const res = await GET(getReq());
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/routesF/wallet-balance/refresh', () => {
+    it('should force recomputation even inside the TTL', async () => {
+      const first = await (await GET(getReq('GVIEWERBETA'))).json();
+
+      now += 10_000; // still inside TTL
+      const refreshed = await REFRESH(refreshReq({ wallet: 'GVIEWERBETA' }));
+      expect(refreshed.status).toBe(200);
+      const refreshData = await refreshed.json();
+
+      expect(refreshData.cached_at).not.toBe(first.cached_at);
+      expect(refreshData.cached_at).toBe(new Date(now).toISOString());
+      expect(refreshData.ttl_seconds).toBe(TTL_SECONDS);
+
+      const after = await (await GET(getReq('GVIEWERBETA'))).json();
+      expect(after.cached_at).toBe(refreshData.cached_at);
+    });
+
+    it('should return 404 for an unknown wallet', async () => {
+      const res = await REFRESH(refreshReq({ wallet: 'GUNKNOWN' }));
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 when wallet is missing', async () => {
+      const res = await REFRESH(refreshReq({}));
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for invalid JSON', async () => {
+      const req = new NextRequest(`${BASE}/refresh`, { method: 'POST', body: 'not-json' });
+      const res = await REFRESH(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/wallet-balance/route.ts
+++ b/app/api/routesF/wallet-balance/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cacheBalance, getCached, remainingTtl } from './store';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const wallet = searchParams.get('wallet');
+
+  if (!wallet) {
+    return NextResponse.json({ error: 'wallet is required' }, { status: 400 });
+  }
+
+  let entry = getCached(wallet);
+  if (!entry) {
+    entry = cacheBalance(wallet);
+    if (!entry) {
+      return NextResponse.json({ error: 'Wallet not found' }, { status: 404 });
+    }
+  }
+
+  return NextResponse.json({
+    balance_xlm: entry.balance_xlm,
+    balance_usdc: entry.balance_usdc,
+    cached_at: entry.cached_at,
+    ttl_seconds: remainingTtl(entry),
+  });
+}

--- a/app/api/routesF/wallet-balance/store.ts
+++ b/app/api/routesF/wallet-balance/store.ts
@@ -1,0 +1,50 @@
+// Seed balances and cache for the wallet balance lookup, bundled inside this
+// folder per the routesF scope constraint.
+
+export interface WalletBalance {
+  balance_xlm: number;
+  balance_usdc: number;
+}
+
+export interface CachedBalance extends WalletBalance {
+  cached_at: string;
+}
+
+export const TTL_SECONDS = 60;
+
+export const SEED_BALANCES: Record<string, WalletBalance> = {
+  GVIEWERALPHA: { balance_xlm: 150.5, balance_usdc: 42.1 },
+  GVIEWERBETA: { balance_xlm: 12.25, balance_usdc: 0 },
+  GVIEWERGAMMA: { balance_xlm: 0, balance_usdc: 310.75 },
+  GVIEWERDELTA: { balance_xlm: 9999.99, balance_usdc: 1250.4 },
+};
+
+// wallet -> cached balance snapshot
+export const BALANCE_CACHE: Record<string, CachedBalance> = {};
+
+export function computeBalance(wallet: string): WalletBalance | null {
+  const seed = SEED_BALANCES[wallet];
+  if (!seed) return null;
+  return { ...seed };
+}
+
+export function cacheBalance(wallet: string): CachedBalance | null {
+  const balance = computeBalance(wallet);
+  if (!balance) return null;
+  const entry: CachedBalance = { ...balance, cached_at: new Date(Date.now()).toISOString() };
+  BALANCE_CACHE[wallet] = entry;
+  return entry;
+}
+
+export function getCached(wallet: string): CachedBalance | null {
+  const entry = BALANCE_CACHE[wallet];
+  if (!entry) return null;
+  const ageSeconds = (Date.now() - new Date(entry.cached_at).getTime()) / 1000;
+  if (ageSeconds >= TTL_SECONDS) return null;
+  return entry;
+}
+
+export function remainingTtl(entry: CachedBalance): number {
+  const ageSeconds = (Date.now() - new Date(entry.cached_at).getTime()) / 1000;
+  return Math.max(0, Math.round(TTL_SECONDS - ageSeconds));
+}


### PR DESCRIPTION
# Description

Closes #1299
Closes #1301
Closes #1302
Closes #1308

This PR implements four self-contained `routesF` endpoints. Per the scope constraint on each issue, every file (handlers, stores, seed data, tests) lives inside its own `app/api/routesF/<route>/` folder — nothing outside `app/api/routesF/` is imported or modified.

# Changes proposed

## What were you told to do?

- #1299 — feat(routesF): cached wallet balance lookup
- #1301 — feat(routesF): viewer preferences export
- #1302 — feat(routesF): 2FA recovery codes
- #1308 — feat(routesF): debug echo endpoint

## What did you do?

- **#1299 — cached wallet balance lookup** (`app/api/routesF/wallet-balance/`): `GET ?wallet` returns `{ balance_xlm, balance_usdc, cached_at, ttl_seconds }` from bundled seed balances (4 wallets). Results are cached per wallet with a 60-second TTL — repeat lookups inside the TTL return the same `cached_at` with a decreasing `ttl_seconds`; after expiry the balance is recomputed. `POST /refresh { wallet }` forces recomputation regardless of TTL. Unknown wallets return 404, missing param 400. Timestamps derive from `Date.now()` so tests control time via a spy instead of sleeping.
- **#1301 — viewer preferences export** (`app/api/routesF/viewer-preferences-export/`): `GET ?viewer_id` returns the viewer's full preferences JSON (theme, notification settings incl. email digest cadence, follows with per-follow notification flags, language, tip currency) from bundled seed data, plus an `export_generated_at` ISO timestamp added at export time. 404 for unknown viewers, 400 when `viewer_id` is missing.
- **#1302 — 2FA recovery codes** (`app/api/routesF/two-factor-recovery-codes/`): `POST /generate { user_id, count? }` returns `count` (default 10, max 20) unique one-time codes in `XXXX-XXXX` format using an alphabet without 0/O/1/I lookalikes; regenerating replaces (invalidates) any previous batch. `POST /use { user_id, code }` returns `{ valid, codes_remaining }` and deletes the code on success, so a second use of the same code returns `valid: false`. Codes are scoped per user — one user's code is not valid for another.
- **#1308 — debug echo endpoint** (`app/api/routesF/debug-echo/`): `POST` echoes any JSON body back as `{ received, headers, timestamp }`. Only allow-listed request headers (`content-type`, `user-agent`, `accept`, `accept-language`, `x-request-id`) are reflected — `authorization`/`cookie` are deliberately excluded to avoid reflecting credentials. Payloads over 100KB are rejected with 413 (byte length, not string length); malformed JSON returns 400; an empty body echoes `received: null`.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [ ] I am making a pull request against the _main branch_ (left side). (Targeting `dev`, the repo default branch.)
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

API-only change; behavior is covered by the colocated jest suites below.

## Test plan

- `npx jest app/api/routesF/wallet-balance app/api/routesF/viewer-preferences-export app/api/routesF/two-factor-recovery-codes app/api/routesF/debug-echo` — 4 suites, 35 tests, all passing locally. Coverage includes: cache hit / TTL expiry / forced refresh (#1299); shape completeness incl. every top-level key and timestamp validity (#1301); generate, use, reuse-rejection, regeneration invalidation, cross-user isolation (#1302); echo shape, header allow-list (secrets excluded), 100KB cap boundary on both sides (#1308).
- `tsc --noEmit` reports no errors in any of the added files.

---

Note: `dev` currently has pre-existing type errors in `app/api/routes-f/featured-stream/mock-data.ts` (unrelated to this PR), which cause the husky pre-commit type-check to fail on any commit; this PR does not touch that file.