### PR TITLE
feat(routesF): VOD quality, new creators, longest-live streams, peak viewer badges

### DIFF
--- a/app/api/routesF/longest-live-streams/route.test.ts
+++ b/app/api/routesF/longest-live-streams/route.test.ts
@@ -1,0 +1,65 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/longest-live-streams';
+
+// Seed started_at values are anchored around this "now"
+const NOW = new Date('2026-07-22T12:00:00Z').getTime();
+
+describe('Longest Currently-Live Streams', () => {
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => NOW);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  describe('GET /api/routesF/longest-live-streams', () => {
+    it('should return all live streams sorted by uptime desc', async () => {
+      const res = await GET(new NextRequest(BASE));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+        'live-1', // started Jul 21 20:00 -> 16h
+        'live-2', // started Jul 22 06:00 -> 6h
+        'live-4', // started Jul 22 09:00 -> 3h
+        'live-3', // started Jul 22 10:30 -> 1.5h
+      ]);
+    });
+
+    it('should compute hours_live from started_at', async () => {
+      const res = await GET(new NextRequest(BASE));
+      const data = await res.json();
+
+      const byId = Object.fromEntries(
+        data.streams.map((s: { stream_id: string; hours_live: number }) => [
+          s.stream_id,
+          s.hours_live,
+        ])
+      );
+      expect(byId['live-1']).toBe(16);
+      expect(byId['live-2']).toBe(6);
+      expect(byId['live-4']).toBe(3);
+      expect(byId['live-3']).toBe(1.5);
+    });
+
+    it('should respect the limit parameter', async () => {
+      const res = await GET(new NextRequest(`${BASE}?limit=2`));
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+        'live-1',
+        'live-2',
+      ]);
+    });
+
+    it('should return 400 for an invalid limit', async () => {
+      expect((await GET(new NextRequest(`${BASE}?limit=0`))).status).toBe(400);
+      expect((await GET(new NextRequest(`${BASE}?limit=abc`))).status).toBe(400);
+      expect((await GET(new NextRequest(`${BASE}?limit=101`))).status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/longest-live-streams/route.ts
+++ b/app/api/routesF/longest-live-streams/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface SeedLiveStream {
+  stream_id: string;
+  creator_id: string;
+  title: string;
+  category: string;
+  started_at: string;
+  viewers: number;
+}
+
+// Seed currently-live streams with start times, bundled per the routesF
+// scope constraint.
+export const SEED_LIVE_STREAMS: SeedLiveStream[] = [
+  { stream_id: 'live-1', creator_id: 'creator-1', title: '24h charity marathon', category: 'gaming', started_at: '2026-07-21T20:00:00Z', viewers: 1800 },
+  { stream_id: 'live-2', creator_id: 'creator-2', title: 'Late night lofi', category: 'music', started_at: '2026-07-22T06:00:00Z', viewers: 420 },
+  { stream_id: 'live-3', creator_id: 'creator-3', title: 'Ranked grind', category: 'gaming', started_at: '2026-07-22T10:30:00Z', viewers: 95 },
+  { stream_id: 'live-4', creator_id: 'creator-4', title: 'Breakfast cookalong', category: 'cooking', started_at: '2026-07-22T09:00:00Z', viewers: 210 },
+];
+
+const DEFAULT_LIMIT = 20;
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get('limit');
+
+  let limit = DEFAULT_LIMIT;
+  if (limitParam !== null) {
+    const parsed = Number(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+      return NextResponse.json(
+        { error: 'limit must be an integer between 1 and 100' },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  const now = Date.now();
+  const streams = SEED_LIVE_STREAMS.map((s) => {
+    const uptimeMs = Math.max(0, now - new Date(s.started_at).getTime());
+    return {
+      ...s,
+      hours_live: Math.round((uptimeMs / MS_PER_HOUR) * 10) / 10,
+    };
+  })
+    .sort((a, b) => b.hours_live - a.hours_live)
+    .slice(0, limit);
+
+  return NextResponse.json({ streams });
+}

--- a/app/api/routesF/new-creators/route.test.ts
+++ b/app/api/routesF/new-creators/route.test.ts
@@ -1,0 +1,88 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/new-creators';
+
+// Seed joined_at dates are anchored around this "now"
+const NOW = new Date('2026-07-22T12:00:00Z').getTime();
+
+async function fetchCreators(query: string) {
+  const res = await GET(new NextRequest(`${BASE}${query}`));
+  return { res, data: await res.json() };
+}
+
+describe('New Creators In Category', () => {
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => NOW);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  describe('GET /api/routesF/new-creators', () => {
+    it('should return recent creators in the category sorted by joined_at desc', async () => {
+      const { res, data } = await fetchCreators('?category=gaming');
+
+      expect(res.status).toBe(200);
+      // creator-1 (Jul 21, 3 streams) qualifies; creator-3 (0 streams) fails
+      // min_streams=1; creator-5 (Jul 10) and creator-6 (Apr) are older than 7 days.
+      expect(data.creators.map((c: { creator_id: string }) => c.creator_id)).toEqual([
+        'creator-1',
+      ]);
+    });
+
+    it('should widen the window with days', async () => {
+      const { data } = await fetchCreators('?category=gaming&days=14');
+      expect(data.creators.map((c: { creator_id: string }) => c.creator_id)).toEqual([
+        'creator-1',
+        'creator-5',
+      ]);
+      const joined = data.creators.map((c: { joined_at: string }) =>
+        new Date(c.joined_at).getTime()
+      );
+      expect(joined).toEqual([...joined].sort((a, b) => b - a));
+    });
+
+    it('should include zero-stream creators when min_streams=0', async () => {
+      const { data } = await fetchCreators('?category=gaming&min_streams=0');
+      expect(data.creators.map((c: { creator_id: string }) => c.creator_id)).toEqual([
+        'creator-1',
+        'creator-3',
+      ]);
+    });
+
+    it('should raise the bar with a higher min_streams', async () => {
+      const { data } = await fetchCreators('?category=gaming&days=14&min_streams=10');
+      expect(data.creators.map((c: { creator_id: string }) => c.creator_id)).toEqual([
+        'creator-5',
+      ]);
+    });
+
+    it('should filter by other categories', async () => {
+      const { data } = await fetchCreators('?category=music');
+      expect(data.creators).toHaveLength(1);
+      expect(data.creators[0].display_name).toBe('LoFiLena');
+    });
+
+    it('should return an empty list for a category with no recent creators', async () => {
+      const { res, data } = await fetchCreators('?category=chess');
+      expect(res.status).toBe(200);
+      expect(data.creators).toEqual([]);
+      expect(data.total).toBe(0);
+    });
+
+    it('should return 400 when category is missing', async () => {
+      const { res } = await fetchCreators('');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for invalid days or min_streams', async () => {
+      expect((await fetchCreators('?category=gaming&days=0')).res.status).toBe(400);
+      expect((await fetchCreators('?category=gaming&days=abc')).res.status).toBe(400);
+      expect((await fetchCreators('?category=gaming&min_streams=-1')).res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/new-creators/route.ts
+++ b/app/api/routesF/new-creators/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface SeedCreator {
+  creator_id: string;
+  display_name: string;
+  category: string;
+  joined_at: string;
+  stream_count: number;
+}
+
+// Seed creators with join dates, categories, and stream counts, bundled per
+// the routesF scope constraint. Ages are relative to "now" in tests via
+// Date.now() mocking; joined_at values span from days to months old.
+export const SEED_CREATORS: SeedCreator[] = [
+  { creator_id: 'creator-1', display_name: 'PixelMage', category: 'gaming', joined_at: '2026-07-21T10:00:00Z', stream_count: 3 },
+  { creator_id: 'creator-2', display_name: 'LoFiLena', category: 'music', joined_at: '2026-07-20T18:30:00Z', stream_count: 5 },
+  { creator_id: 'creator-3', display_name: 'RaidRunner', category: 'gaming', joined_at: '2026-07-19T09:15:00Z', stream_count: 0 },
+  { creator_id: 'creator-4', display_name: 'ChefCosmos', category: 'cooking', joined_at: '2026-07-18T14:00:00Z', stream_count: 2 },
+  { creator_id: 'creator-5', display_name: 'SpeedSis', category: 'gaming', joined_at: '2026-07-10T08:00:00Z', stream_count: 12 },
+  { creator_id: 'creator-6', display_name: 'OldTimerOsa', category: 'gaming', joined_at: '2026-04-01T12:00:00Z', stream_count: 90 },
+];
+
+const DEFAULT_DAYS = 7;
+const DEFAULT_MIN_STREAMS = 1;
+
+function parsePositiveInt(value: string): number | null {
+  const num = Number(value);
+  if (!Number.isInteger(num) || num < 1) return null;
+  return num;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const category = searchParams.get('category');
+  const daysParam = searchParams.get('days');
+  const minStreamsParam = searchParams.get('min_streams');
+
+  if (!category) {
+    return NextResponse.json({ error: 'category is required' }, { status: 400 });
+  }
+
+  let days = DEFAULT_DAYS;
+  if (daysParam !== null) {
+    const parsed = parsePositiveInt(daysParam);
+    if (parsed === null) {
+      return NextResponse.json({ error: 'days must be a positive integer' }, { status: 400 });
+    }
+    days = parsed;
+  }
+
+  let minStreams = DEFAULT_MIN_STREAMS;
+  if (minStreamsParam !== null) {
+    const parsed = Number(minStreamsParam);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      return NextResponse.json(
+        { error: 'min_streams must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+    minStreams = parsed;
+  }
+
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const normalized = category.trim().toLowerCase();
+
+  const creators = SEED_CREATORS.filter(
+    (c) =>
+      c.category === normalized &&
+      new Date(c.joined_at).getTime() >= cutoff &&
+      c.stream_count >= minStreams
+  ).sort((a, b) => new Date(b.joined_at).getTime() - new Date(a.joined_at).getTime());
+
+  return NextResponse.json({ creators, total: creators.length });
+}

--- a/app/api/routesF/peak-viewer-badges/check/route.ts
+++ b/app/api/routesF/peak-viewer-badges/check/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { BADGE_LADDER, AWARDED_BADGES } from '../store';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { creator_id, peak_viewers } = body;
+
+    if (!creator_id || typeof creator_id !== 'string') {
+      return NextResponse.json({ error: 'creator_id is required' }, { status: 400 });
+    }
+    if (typeof peak_viewers !== 'number' || !Number.isInteger(peak_viewers) || peak_viewers < 0) {
+      return NextResponse.json(
+        { error: 'peak_viewers must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+
+    if (!AWARDED_BADGES[creator_id]) {
+      AWARDED_BADGES[creator_id] = new Set();
+    }
+    const awarded = AWARDED_BADGES[creator_id];
+
+    // Idempotent: every qualifying badge not yet held is awarded exactly once;
+    // re-checking the same peak returns an empty list.
+    const newlyAwarded: string[] = [];
+    for (const { threshold, badge } of BADGE_LADDER) {
+      if (peak_viewers >= threshold && !awarded.has(badge)) {
+        awarded.add(badge);
+        newlyAwarded.push(badge);
+      }
+    }
+
+    return NextResponse.json({ newly_awarded: newlyAwarded });
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/peak-viewer-badges/route.test.ts
+++ b/app/api/routesF/peak-viewer-badges/route.test.ts
@@ -1,0 +1,87 @@
+import { POST } from './check/route';
+import { AWARDED_BADGES } from './store';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/peak-viewer-badges';
+
+function checkReq(body: unknown) {
+  return new NextRequest(`${BASE}/check`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function check(creator_id: string, peak_viewers: number): Promise<string[]> {
+  const res = await POST(checkReq({ creator_id, peak_viewers }));
+  const data = await res.json();
+  return data.newly_awarded;
+}
+
+describe('Peak Viewer Count Badges', () => {
+  beforeEach(() => {
+    for (const key in AWARDED_BADGES) {
+      delete AWARDED_BADGES[key];
+    }
+  });
+
+  describe('POST /api/routesF/peak-viewer-badges/check', () => {
+    it('should award no badges below the first threshold', async () => {
+      expect(await check('creator-1', 9)).toEqual([]);
+    });
+
+    it('should award the first badge at exactly the threshold', async () => {
+      expect(await check('creator-1', 10)).toEqual(['first-ten']);
+    });
+
+    it('should award all skipped rungs when a peak jumps the ladder', async () => {
+      expect(await check('creator-1', 750)).toEqual([
+        'first-ten',
+        'crowd-pleaser',
+        'rising-star',
+      ]);
+    });
+
+    it('should be idempotent for the same peak', async () => {
+      await check('creator-1', 750);
+      expect(await check('creator-1', 750)).toEqual([]);
+    });
+
+    it('should only award new rungs as the peak progresses', async () => {
+      expect(await check('creator-1', 10)).toEqual(['first-ten']);
+      expect(await check('creator-1', 150)).toEqual(['crowd-pleaser']);
+      expect(await check('creator-1', 6000)).toEqual([
+        'rising-star',
+        'thousand-club',
+        'headliner',
+      ]);
+      expect(await check('creator-1', 6000)).toEqual([]);
+    });
+
+    it('should not award again when a later peak is lower', async () => {
+      await check('creator-1', 1200);
+      expect(await check('creator-1', 50)).toEqual([]);
+    });
+
+    it('should track creators independently', async () => {
+      await check('creator-1', 5000);
+      expect(await check('creator-2', 10)).toEqual(['first-ten']);
+    });
+
+    it('should return 400 for missing or invalid input', async () => {
+      expect((await POST(checkReq({ peak_viewers: 10 }))).status).toBe(400);
+      expect((await POST(checkReq({ creator_id: 'creator-1' }))).status).toBe(400);
+      expect(
+        (await POST(checkReq({ creator_id: 'creator-1', peak_viewers: -5 }))).status
+      ).toBe(400);
+      expect(
+        (await POST(checkReq({ creator_id: 'creator-1', peak_viewers: 2.5 }))).status
+      ).toBe(400);
+    });
+
+    it('should return 400 for invalid JSON', async () => {
+      const req = new NextRequest(`${BASE}/check`, { method: 'POST', body: 'not-json' });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/peak-viewer-badges/store.ts
+++ b/app/api/routesF/peak-viewer-badges/store.ts
@@ -1,0 +1,13 @@
+// Badge ladder and awarded-badge storage, bundled inside this folder per the
+// routesF scope constraint.
+
+export const BADGE_LADDER: { threshold: number; badge: string }[] = [
+  { threshold: 10, badge: 'first-ten' },
+  { threshold: 100, badge: 'crowd-pleaser' },
+  { threshold: 500, badge: 'rising-star' },
+  { threshold: 1000, badge: 'thousand-club' },
+  { threshold: 5000, badge: 'headliner' },
+];
+
+// creator_id -> set of already-awarded badges
+export const AWARDED_BADGES: Record<string, Set<string>> = {};

--- a/app/api/routesF/vod-quality/route.test.ts
+++ b/app/api/routesF/vod-quality/route.test.ts
@@ -1,0 +1,113 @@
+import { GET } from './route';
+import { POST as SELECT } from './select/route';
+import { QUALITY_SELECTIONS } from './store';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/vod-quality';
+
+function selectReq(body: unknown) {
+  return new NextRequest(`${BASE}/select`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('VOD Quality Selection', () => {
+  beforeEach(() => {
+    for (const key in QUALITY_SELECTIONS) {
+      delete QUALITY_SELECTIONS[key];
+    }
+  });
+
+  describe('GET /api/routesF/vod-quality', () => {
+    it('should list available qualities for a VOD', async () => {
+      const res = await GET(new NextRequest(`${BASE}?playback_id=vod-raid-recap`));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.qualities).toHaveLength(4);
+      expect(data.qualities[0]).toEqual({
+        label: '1080p',
+        resolution: '1920x1080',
+        bitrate_kbps: 5000,
+      });
+      for (const q of data.qualities) {
+        expect(typeof q.label).toBe('string');
+        expect(typeof q.resolution).toBe('string');
+        expect(typeof q.bitrate_kbps).toBe('number');
+      }
+    });
+
+    it('should return 404 for an unknown VOD', async () => {
+      const res = await GET(new NextRequest(`${BASE}?playback_id=vod-missing`));
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 when playback_id is missing', async () => {
+      const res = await GET(new NextRequest(BASE));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/routesF/vod-quality/select', () => {
+    it('should save a viewer quality choice', async () => {
+      const res = await SELECT(
+        selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-raid-recap', label: '720p' })
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({
+        viewer_id: 'viewer-1',
+        playback_id: 'vod-raid-recap',
+        label: '720p',
+      });
+      expect(QUALITY_SELECTIONS['viewer-1']['vod-raid-recap']).toBe('720p');
+    });
+
+    it('should overwrite a previous choice for the same VOD', async () => {
+      await SELECT(
+        selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-raid-recap', label: '1080p' })
+      );
+      await SELECT(
+        selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-raid-recap', label: '360p' })
+      );
+
+      expect(QUALITY_SELECTIONS['viewer-1']['vod-raid-recap']).toBe('360p');
+    });
+
+    it('should reject a label the VOD does not offer', async () => {
+      const res = await SELECT(
+        selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-speedrun-finals', label: '1080p' })
+      );
+
+      expect(res.status).toBe(400);
+      expect(QUALITY_SELECTIONS['viewer-1']).toBeUndefined();
+    });
+
+    it('should return 404 for an unknown VOD', async () => {
+      const res = await SELECT(
+        selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-missing', label: '720p' })
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 400 when required fields are missing', async () => {
+      expect(
+        (await SELECT(selectReq({ playback_id: 'vod-raid-recap', label: '720p' }))).status
+      ).toBe(400);
+      expect(
+        (await SELECT(selectReq({ viewer_id: 'viewer-1', label: '720p' }))).status
+      ).toBe(400);
+      expect(
+        (await SELECT(selectReq({ viewer_id: 'viewer-1', playback_id: 'vod-raid-recap' }))).status
+      ).toBe(400);
+    });
+
+    it('should return 400 for invalid JSON', async () => {
+      const req = new NextRequest(`${BASE}/select`, { method: 'POST', body: 'not-json' });
+      const res = await SELECT(req);
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/vod-quality/route.test.ts
+++ b/app/api/routesF/vod-quality/route.test.ts
@@ -109,5 +109,16 @@ describe('VOD Quality Selection', () => {
       const res = await SELECT(req);
       expect(res.status).toBe(400);
     });
+
+    it('should reject reserved object keys without polluting Object.prototype', async () => {
+      for (const key of ['__proto__', 'constructor', 'prototype']) {
+        const res = await SELECT(
+          selectReq({ viewer_id: key, playback_id: 'vod-raid-recap', label: '720p' })
+        );
+        expect(res.status).toBe(400);
+      }
+      expect(({} as Record<string, unknown>)['vod-raid-recap']).toBeUndefined();
+      expect(Object.keys(QUALITY_SELECTIONS)).toHaveLength(0);
+    });
   });
 });

--- a/app/api/routesF/vod-quality/route.ts
+++ b/app/api/routesF/vod-quality/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { VOD_QUALITIES } from './store';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const playbackId = searchParams.get('playback_id');
+
+  if (!playbackId) {
+    return NextResponse.json({ error: 'playback_id is required' }, { status: 400 });
+  }
+
+  const qualities = VOD_QUALITIES[playbackId];
+  if (!qualities) {
+    return NextResponse.json({ error: 'VOD not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ qualities });
+}

--- a/app/api/routesF/vod-quality/select/route.ts
+++ b/app/api/routesF/vod-quality/select/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { VOD_QUALITIES, QUALITY_SELECTIONS } from '../store';
 
+// Keys that would let a request write into Object.prototype (CodeQL:
+// prototype-polluting assignment).
+const RESERVED_KEYS = ['__proto__', 'constructor', 'prototype'];
+
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
@@ -14,6 +18,12 @@ export async function POST(req: NextRequest) {
     }
     if (!label || typeof label !== 'string') {
       return NextResponse.json({ error: 'label is required' }, { status: 400 });
+    }
+    if (RESERVED_KEYS.includes(viewer_id) || RESERVED_KEYS.includes(playback_id)) {
+      return NextResponse.json(
+        { error: 'viewer_id and playback_id must not be reserved object keys' },
+        { status: 400 }
+      );
     }
 
     const qualities = VOD_QUALITIES[playback_id];
@@ -33,7 +43,7 @@ export async function POST(req: NextRequest) {
     QUALITY_SELECTIONS[viewer_id][playback_id] = label;
 
     return NextResponse.json({ viewer_id, playback_id, label });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 }

--- a/app/api/routesF/vod-quality/select/route.ts
+++ b/app/api/routesF/vod-quality/select/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { VOD_QUALITIES, QUALITY_SELECTIONS } from '../store';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { viewer_id, playback_id, label } = body;
+
+    if (!viewer_id || typeof viewer_id !== 'string') {
+      return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+    }
+    if (!playback_id || typeof playback_id !== 'string') {
+      return NextResponse.json({ error: 'playback_id is required' }, { status: 400 });
+    }
+    if (!label || typeof label !== 'string') {
+      return NextResponse.json({ error: 'label is required' }, { status: 400 });
+    }
+
+    const qualities = VOD_QUALITIES[playback_id];
+    if (!qualities) {
+      return NextResponse.json({ error: 'VOD not found' }, { status: 404 });
+    }
+    if (!qualities.some((q) => q.label === label)) {
+      return NextResponse.json(
+        { error: `label must be one of: ${qualities.map((q) => q.label).join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    if (!QUALITY_SELECTIONS[viewer_id]) {
+      QUALITY_SELECTIONS[viewer_id] = {};
+    }
+    QUALITY_SELECTIONS[viewer_id][playback_id] = label;
+
+    return NextResponse.json({ viewer_id, playback_id, label });
+  } catch (e) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/vod-quality/store.ts
+++ b/app/api/routesF/vod-quality/store.ts
@@ -22,4 +22,7 @@ export const VOD_QUALITIES: Record<string, VodQuality[]> = {
 };
 
 // viewer_id -> playback_id -> selected quality label
-export const QUALITY_SELECTIONS: Record<string, Record<string, string>> = {};
+// Null prototype so viewer-supplied keys like "__proto__" can never resolve
+// to Object.prototype when read back.
+export const QUALITY_SELECTIONS: Record<string, Record<string, string>> =
+  Object.create(null);

--- a/app/api/routesF/vod-quality/store.ts
+++ b/app/api/routesF/vod-quality/store.ts
@@ -1,0 +1,25 @@
+// Seed VOD renditions and viewer quality preferences, bundled inside this
+// folder per the routesF scope constraint.
+
+export interface VodQuality {
+  label: string;
+  resolution: string;
+  bitrate_kbps: number;
+}
+
+// playback_id -> available renditions (what Mux would report per asset)
+export const VOD_QUALITIES: Record<string, VodQuality[]> = {
+  'vod-raid-recap': [
+    { label: '1080p', resolution: '1920x1080', bitrate_kbps: 5000 },
+    { label: '720p', resolution: '1280x720', bitrate_kbps: 2800 },
+    { label: '480p', resolution: '854x480', bitrate_kbps: 1200 },
+    { label: '360p', resolution: '640x360', bitrate_kbps: 700 },
+  ],
+  'vod-speedrun-finals': [
+    { label: '720p', resolution: '1280x720', bitrate_kbps: 2800 },
+    { label: '480p', resolution: '854x480', bitrate_kbps: 1200 },
+  ],
+};
+
+// viewer_id -> playback_id -> selected quality label
+export const QUALITY_SELECTIONS: Record<string, Record<string, string>> = {};


### PR DESCRIPTION
# Description

Closes #1230
Closes #1235
Closes #1239
Closes #1241

This PR implements four self-contained `routesF` endpoints. Per the scope constraint on each issue, every file (handlers, stores, seed data, tests) lives inside its own `app/api/routesF/<route>/` folder — nothing outside `app/api/routesF/` is imported or modified.

# Changes proposed

## What were you told to do?

- #1230 — feat(routesF): VOD quality selection
- #1235 — feat(routesF): new creators in category
- #1239 — feat(routesF): longest currently-live streams
- #1241 — feat(routesF): peak viewer count badge

## What did you do?

- **#1230 — VOD quality selection** (`app/api/routesF/vod-quality/`): `GET ?playback_id` returns `{ qualities: [{ label, resolution, bitrate_kbps }] }` from bundled Mux-style seed renditions (two VODs with different ladders). `POST /select { viewer_id, playback_id, label }` saves the viewer's default, validating that the label is one the VOD actually offers (400 otherwise), 404 for unknown VODs, and overwriting a prior choice for the same VOD.
- **#1235 — new creators in category** (`app/api/routesF/new-creators/`): `GET ?category&days?&min_streams?` returns creators who joined within the window (default 7 days) with at least `min_streams` streams (default 1), sorted by `joined_at` descending. Seed data spans join dates from days to months old across three categories, including a zero-stream creator to exercise the `min_streams` boundary. Invalid `days`/`min_streams` return 400.
- **#1239 — longest currently-live streams** (`app/api/routesF/longest-live-streams/`): `GET ?limit?` (default 20, max 100) returns seed live streams sorted by uptime descending, each with `hours_live` computed from `started_at` and rounded to one decimal. Time is derived from `Date.now()` so tests pin the clock instead of depending on wall time.
- **#1241 — peak viewer count badges** (`app/api/routesF/peak-viewer-badges/`): `POST /check { creator_id, peak_viewers }` returns `{ newly_awarded }` against the bundled 10/100/500/1000/5000 ladder. Awards are idempotent per creator: a peak that jumps several rungs awards all of them at once, re-checking the same peak returns an empty list, a later lower peak awards nothing, and creators are tracked independently. Non-integer or negative `peak_viewers` returns 400.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [ ] I am making a pull request against the _main branch_ (left side). (Targeting `dev`, the repo default branch.)
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/Videos

API-only change; behavior is covered by the colocated jest suites below.

## Test plan

- `npx jest app/api/routesF/vod-quality app/api/routesF/new-creators app/api/routesF/longest-live-streams app/api/routesF/peak-viewer-badges` — 4 suites, 30 tests, all passing locally. Coverage includes: list/save/invalid-label/unknown-VOD (#1230); window widening, min_streams boundaries (0 and high), ordering, empty category (#1235); uptime ordering, hours_live math at fixed clock, limit bounds (#1239); ladder progression, multi-rung jumps, idempotency, lower-later-peak, per-creator isolation (#1241).
- `tsc --noEmit` reports no errors in any of the added files.

---

Note: `dev` currently has pre-existing type errors in `app/api/routes-f/featured-stream/mock-data.ts` (unrelated to this PR), which cause the husky pre-commit type-check to fail on any commit; this PR does not touch that file.