### PR TITLE
feat(routes-f): add viewer digest, returning-viewer, conversion, and day-performance analytics APIs

### DIFF
--- a/app/api/routes-f/day-performance/__tests__/route.test.ts
+++ b/app/api/routes-f/day-performance/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { computeDayPerformance, getWeekdayName, WEEKDAY_ORDER } from "../utils";
+import { getStreamsForCreator } from "../seedData";
+
+function makeReq(creatorId?: string): NextRequest {
+  const url = creatorId
+    ? `http://localhost/api/routes-f/day-performance?creator_id=${creatorId}`
+    : "http://localhost/api/routes-f/day-performance";
+  return new NextRequest(url);
+}
+
+describe("GET /api/routes-f/day-performance", () => {
+  describe("Required Parameters", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeReq());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("creator_id");
+    });
+  });
+
+  describe("Aggregation", () => {
+    it("returns all 7 days in Monday-first order", async () => {
+      const res = await GET(makeReq("creator_delta"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.days).toHaveLength(7);
+      expect(body.days.map((d: { day: string }) => d.day)).toEqual(
+        WEEKDAY_ORDER
+      );
+    });
+
+    it("computes avg_viewers, avg_tips_usdc, and stream_count per weekday", async () => {
+      const res = await GET(makeReq("creator_delta"));
+      const body = await res.json();
+
+      const monday = body.days.find((d: { day: string }) => d.day === "Monday");
+      // streams on 06-01 (100v/50t), 06-08 (200v/150t), 06-15 (300v/100t)
+      expect(monday).toEqual({
+        day: "Monday",
+        avg_viewers: 200,
+        avg_tips_usdc: 100,
+        stream_count: 3,
+      });
+
+      const tuesday = body.days.find(
+        (d: { day: string }) => d.day === "Tuesday"
+      );
+      // single stream on 06-02 (80v/20t)
+      expect(tuesday).toEqual({
+        day: "Tuesday",
+        avg_viewers: 80,
+        avg_tips_usdc: 20,
+        stream_count: 1,
+      });
+    });
+
+    it("zeroes out days with no streams", async () => {
+      const res = await GET(makeReq("creator_delta"));
+      const body = await res.json();
+
+      const wednesday = body.days.find(
+        (d: { day: string }) => d.day === "Wednesday"
+      );
+      expect(wednesday).toEqual({
+        day: "Wednesday",
+        avg_viewers: 0,
+        avg_tips_usdc: 0,
+        stream_count: 0,
+      });
+    });
+
+    it("scopes results to the requested creator_id", async () => {
+      const res = await GET(makeReq("creator_epsilon"));
+      const body = await res.json();
+
+      const tuesday = body.days.find(
+        (d: { day: string }) => d.day === "Tuesday"
+      );
+      expect(tuesday).toEqual({
+        day: "Tuesday",
+        avg_viewers: 50,
+        avg_tips_usdc: 10,
+        stream_count: 1,
+      });
+
+      const monday = body.days.find((d: { day: string }) => d.day === "Monday");
+      expect(monday.stream_count).toBe(0);
+    });
+
+    it("returns all-zero days for an unknown creator_id", async () => {
+      const res = await GET(makeReq("unknown_creator_xyz"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.days).toHaveLength(7);
+      for (const day of body.days) {
+        expect(day.stream_count).toBe(0);
+        expect(day.avg_viewers).toBe(0);
+        expect(day.avg_tips_usdc).toBe(0);
+      }
+    });
+  });
+
+  describe("utils: getWeekdayName", () => {
+    it("maps known ISO dates to the correct weekday", () => {
+      expect(getWeekdayName("2026-06-01T00:00:00.000Z")).toBe("Monday");
+      expect(getWeekdayName("2026-06-02T00:00:00.000Z")).toBe("Tuesday");
+    });
+  });
+
+  describe("utils: computeDayPerformance", () => {
+    it("handles an empty stream list", () => {
+      const days = computeDayPerformance([]);
+      expect(days).toHaveLength(7);
+      expect(days.every(d => d.stream_count === 0)).toBe(true);
+    });
+
+    it("rounds averages to two decimal places", () => {
+      const days = computeDayPerformance([
+        {
+          id: "a",
+          creator_id: "c",
+          date: "2026-06-01T00:00:00.000Z",
+          viewer_count: 10,
+          tips_usdc: 10,
+        },
+        {
+          id: "b",
+          creator_id: "c",
+          date: "2026-06-08T00:00:00.000Z",
+          viewer_count: 11,
+          tips_usdc: 5,
+        },
+        {
+          id: "c",
+          creator_id: "c",
+          date: "2026-06-15T00:00:00.000Z",
+          viewer_count: 12,
+          tips_usdc: 3,
+        },
+      ]);
+      const monday = days.find(d => d.day === "Monday")!;
+      expect(monday.avg_viewers).toBe(11);
+      expect(monday.avg_tips_usdc).toBe(6);
+      expect(monday.stream_count).toBe(3);
+    });
+  });
+
+  describe("seedData", () => {
+    it("filters streams by creator_id", () => {
+      const streams = getStreamsForCreator("creator_delta");
+      expect(streams.every(s => s.creator_id === "creator_delta")).toBe(true);
+      expect(streams.length).toBe(4);
+    });
+
+    it("returns empty array for unknown creator", () => {
+      expect(getStreamsForCreator("nope")).toEqual([]);
+    });
+  });
+});

--- a/app/api/routes-f/day-performance/route.ts
+++ b/app/api/routes-f/day-performance/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getStreamsForCreator } from "./seedData";
+import { computeDayPerformance } from "./utils";
+import type { DayPerformanceResponse } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const streams = getStreamsForCreator(creatorId);
+  const days = computeDayPerformance(streams);
+
+  return NextResponse.json({ days } as DayPerformanceResponse);
+}

--- a/app/api/routes-f/day-performance/seedData.ts
+++ b/app/api/routes-f/day-performance/seedData.ts
@@ -1,0 +1,47 @@
+import type { StreamRecord } from "./types";
+
+// Fixed calendar dates (not relative to "now") so day-of-week aggregation is
+// exactly reproducible: 2026-06-01/08/15 are Mondays, 2026-06-02 is a Tuesday.
+export const streamStore: StreamRecord[] = [
+  {
+    id: "stream_1",
+    creator_id: "creator_delta",
+    date: "2026-06-01T00:00:00.000Z",
+    viewer_count: 100,
+    tips_usdc: 50,
+  },
+  {
+    id: "stream_2",
+    creator_id: "creator_delta",
+    date: "2026-06-08T00:00:00.000Z",
+    viewer_count: 200,
+    tips_usdc: 150,
+  },
+  {
+    id: "stream_3",
+    creator_id: "creator_delta",
+    date: "2026-06-15T00:00:00.000Z",
+    viewer_count: 300,
+    tips_usdc: 100,
+  },
+  {
+    id: "stream_4",
+    creator_id: "creator_delta",
+    date: "2026-06-02T00:00:00.000Z",
+    viewer_count: 80,
+    tips_usdc: 20,
+  },
+
+  // creator_epsilon — separate creator, used to verify creator_id filtering.
+  {
+    id: "stream_5",
+    creator_id: "creator_epsilon",
+    date: "2026-06-09T00:00:00.000Z",
+    viewer_count: 50,
+    tips_usdc: 10,
+  },
+];
+
+export function getStreamsForCreator(creatorId: string): StreamRecord[] {
+  return streamStore.filter(s => s.creator_id === creatorId);
+}

--- a/app/api/routes-f/day-performance/types.ts
+++ b/app/api/routes-f/day-performance/types.ts
@@ -1,0 +1,18 @@
+export interface StreamRecord {
+  id: string;
+  creator_id: string;
+  date: string; // ISO date string, e.g. "2026-06-01T00:00:00.000Z"
+  viewer_count: number;
+  tips_usdc: number;
+}
+
+export interface DayPerformance {
+  day: string;
+  avg_viewers: number;
+  avg_tips_usdc: number;
+  stream_count: number;
+}
+
+export interface DayPerformanceResponse {
+  days: DayPerformance[];
+}

--- a/app/api/routes-f/day-performance/utils.ts
+++ b/app/api/routes-f/day-performance/utils.ts
@@ -1,0 +1,63 @@
+import type { StreamRecord, DayPerformance } from "./types";
+
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+// Output order starts on Monday, matching a typical weekly schedule view.
+export const WEEKDAY_ORDER = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+export function getWeekdayName(isoDate: string): string {
+  return WEEKDAY_NAMES[new Date(isoDate).getUTCDay()];
+}
+
+// Always returns all 7 weekdays, in WEEKDAY_ORDER, with zeroed stats for
+// days with no streams — so consumers can render a full week grid.
+export function computeDayPerformance(streams: StreamRecord[]): DayPerformance[] {
+  const byDay = new Map<string, StreamRecord[]>();
+  for (const day of WEEKDAY_ORDER) {
+    byDay.set(day, []);
+  }
+  for (const stream of streams) {
+    const day = getWeekdayName(stream.date);
+    byDay.get(day)?.push(stream);
+  }
+
+  return WEEKDAY_ORDER.map(day => {
+    const dayStreams = byDay.get(day) ?? [];
+    const stream_count = dayStreams.length;
+    const avg_viewers =
+      stream_count === 0
+        ? 0
+        : roundToTwo(
+            dayStreams.reduce((sum, s) => sum + s.viewer_count, 0) /
+              stream_count
+          );
+    const avg_tips_usdc =
+      stream_count === 0
+        ? 0
+        : roundToTwo(
+            dayStreams.reduce((sum, s) => sum + s.tips_usdc, 0) / stream_count
+          );
+
+    return { day, avg_viewers, avg_tips_usdc, stream_count };
+  });
+}
+
+function roundToTwo(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/app/api/routes-f/digest-preview/__tests__/route.test.ts
+++ b/app/api/routes-f/digest-preview/__tests__/route.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { buildSections, getNextScheduledSend } from "../utils";
+import { getOptIns, defaultOptIns } from "../seedData";
+
+function makeReq(viewerId?: string): NextRequest {
+  const url = viewerId
+    ? `http://localhost/api/routes-f/digest-preview?viewer_id=${viewerId}`
+    : "http://localhost/api/routes-f/digest-preview";
+  return new NextRequest(url);
+}
+
+describe("GET /api/routes-f/digest-preview", () => {
+  describe("Required Parameters", () => {
+    it("returns 400 when viewer_id is missing", async () => {
+      const res = await GET(makeReq());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("viewer_id");
+    });
+  });
+
+  describe("Mixed opt-ins", () => {
+    it("returns all four sections for a viewer opted into everything", async () => {
+      const res = await GET(makeReq("viewer_all_optin"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.sections).toHaveLength(4);
+      const titles = body.sections.map((s: { title: string }) => s.title);
+      expect(titles).toEqual([
+        "Live now from creators you follow",
+        "New streams this week",
+        "Your tips recap",
+        "Recommended for you",
+      ]);
+      expect(body.sections[2].items.length).toBeGreaterThan(0);
+    });
+
+    it("returns only opted-in sections for a viewer with mixed opt-ins", async () => {
+      const res = await GET(makeReq("viewer_mixed_optin"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      const titles = body.sections.map((s: { title: string }) => s.title);
+      expect(titles).toEqual([
+        "Live now from creators you follow",
+        "Your tips recap",
+      ]);
+      expect(titles).not.toContain("New streams this week");
+      expect(titles).not.toContain("Recommended for you");
+    });
+
+    it("returns no sections for a viewer opted out of everything", async () => {
+      const res = await GET(makeReq("viewer_none_optin"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.sections).toEqual([]);
+    });
+
+    it("applies defaults for an unknown viewer_id", async () => {
+      const res = await GET(makeReq("some_unknown_viewer_xyz"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      const titles = body.sections.map((s: { title: string }) => s.title);
+      expect(titles).toEqual([
+        "Live now from creators you follow",
+        "New streams this week",
+        "Recommended for you",
+      ]);
+    });
+  });
+
+  describe("Section item shape", () => {
+    it("every item has id, title, and subtitle", async () => {
+      const res = await GET(makeReq("viewer_all_optin"));
+      const body = await res.json();
+
+      for (const section of body.sections) {
+        for (const item of section.items) {
+          expect(item).toHaveProperty("id");
+          expect(item).toHaveProperty("title");
+          expect(item).toHaveProperty("subtitle");
+        }
+      }
+    });
+
+    it("tips recap is personalized per viewer", async () => {
+      const res = await GET(makeReq("viewer_mixed_optin"));
+      const body = await res.json();
+
+      const tipsSection = body.sections.find(
+        (s: { title: string }) => s.title === "Your tips recap"
+      );
+      expect(tipsSection.items).toHaveLength(1);
+      expect(tipsSection.items[0].title).toContain("pixel_forge");
+    });
+  });
+
+  describe("scheduled_send", () => {
+    it("is a valid ISO date string in the future", async () => {
+      const res = await GET(makeReq("viewer_all_optin"));
+      const body = await res.json();
+
+      expect(typeof body.scheduled_send).toBe("string");
+      const parsed = new Date(body.scheduled_send);
+      expect(parsed.toISOString()).toBe(body.scheduled_send);
+      expect(parsed.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it("lands on 09:00 UTC", async () => {
+      const res = await GET(makeReq("viewer_all_optin"));
+      const body = await res.json();
+      const parsed = new Date(body.scheduled_send);
+      expect(parsed.getUTCHours()).toBe(9);
+      expect(parsed.getUTCMinutes()).toBe(0);
+    });
+  });
+
+  describe("utils: getNextScheduledSend", () => {
+    it("rolls to today 09:00 UTC when called before that time", () => {
+      const before = new Date(Date.UTC(2026, 0, 15, 3, 0, 0));
+      const result = getNextScheduledSend(before);
+      expect(result).toBe(new Date(Date.UTC(2026, 0, 15, 9, 0, 0)).toISOString());
+    });
+
+    it("rolls to tomorrow 09:00 UTC when called after that time", () => {
+      const after = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+      const result = getNextScheduledSend(after);
+      expect(result).toBe(new Date(Date.UTC(2026, 0, 16, 9, 0, 0)).toISOString());
+    });
+
+    it("rolls to tomorrow 09:00 UTC when called exactly at 09:00 UTC", () => {
+      const exact = new Date(Date.UTC(2026, 0, 15, 9, 0, 0));
+      const result = getNextScheduledSend(exact);
+      expect(result).toBe(new Date(Date.UTC(2026, 0, 16, 9, 0, 0)).toISOString());
+    });
+  });
+
+  describe("utils: buildSections", () => {
+    it("returns empty array when all opt-ins are false", () => {
+      const optIns = defaultOptIns("x");
+      const sections = buildSections({
+        ...optIns,
+        followed_live: false,
+        new_streams: false,
+        tips_recap: false,
+        recommended: false,
+      });
+      expect(sections).toEqual([]);
+    });
+  });
+
+  describe("seedData: getOptIns", () => {
+    it("returns seeded opt-ins for a known viewer", () => {
+      const optIns = getOptIns("viewer_none_optin");
+      expect(optIns.followed_live).toBe(false);
+      expect(optIns.tips_recap).toBe(false);
+    });
+
+    it("returns defaults for an unknown viewer", () => {
+      const optIns = getOptIns("totally_unknown_viewer");
+      expect(optIns).toEqual(defaultOptIns("totally_unknown_viewer"));
+    });
+  });
+});

--- a/app/api/routes-f/digest-preview/route.ts
+++ b/app/api/routes-f/digest-preview/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOptIns } from "./seedData";
+import { buildSections, getNextScheduledSend } from "./utils";
+import type { DigestPreviewResponse } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const viewerId = searchParams.get("viewer_id");
+
+  if (!viewerId) {
+    return NextResponse.json(
+      { error: "viewer_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const optIns = getOptIns(viewerId);
+  const sections = buildSections(optIns);
+  const scheduled_send = getNextScheduledSend();
+
+  return NextResponse.json({
+    sections,
+    scheduled_send,
+  } as DigestPreviewResponse);
+}

--- a/app/api/routes-f/digest-preview/seedData.ts
+++ b/app/api/routes-f/digest-preview/seedData.ts
@@ -1,0 +1,128 @@
+import type { DigestOptIns, DigestItem } from "./types";
+
+// Seeded opt-in preferences per viewer, mirroring realistic mixed-preference scenarios.
+export const optInStore: Map<string, DigestOptIns> = new Map([
+  [
+    "viewer_all_optin",
+    {
+      viewer_id: "viewer_all_optin",
+      followed_live: true,
+      new_streams: true,
+      tips_recap: true,
+      recommended: true,
+    },
+  ],
+  [
+    "viewer_mixed_optin",
+    {
+      viewer_id: "viewer_mixed_optin",
+      followed_live: true,
+      new_streams: false,
+      tips_recap: true,
+      recommended: false,
+    },
+  ],
+  [
+    "viewer_none_optin",
+    {
+      viewer_id: "viewer_none_optin",
+      followed_live: false,
+      new_streams: false,
+      tips_recap: false,
+      recommended: false,
+    },
+  ],
+]);
+
+export function defaultOptIns(viewer_id: string): DigestOptIns {
+  return {
+    viewer_id,
+    followed_live: true,
+    new_streams: true,
+    tips_recap: false,
+    recommended: true,
+  };
+}
+
+export function getOptIns(viewer_id: string): DigestOptIns {
+  return optInStore.get(viewer_id) ?? defaultOptIns(viewer_id);
+}
+
+// Shared content pools — same for every viewer that has the category enabled,
+// matching how a real digest would surface platform-wide live/new/recommended content.
+export const followedLiveItems: DigestItem[] = [
+  {
+    id: "live_1",
+    title: "nova_streams is live: Ranked Valorant grind",
+    subtitle: "1.2k watching",
+  },
+  {
+    id: "live_2",
+    title: "chainbeats is live: Lo-fi beats + XLM giveaways",
+    subtitle: "340 watching",
+  },
+];
+
+export const newStreamsItems: DigestItem[] = [
+  {
+    id: "new_1",
+    title: "pixel_forge went live for the first time this week",
+    subtitle: "Art & Design",
+  },
+  {
+    id: "new_2",
+    title: "stellar_sam started a new series: Crypto 101",
+    subtitle: "Education",
+  },
+  {
+    id: "new_3",
+    title: "midnight_dao is streaming a subscriber-only AMA",
+    subtitle: "Subscribers only",
+  },
+];
+
+export const recommendedItems: DigestItem[] = [
+  {
+    id: "rec_1",
+    title: "Top clip: nova_streams' clutch ace",
+    subtitle: "12.4k views this week",
+  },
+  {
+    id: "rec_2",
+    title: "Trending category: Music",
+    subtitle: "Based on your watch history",
+  },
+];
+
+// Per-viewer tips recap items — personalized, so most viewers have none.
+export const tipsRecapByViewer: Map<string, DigestItem[]> = new Map([
+  [
+    "viewer_all_optin",
+    [
+      {
+        id: "tip_1",
+        title: "You tipped nova_streams 25 USDC this week",
+        subtitle: "3 tips sent",
+      },
+      {
+        id: "tip_2",
+        title: "You tipped chainbeats 5 XLM this week",
+        subtitle: "1 tip sent",
+      },
+    ],
+  ],
+  [
+    "viewer_mixed_optin",
+    [
+      {
+        id: "tip_3",
+        title: "You tipped pixel_forge 10 USDC this week",
+        subtitle: "1 tip sent",
+      },
+    ],
+  ],
+]);
+
+export function getTipsRecapItems(viewer_id: string): DigestItem[] {
+  return tipsRecapByViewer.get(viewer_id) ?? [];
+}

--- a/app/api/routes-f/digest-preview/types.ts
+++ b/app/api/routes-f/digest-preview/types.ts
@@ -1,0 +1,29 @@
+export type DigestCategory =
+  | "followed_live"
+  | "new_streams"
+  | "tips_recap"
+  | "recommended";
+
+export interface DigestOptIns {
+  viewer_id: string;
+  followed_live: boolean;
+  new_streams: boolean;
+  tips_recap: boolean;
+  recommended: boolean;
+}
+
+export interface DigestItem {
+  id: string;
+  title: string;
+  subtitle: string;
+}
+
+export interface DigestSection {
+  title: string;
+  items: DigestItem[];
+}
+
+export interface DigestPreviewResponse {
+  sections: DigestSection[];
+  scheduled_send: string;
+}

--- a/app/api/routes-f/digest-preview/utils.ts
+++ b/app/api/routes-f/digest-preview/utils.ts
@@ -1,0 +1,73 @@
+import type { DigestOptIns, DigestSection } from "./types";
+import {
+  followedLiveItems,
+  newStreamsItems,
+  recommendedItems,
+  getTipsRecapItems,
+} from "./seedData";
+
+const SECTION_TITLES: Record<
+  Exclude<keyof DigestOptIns, "viewer_id">,
+  string
+> = {
+  followed_live: "Live now from creators you follow",
+  new_streams: "New streams this week",
+  tips_recap: "Your tips recap",
+  recommended: "Recommended for you",
+};
+
+// Sections only appear when the viewer has opted in to that category,
+// in a fixed, deterministic order.
+export function buildSections(optIns: DigestOptIns): DigestSection[] {
+  const sections: DigestSection[] = [];
+
+  if (optIns.followed_live) {
+    sections.push({
+      title: SECTION_TITLES.followed_live,
+      items: followedLiveItems,
+    });
+  }
+  if (optIns.new_streams) {
+    sections.push({
+      title: SECTION_TITLES.new_streams,
+      items: newStreamsItems,
+    });
+  }
+  if (optIns.tips_recap) {
+    sections.push({
+      title: SECTION_TITLES.tips_recap,
+      items: getTipsRecapItems(optIns.viewer_id),
+    });
+  }
+  if (optIns.recommended) {
+    sections.push({
+      title: SECTION_TITLES.recommended,
+      items: recommendedItems,
+    });
+  }
+
+  return sections;
+}
+
+const DAILY_SEND_HOUR_UTC = 9;
+
+// Next occurrence of the daily 09:00 UTC digest send, as an ISO string.
+export function getNextScheduledSend(now: Date = new Date()): string {
+  const next = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      DAILY_SEND_HOUR_UTC,
+      0,
+      0,
+      0
+    )
+  );
+
+  if (next.getTime() <= now.getTime()) {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+
+  return next.toISOString();
+}

--- a/app/api/routes-f/follower-conversion/__tests__/route.test.ts
+++ b/app/api/routes-f/follower-conversion/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { computeConversion, isValidWindowDays } from "../utils";
+import { getViewerEvents, getFollowEvents } from "../seedData";
+
+function makeReq(creatorId?: string, windowDays?: number | string): NextRequest {
+  let url = "http://localhost/api/routes-f/follower-conversion";
+  const params: string[] = [];
+  if (creatorId) params.push(`creator_id=${creatorId}`);
+  if (windowDays !== undefined) params.push(`window_days=${windowDays}`);
+  if (params.length) url += `?${params.join("&")}`;
+  return new NextRequest(url);
+}
+
+describe("GET /api/routes-f/follower-conversion", () => {
+  describe("Required Parameters", () => {
+    it("returns 400 when creator_id is missing", async () => {
+      const res = await GET(makeReq());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("creator_id");
+    });
+
+    it("returns 400 for a non-numeric window_days", async () => {
+      const res = await GET(makeReq("creator_alpha", "abc"));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("window_days");
+    });
+
+    it("returns 400 for a non-integer window_days", async () => {
+      const res = await GET(makeReq("creator_alpha", "7.5"));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for window_days less than 1", async () => {
+      const res = await GET(makeReq("creator_alpha", 0));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("Math with default 30-day window", () => {
+    it("computes total_viewers, new_followers, and conversion_percent", async () => {
+      const res = await GET(makeReq("creator_alpha"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.total_viewers).toBe(7);
+      expect(body.new_followers).toBe(3);
+      expect(body.conversion_percent).toBe(42.86);
+    });
+
+    it("does not count a follower who was never a viewer", async () => {
+      // viewer_11 follows but never appears in viewerEventStore — verified
+      // indirectly: new_followers stays at 3, not 4.
+      const res = await GET(makeReq("creator_alpha"));
+      const body = await res.json();
+      expect(body.new_followers).toBe(3);
+    });
+  });
+
+  describe("window_days filter", () => {
+    it("produces different results for a narrower window", async () => {
+      const res = await GET(makeReq("creator_alpha", 7));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.total_viewers).toBe(3);
+      expect(body.new_followers).toBe(2);
+      expect(body.conversion_percent).toBe(66.67);
+    });
+
+    it("excludes events older than the window", async () => {
+      const wide = await GET(makeReq("creator_alpha", 60));
+      const narrow = await GET(makeReq("creator_alpha", 3));
+      const wideBody = await wide.json();
+      const narrowBody = await narrow.json();
+
+      expect(wideBody.total_viewers).toBeGreaterThan(narrowBody.total_viewers);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("returns zero conversion when no one follows back", async () => {
+      const res = await GET(makeReq("creator_beta"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.total_viewers).toBe(2);
+      expect(body.new_followers).toBe(0);
+      expect(body.conversion_percent).toBe(0);
+    });
+
+    it("returns zeros for an unknown creator_id", async () => {
+      const res = await GET(makeReq("unknown_creator_xyz"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body).toEqual({
+        total_viewers: 0,
+        new_followers: 0,
+        conversion_percent: 0,
+      });
+    });
+  });
+
+  describe("utils: computeConversion", () => {
+    it("handles no viewers", () => {
+      const result = computeConversion([], [], 30);
+      expect(result).toEqual({
+        total_viewers: 0,
+        new_followers: 0,
+        conversion_percent: 0,
+      });
+    });
+
+    it("computes 100% conversion when every viewer follows", () => {
+      const now = 1_000_000_000_000;
+      const result = computeConversion(
+        [
+          { creator_id: "c", viewer: "a", timestamp: now },
+          { creator_id: "c", viewer: "b", timestamp: now },
+        ],
+        [
+          { creator_id: "c", viewer: "a", timestamp: now },
+          { creator_id: "c", viewer: "b", timestamp: now },
+        ],
+        30,
+        now
+      );
+      expect(result).toEqual({
+        total_viewers: 2,
+        new_followers: 2,
+        conversion_percent: 100,
+      });
+    });
+  });
+
+  describe("utils: isValidWindowDays", () => {
+    it("defaults to 30 when undefined", () => {
+      expect(isValidWindowDays(undefined)).toEqual({ valid: true, value: 30 });
+    });
+
+    it("accepts a valid string integer", () => {
+      expect(isValidWindowDays("14")).toEqual({ valid: true, value: 14 });
+    });
+
+    it("rejects negative values", () => {
+      expect(isValidWindowDays(-5).valid).toBe(false);
+    });
+  });
+
+  describe("seedData", () => {
+    it("filters events by creator_id", () => {
+      const events = getViewerEvents("creator_alpha");
+      expect(events.every(e => e.creator_id === "creator_alpha")).toBe(true);
+      expect(events.length).toBe(10);
+    });
+
+    it("returns empty arrays for unknown creator", () => {
+      expect(getViewerEvents("nope")).toEqual([]);
+      expect(getFollowEvents("nope")).toEqual([]);
+    });
+  });
+});

--- a/app/api/routes-f/follower-conversion/route.ts
+++ b/app/api/routes-f/follower-conversion/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getViewerEvents, getFollowEvents } from "./seedData";
+import { computeConversion, isValidWindowDays } from "./utils";
+import type { ConversionResponse } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+  const windowDaysParam = searchParams.get("window_days");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const windowValidation = isValidWindowDays(windowDaysParam ?? undefined);
+  if (!windowValidation.valid) {
+    return NextResponse.json(
+      { error: windowValidation.error },
+      { status: 400 }
+    );
+  }
+
+  const viewerEvents = getViewerEvents(creatorId);
+  const followEvents = getFollowEvents(creatorId);
+  const result = computeConversion(
+    viewerEvents,
+    followEvents,
+    windowValidation.value!
+  );
+
+  return NextResponse.json(result as ConversionResponse);
+}

--- a/app/api/routes-f/follower-conversion/seedData.ts
+++ b/app/api/routes-f/follower-conversion/seedData.ts
@@ -1,0 +1,45 @@
+import type { ViewerEvent, FollowEvent } from "./types";
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): number {
+  return Date.now() - days * ONE_DAY;
+}
+
+// Deterministic seed events, offset in whole days from "now" so window_days
+// filtering produces exactly reproducible math without relying on wall-clock
+// boundaries falling mid-test-run.
+export const viewerEventStore: ViewerEvent[] = [
+  { creator_id: "creator_alpha", viewer: "viewer_1", timestamp: daysAgo(5) },
+  { creator_id: "creator_alpha", viewer: "viewer_2", timestamp: daysAgo(10) },
+  { creator_id: "creator_alpha", viewer: "viewer_3", timestamp: daysAgo(15) },
+  { creator_id: "creator_alpha", viewer: "viewer_4", timestamp: daysAgo(25) },
+  { creator_id: "creator_alpha", viewer: "viewer_5", timestamp: daysAgo(40) },
+  { creator_id: "creator_alpha", viewer: "viewer_6", timestamp: daysAgo(50) },
+  { creator_id: "creator_alpha", viewer: "viewer_7", timestamp: daysAgo(2) },
+  { creator_id: "creator_alpha", viewer: "viewer_8", timestamp: daysAgo(29) },
+  { creator_id: "creator_alpha", viewer: "viewer_9", timestamp: daysAgo(31) },
+  { creator_id: "creator_alpha", viewer: "viewer_10", timestamp: daysAgo(1) },
+
+  // creator_beta — nobody converts within any reasonable window.
+  { creator_id: "creator_beta", viewer: "viewer_20", timestamp: daysAgo(3) },
+  { creator_id: "creator_beta", viewer: "viewer_21", timestamp: daysAgo(6) },
+];
+
+export const followEventStore: FollowEvent[] = [
+  { creator_id: "creator_alpha", viewer: "viewer_1", timestamp: daysAgo(4) },
+  { creator_id: "creator_alpha", viewer: "viewer_3", timestamp: daysAgo(14) },
+  { creator_id: "creator_alpha", viewer: "viewer_7", timestamp: daysAgo(1) },
+  { creator_id: "creator_alpha", viewer: "viewer_5", timestamp: daysAgo(38) },
+  // viewer_11 follows creator_alpha but never appears in viewerEventStore —
+  // shouldn't count as a conversion since they were never counted as a viewer.
+  { creator_id: "creator_alpha", viewer: "viewer_11", timestamp: daysAgo(3) },
+];
+
+export function getViewerEvents(creatorId: string): ViewerEvent[] {
+  return viewerEventStore.filter(e => e.creator_id === creatorId);
+}
+
+export function getFollowEvents(creatorId: string): FollowEvent[] {
+  return followEventStore.filter(e => e.creator_id === creatorId);
+}

--- a/app/api/routes-f/follower-conversion/types.ts
+++ b/app/api/routes-f/follower-conversion/types.ts
@@ -1,0 +1,17 @@
+export interface ViewerEvent {
+  creator_id: string;
+  viewer: string;
+  timestamp: number; // Unix timestamp in milliseconds
+}
+
+export interface FollowEvent {
+  creator_id: string;
+  viewer: string;
+  timestamp: number; // Unix timestamp in milliseconds
+}
+
+export interface ConversionResponse {
+  total_viewers: number;
+  new_followers: number;
+  conversion_percent: number;
+}

--- a/app/api/routes-f/follower-conversion/utils.ts
+++ b/app/api/routes-f/follower-conversion/utils.ts
@@ -1,0 +1,63 @@
+import type { ViewerEvent, FollowEvent, ConversionResponse } from "./types";
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+export const DEFAULT_WINDOW_DAYS = 30;
+
+export function computeConversion(
+  viewerEvents: ViewerEvent[],
+  followEvents: FollowEvent[],
+  windowDays: number,
+  now: number = Date.now()
+): ConversionResponse {
+  const cutoff = now - windowDays * ONE_DAY;
+
+  const viewersInWindow = new Set(
+    viewerEvents.filter(e => e.timestamp >= cutoff).map(e => e.viewer)
+  );
+  const followersInWindow = new Set(
+    followEvents.filter(e => e.timestamp >= cutoff).map(e => e.viewer)
+  );
+
+  const total_viewers = viewersInWindow.size;
+  let new_followers = 0;
+  for (const viewer of viewersInWindow) {
+    if (followersInWindow.has(viewer)) {
+      new_followers += 1;
+    }
+  }
+
+  const conversion_percent =
+    total_viewers === 0
+      ? 0
+      : roundToTwo((new_followers / total_viewers) * 100);
+
+  return { total_viewers, new_followers, conversion_percent };
+}
+
+export function isValidWindowDays(value: unknown): {
+  valid: boolean;
+  value?: number;
+  error?: string;
+} {
+  if (value === undefined || value === null) {
+    return { valid: true, value: DEFAULT_WINDOW_DAYS };
+  }
+
+  const parsed = typeof value === "string" ? Number(value) : value;
+
+  if (typeof parsed !== "number" || Number.isNaN(parsed)) {
+    return { valid: false, error: "window_days must be a number" };
+  }
+  if (!Number.isInteger(parsed)) {
+    return { valid: false, error: "window_days must be an integer" };
+  }
+  if (parsed < 1) {
+    return { valid: false, error: "window_days must be at least 1" };
+  }
+
+  return { valid: true, value: parsed };
+}
+
+function roundToTwo(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/app/api/routes-f/returning-viewers/__tests__/route.test.ts
+++ b/app/api/routes-f/returning-viewers/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { computeReturningStats } from "../utils";
+import { getHistoryForStream, viewerHistoryStore } from "../seedData";
+
+function makeReq(streamId?: string): NextRequest {
+  const url = streamId
+    ? `http://localhost/api/routes-f/returning-viewers?stream_id=${streamId}`
+    : "http://localhost/api/routes-f/returning-viewers";
+  return new NextRequest(url);
+}
+
+describe("GET /api/routes-f/returning-viewers", () => {
+  describe("Required Parameters", () => {
+    it("returns 400 when stream_id is missing", async () => {
+      const res = await GET(makeReq());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("stream_id");
+    });
+  });
+
+  describe("Aggregation math", () => {
+    it("computes returning_count, avg_prior_visits, and top_returning for a mixed stream", async () => {
+      const res = await GET(makeReq("stream_alpha_1"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // returning viewers: a(5) b(3) d(8) f(1) -> 4 returning, avg = 17/4 = 4.25
+      expect(body.returning_count).toBe(4);
+      expect(body.avg_prior_visits).toBe(4.25);
+      expect(body.top_returning).toEqual([
+        { viewer: "viewer_d", prior_visits: 8 },
+        { viewer: "viewer_a", prior_visits: 5 },
+        { viewer: "viewer_b", prior_visits: 3 },
+        { viewer: "viewer_f", prior_visits: 1 },
+      ]);
+    });
+
+    it("caps top_returning at 5 entries, sorted descending", async () => {
+      const res = await GET(makeReq("stream_gamma_3"));
+      const body = await res.json();
+
+      // 7 returning viewers seeded, only top 5 should be returned
+      expect(body.returning_count).toBe(7);
+      expect(body.top_returning).toHaveLength(5);
+      expect(body.top_returning).toEqual([
+        { viewer: "viewer_m", prior_visits: 20 },
+        { viewer: "viewer_o", prior_visits: 15 },
+        { viewer: "viewer_j", prior_visits: 12 },
+        { viewer: "viewer_p", prior_visits: 9 },
+        { viewer: "viewer_l", prior_visits: 7 },
+      ]);
+
+      const avg = Math.round(((12 + 2 + 7 + 20 + 1 + 15 + 9) / 7) * 100) / 100;
+      expect(body.avg_prior_visits).toBe(avg);
+    });
+
+    it("returns zeros when no viewers are returning", async () => {
+      const res = await GET(makeReq("stream_beta_2"));
+      const body = await res.json();
+
+      expect(body.returning_count).toBe(0);
+      expect(body.avg_prior_visits).toBe(0);
+      expect(body.top_returning).toEqual([]);
+    });
+
+    it("returns zeros for an unknown stream_id", async () => {
+      const res = await GET(makeReq("unknown_stream_xyz"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.returning_count).toBe(0);
+      expect(body.avg_prior_visits).toBe(0);
+      expect(body.top_returning).toEqual([]);
+    });
+  });
+
+  describe("utils: computeReturningStats", () => {
+    it("excludes zero-visit viewers from returning_count", () => {
+      const stats = computeReturningStats([
+        { stream_id: "s", viewer: "x", prior_visits: 0 },
+        { stream_id: "s", viewer: "y", prior_visits: 2 },
+      ]);
+      expect(stats.returning_count).toBe(1);
+      expect(stats.avg_prior_visits).toBe(2);
+    });
+
+    it("handles an empty record set", () => {
+      expect(computeReturningStats([])).toEqual({
+        returning_count: 0,
+        avg_prior_visits: 0,
+        top_returning: [],
+      });
+    });
+  });
+
+  describe("seedData", () => {
+    it("filters records by stream_id", () => {
+      const records = getHistoryForStream("stream_alpha_1");
+      expect(records.every(r => r.stream_id === "stream_alpha_1")).toBe(true);
+      expect(records.length).toBe(6);
+    });
+
+    it("returns empty array for unknown stream", () => {
+      expect(getHistoryForStream("nope")).toEqual([]);
+    });
+
+    it("has seed data loaded", () => {
+      expect(viewerHistoryStore.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/api/routes-f/returning-viewers/route.ts
+++ b/app/api/routes-f/returning-viewers/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getHistoryForStream } from "./seedData";
+import { computeReturningStats } from "./utils";
+import type { ReturningViewersResponse } from "./types";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const streamId = searchParams.get("stream_id");
+
+  if (!streamId) {
+    return NextResponse.json(
+      { error: "stream_id is required" },
+      { status: 400 }
+    );
+  }
+
+  const records = getHistoryForStream(streamId);
+  const stats = computeReturningStats(records);
+
+  return NextResponse.json(stats as ReturningViewersResponse);
+}

--- a/app/api/routes-f/returning-viewers/seedData.ts
+++ b/app/api/routes-f/returning-viewers/seedData.ts
@@ -1,0 +1,32 @@
+import type { ViewerVisitRecord } from "./types";
+
+// Deterministic seed viewer-history — a mix of returning and first-time
+// viewers per stream, so aggregation math is exactly reproducible in tests.
+export const viewerHistoryStore: ViewerVisitRecord[] = [
+  // stream_alpha_1 — a mix of returning and brand-new viewers.
+  { stream_id: "stream_alpha_1", viewer: "viewer_a", prior_visits: 5 },
+  { stream_id: "stream_alpha_1", viewer: "viewer_b", prior_visits: 3 },
+  { stream_id: "stream_alpha_1", viewer: "viewer_c", prior_visits: 0 },
+  { stream_id: "stream_alpha_1", viewer: "viewer_d", prior_visits: 8 },
+  { stream_id: "stream_alpha_1", viewer: "viewer_e", prior_visits: 0 },
+  { stream_id: "stream_alpha_1", viewer: "viewer_f", prior_visits: 1 },
+
+  // stream_beta_2 — every viewer is brand new (no returning viewers).
+  { stream_id: "stream_beta_2", viewer: "viewer_g", prior_visits: 0 },
+  { stream_id: "stream_beta_2", viewer: "viewer_h", prior_visits: 0 },
+  { stream_id: "stream_beta_2", viewer: "viewer_i", prior_visits: 0 },
+
+  // stream_gamma_3 — more than 5 returning viewers, to exercise the top-5 cap.
+  { stream_id: "stream_gamma_3", viewer: "viewer_j", prior_visits: 12 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_k", prior_visits: 2 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_l", prior_visits: 7 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_m", prior_visits: 20 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_n", prior_visits: 1 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_o", prior_visits: 15 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_p", prior_visits: 9 },
+  { stream_id: "stream_gamma_3", viewer: "viewer_q", prior_visits: 0 },
+];
+
+export function getHistoryForStream(streamId: string): ViewerVisitRecord[] {
+  return viewerHistoryStore.filter(record => record.stream_id === streamId);
+}

--- a/app/api/routes-f/returning-viewers/types.ts
+++ b/app/api/routes-f/returning-viewers/types.ts
@@ -1,0 +1,16 @@
+export interface ViewerVisitRecord {
+  stream_id: string;
+  viewer: string;
+  prior_visits: number;
+}
+
+export interface ReturningViewerEntry {
+  viewer: string;
+  prior_visits: number;
+}
+
+export interface ReturningViewersResponse {
+  returning_count: number;
+  avg_prior_visits: number;
+  top_returning: ReturningViewerEntry[];
+}

--- a/app/api/routes-f/returning-viewers/utils.ts
+++ b/app/api/routes-f/returning-viewers/utils.ts
@@ -1,0 +1,29 @@
+import type { ViewerVisitRecord, ReturningViewersResponse } from "./types";
+
+const TOP_RETURNING_LIMIT = 5;
+
+export function computeReturningStats(
+  records: ViewerVisitRecord[]
+): ReturningViewersResponse {
+  const returning = records.filter(r => r.prior_visits > 0);
+
+  const returning_count = returning.length;
+  const avg_prior_visits =
+    returning_count === 0
+      ? 0
+      : roundToTwo(
+          returning.reduce((sum, r) => sum + r.prior_visits, 0) /
+            returning_count
+        );
+
+  const top_returning = [...returning]
+    .sort((a, b) => b.prior_visits - a.prior_visits)
+    .slice(0, TOP_RETURNING_LIMIT)
+    .map(({ viewer, prior_visits }) => ({ viewer, prior_visits }));
+
+  return { returning_count, avg_prior_visits, top_returning };
+}
+
+function roundToTwo(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
## Summary
- `GET /api/routes-f/digest-preview?viewer_id=` — previews a viewer's next digest email; sections are included only for categories the viewer has opted into (`followed_live`, `new_streams`, `tips_recap`, `recommended`), plus the next `scheduled_send` time.
- `GET /api/routes-f/returning-viewers?stream_id=` — returning-viewer stats for a stream: `returning_count`, `avg_prior_visits`, and the top 5 `top_returning` viewers by prior visit count.
- `GET /api/routes-f/follower-conversion?creator_id=&window_days=` — how often viewers convert to followers within a window (default 30 days): `total_viewers`, `new_followers`, `conversion_percent`.
- `GET /api/routes-f/day-performance?creator_id=` — average performance per day of week for a creator: `avg_viewers`, `avg_tips_usdc`, and `stream_count` for all 7 weekdays.

Each endpoint is fully self-contained under its own `app/api/routes-f/<feature>/` folder (`route.ts`, `types.ts`, `seedData.ts`, `utils.ts`, `__tests__/`), with deterministic in-memory seed data and no imports outside its own folder, per the task scope constraints.

Closes #1252
Closes #1261
Closes #1267
Closes #1273

## Test plan
- [x] `npx jest app/api/routes-f/{digest-preview,returning-viewers,follower-conversion,day-performance}` — 53/53 tests passing, covering mixed opt-ins, aggregation math, window filtering, and weekday grouping
- [x] `tsc --noEmit` clean on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)