### PR TITLE
feat(routesF): add creator analytics routes

### DIFF
--- a/app/api/routesF/follower-churn-analysis/route.test.ts
+++ b/app/api/routesF/follower-churn-analysis/route.test.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routesF/follower-churn-analysis${query}`
+  );
+}
+
+describe("/api/routesF/follower-churn-analysis", () => {
+  it("computes the default 30-day churn window", async () => {
+    const res = await GET(makeReq("?creator_id=creator-alpha"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.starting_followers).toBe(4);
+    expect(data.gained).toBe(3);
+    expect(data.lost).toBe(2);
+    expect(data.ending).toBe(5);
+    expect(data.churn_rate_percent).toBeCloseTo(50, 5);
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeReq(""));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when window_days is invalid", async () => {
+    const res = await GET(
+      makeReq("?creator_id=creator-alpha&window_days=-5")
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/follower-churn-analysis/route.ts
+++ b/app/api/routesF/follower-churn-analysis/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from "next/server";
+
+type FollowEvent = {
+  creator_id: string;
+  user_id: string;
+  action: "follow" | "unfollow";
+  happened_at: string;
+};
+
+const FOLLOW_EVENTS: FollowEvent[] = [
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-1",
+    action: "follow",
+    happened_at: "2026-06-01T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-2",
+    action: "follow",
+    happened_at: "2026-06-03T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-3",
+    action: "follow",
+    happened_at: "2026-06-10T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-4",
+    action: "follow",
+    happened_at: "2026-06-12T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-5",
+    action: "follow",
+    happened_at: "2026-07-05T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-2",
+    action: "unfollow",
+    happened_at: "2026-07-12T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-6",
+    action: "follow",
+    happened_at: "2026-07-20T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-4",
+    action: "unfollow",
+    happened_at: "2026-07-23T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    user_id: "fan-7",
+    action: "follow",
+    happened_at: "2026-07-24T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-beta",
+    user_id: "fan-z",
+    action: "follow",
+    happened_at: "2026-07-24T00:00:00.000Z",
+  },
+];
+
+function parseWindowDays(value: string | null) {
+  if (value === null || value === "") {
+    return 30;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function startOfUtcDay(dateString: string) {
+  const date = new Date(dateString);
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+}
+
+function addUtcDays(date: Date, days: number) {
+  const nextDate = new Date(date);
+  nextDate.setUTCDate(nextDate.getUTCDate() + days);
+  return nextDate;
+}
+
+function getWindowBounds(eventDates: string[], windowDays: number) {
+  const latestDay = eventDates
+    .map(startOfUtcDay)
+    .reduce((latest, candidate) => (candidate > latest ? candidate : latest));
+
+  const windowStart = addUtcDays(latestDay, -(windowDays - 1));
+  return { windowStart, windowEnd: latestDay };
+}
+
+function countFollowers(events: FollowEvent[]) {
+  const followers = new Set<string>();
+
+  for (const event of events) {
+    if (event.action === "follow") {
+      followers.add(event.user_id);
+    } else {
+      followers.delete(event.user_id);
+    }
+  }
+
+  return followers.size;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creatorId = searchParams.get("creator_id");
+  const windowDays = parseWindowDays(searchParams.get("window_days"));
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+
+  if (windowDays === null) {
+    return NextResponse.json(
+      { error: "window_days must be a positive integer." },
+      { status: 400 }
+    );
+  }
+
+  const creatorEvents = FOLLOW_EVENTS.filter(
+    event => event.creator_id === creatorId
+  );
+
+  if (creatorEvents.length === 0) {
+    return NextResponse.json({
+      starting_followers: 0,
+      gained: 0,
+      lost: 0,
+      ending: 0,
+      churn_rate_percent: 0,
+    });
+  }
+
+  const eventDates = creatorEvents.map(event => event.happened_at);
+  const { windowStart, windowEnd } = getWindowBounds(eventDates, windowDays);
+
+  const startingEvents = creatorEvents.filter(event => {
+    const occurredAt = startOfUtcDay(event.happened_at);
+    return occurredAt < windowStart;
+  });
+  const windowEvents = creatorEvents.filter(event => {
+    const occurredAt = startOfUtcDay(event.happened_at);
+    return occurredAt >= windowStart && occurredAt <= windowEnd;
+  });
+
+  const starting_followers = countFollowers(startingEvents);
+  const gained = windowEvents.filter(event => event.action === "follow").length;
+  const lost = windowEvents.filter(event => event.action === "unfollow").length;
+  const ending = starting_followers + gained - lost;
+  const churn_rate_percent =
+    starting_followers === 0 ? 0 : (lost / starting_followers) * 100;
+
+  return NextResponse.json({
+    starting_followers,
+    gained,
+    lost,
+    ending,
+    churn_rate_percent,
+  });
+}

--- a/app/api/routesF/peer-benchmark-comparison/route.test.ts
+++ b/app/api/routesF/peer-benchmark-comparison/route.test.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routesF/peer-benchmark-comparison${query}`
+  );
+}
+
+describe("/api/routesF/peer-benchmark-comparison", () => {
+  it("places the top creator at the top percentile", async () => {
+    const res = await GET(makeReq("?creator_id=creator-top"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.creator.creator_id).toBe("creator-top");
+    expect(data.percentile).toBe(100);
+    expect(data.peer_avg.followers).toBeCloseTo(2150, 5);
+  });
+
+  it("places the median creator around the middle percentile", async () => {
+    const res = await GET(makeReq("?creator_id=creator-mid"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.creator.creator_id).toBe("creator-mid");
+    expect(data.percentile).toBe(50);
+  });
+
+  it("places the bottom creator at the lowest percentile", async () => {
+    const res = await GET(makeReq("?creator_id=creator-bottom"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.creator.creator_id).toBe("creator-bottom");
+    expect(data.percentile).toBe(0);
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeReq(""));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/peer-benchmark-comparison/route.ts
+++ b/app/api/routesF/peer-benchmark-comparison/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+
+type CreatorStats = {
+  creator_id: string;
+  category: string;
+  followers: number;
+  avg_watch_minutes: number;
+  conversion_rate: number;
+  tips_usdc: number;
+};
+
+const CREATOR_STATS: CreatorStats[] = [
+  {
+    creator_id: "creator-top",
+    category: "gaming",
+    followers: 5200,
+    avg_watch_minutes: 42,
+    conversion_rate: 8.4,
+    tips_usdc: 940,
+  },
+  {
+    creator_id: "creator-mid",
+    category: "gaming",
+    followers: 3200,
+    avg_watch_minutes: 31,
+    conversion_rate: 6.2,
+    tips_usdc: 540,
+  },
+  {
+    creator_id: "creator-bottom",
+    category: "gaming",
+    followers: 1100,
+    avg_watch_minutes: 14,
+    conversion_rate: 2.1,
+    tips_usdc: 130,
+  },
+  {
+    creator_id: "music-top",
+    category: "music",
+    followers: 4100,
+    avg_watch_minutes: 39,
+    conversion_rate: 7.2,
+    tips_usdc: 780,
+  },
+];
+
+function scoreCreator(stats: CreatorStats) {
+  return (
+    stats.followers / 100 +
+    stats.avg_watch_minutes * 10 +
+    stats.conversion_rate * 50 +
+    stats.tips_usdc / 10
+  );
+}
+
+function buildCreatorSnapshot(stats: CreatorStats) {
+  return {
+    creator_id: stats.creator_id,
+    category: stats.category,
+    score: scoreCreator(stats),
+    followers: stats.followers,
+    avg_watch_minutes: stats.avg_watch_minutes,
+    conversion_rate: stats.conversion_rate,
+    tips_usdc: stats.tips_usdc,
+  };
+}
+
+function averagePeerSnapshot(peers: CreatorStats[]) {
+  const totals = peers.reduce(
+    (accumulator, peer) => ({
+      followers: accumulator.followers + peer.followers,
+      avg_watch_minutes: accumulator.avg_watch_minutes + peer.avg_watch_minutes,
+      conversion_rate: accumulator.conversion_rate + peer.conversion_rate,
+      tips_usdc: accumulator.tips_usdc + peer.tips_usdc,
+      score: accumulator.score + scoreCreator(peer),
+    }),
+    {
+      followers: 0,
+      avg_watch_minutes: 0,
+      conversion_rate: 0,
+      tips_usdc: 0,
+      score: 0,
+    }
+  );
+
+  const divisor = peers.length || 1;
+  return {
+    score: totals.score / divisor,
+    followers: totals.followers / divisor,
+    avg_watch_minutes: totals.avg_watch_minutes / divisor,
+    conversion_rate: totals.conversion_rate / divisor,
+    tips_usdc: totals.tips_usdc / divisor,
+  };
+}
+
+function rankPercentile(targetScore: number, scores: number[]) {
+  const sortedScores = [...scores].sort((left, right) => left - right);
+  const rank = sortedScores.findIndex(score => score === targetScore);
+
+  if (sortedScores.length <= 1) {
+    return 100;
+  }
+
+  if (rank === -1) {
+    return 0;
+  }
+
+  return (rank / (sortedScores.length - 1)) * 100;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+
+  const creator = CREATOR_STATS.find(entry => entry.creator_id === creatorId);
+  if (!creator) {
+    return NextResponse.json({ error: "creator_id not found." }, { status: 404 });
+  }
+
+  const peers = CREATOR_STATS.filter(
+    entry => entry.category === creator.category && entry.creator_id !== creatorId
+  );
+
+  const creatorSnapshot = buildCreatorSnapshot(creator);
+  const peerAvg = averagePeerSnapshot(peers);
+  const categoryScores = [
+    ...peers.map(peer => scoreCreator(peer)),
+    creatorSnapshot.score,
+  ];
+
+  return NextResponse.json({
+    creator: creatorSnapshot,
+    peer_avg: peerAvg,
+    percentile: rankPercentile(creatorSnapshot.score, categoryScores),
+  });
+}

--- a/app/api/routesF/view-to-sub-conversion/route.test.ts
+++ b/app/api/routesF/view-to-sub-conversion/route.test.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(query: string) {
+  return new NextRequest(
+    `http://localhost/api/routesF/view-to-sub-conversion${query}`
+  );
+}
+
+describe("/api/routesF/view-to-sub-conversion", () => {
+  it("computes the default 30-day conversion window", async () => {
+    const res = await GET(makeReq("?creator_id=creator-alpha"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total_viewers).toBe(5);
+    expect(data.new_subs).toBe(2);
+    expect(data.conversion_percent).toBeCloseTo(40, 5);
+  });
+
+  it("narrows the conversion window when window_days is provided", async () => {
+    const res = await GET(
+      makeReq("?creator_id=creator-alpha&window_days=7")
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total_viewers).toBe(3);
+    expect(data.new_subs).toBe(2);
+    expect(data.conversion_percent).toBeCloseTo(66.6667, 4);
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeReq(""));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when window_days is invalid", async () => {
+    const res = await GET(
+      makeReq("?creator_id=creator-alpha&window_days=zero")
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/view-to-sub-conversion/route.ts
+++ b/app/api/routesF/view-to-sub-conversion/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from "next/server";
+
+type ViewEvent = {
+  creator_id: string;
+  viewer_id: string;
+  viewed_at: string;
+};
+
+type SubEvent = {
+  creator_id: string;
+  viewer_id: string;
+  subscribed_at: string;
+};
+
+const VIEW_EVENTS: ViewEvent[] = [
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "ava",
+    viewed_at: "2026-07-01T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "ben",
+    viewed_at: "2026-07-02T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "ava",
+    viewed_at: "2026-07-03T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "chloe",
+    viewed_at: "2026-07-21T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "dan",
+    viewed_at: "2026-07-23T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "erica",
+    viewed_at: "2026-07-24T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-beta",
+    viewer_id: "zoe",
+    viewed_at: "2026-07-24T00:00:00.000Z",
+  },
+];
+
+const SUB_EVENTS: SubEvent[] = [
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "ava",
+    subscribed_at: "2026-07-22T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "erica",
+    subscribed_at: "2026-07-24T00:00:00.000Z",
+  },
+  {
+    creator_id: "creator-alpha",
+    viewer_id: "frank",
+    subscribed_at: "2026-06-10T00:00:00.000Z",
+  },
+];
+
+function parseWindowDays(value: string | null) {
+  if (value === null || value === "") {
+    return 30;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function startOfUtcDay(dateString: string) {
+  const date = new Date(dateString);
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+}
+
+function addUtcDays(date: Date, days: number) {
+  const nextDate = new Date(date);
+  nextDate.setUTCDate(nextDate.getUTCDate() + days);
+  return nextDate;
+}
+
+function getWindowBounds(eventDates: string[], windowDays: number) {
+  const latestDay = eventDates
+    .map(startOfUtcDay)
+    .reduce((latest, candidate) => (candidate > latest ? candidate : latest));
+
+  const windowStart = addUtcDays(latestDay, -(windowDays - 1));
+  return { windowStart, windowEnd: latestDay };
+}
+
+function uniqueIds<T extends { viewer_id: string }>(events: T[]) {
+  return new Set(events.map(event => event.viewer_id));
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creatorId = searchParams.get("creator_id");
+  const windowDays = parseWindowDays(searchParams.get("window_days"));
+
+  if (!creatorId) {
+    return NextResponse.json(
+      { error: "creator_id is required." },
+      { status: 400 }
+    );
+  }
+
+  if (windowDays === null) {
+    return NextResponse.json(
+      { error: "window_days must be a positive integer." },
+      { status: 400 }
+    );
+  }
+
+  const creatorViews = VIEW_EVENTS.filter(
+    event => event.creator_id === creatorId
+  );
+  const creatorSubs = SUB_EVENTS.filter(event => event.creator_id === creatorId);
+
+  if (creatorViews.length === 0 && creatorSubs.length === 0) {
+    return NextResponse.json({
+      total_viewers: 0,
+      new_subs: 0,
+      conversion_percent: 0,
+    });
+  }
+
+  const eventDates = [...creatorViews, ...creatorSubs].map(
+    event => "viewed_at" in event ? event.viewed_at : event.subscribed_at
+  );
+  const { windowStart, windowEnd } = getWindowBounds(eventDates, windowDays);
+
+  const windowedViews = creatorViews.filter(event => {
+    const viewedAt = startOfUtcDay(event.viewed_at);
+    return viewedAt >= windowStart && viewedAt <= windowEnd;
+  });
+
+  const windowedSubs = creatorSubs.filter(event => {
+    const subscribedAt = startOfUtcDay(event.subscribed_at);
+    return subscribedAt >= windowStart && subscribedAt <= windowEnd;
+  });
+
+  const total_viewers = uniqueIds(windowedViews).size;
+  const new_subs = uniqueIds(windowedSubs).size;
+  const conversion_percent =
+    total_viewers === 0 ? 0 : (new_subs / total_viewers) * 100;
+
+  return NextResponse.json({
+    total_viewers,
+    new_subs,
+    conversion_percent,
+  });
+}

--- a/app/api/routesF/viewer-lifetime-value/route.test.ts
+++ b/app/api/routesF/viewer-lifetime-value/route.test.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/viewer-lifetime-value", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/routesF/viewer-lifetime-value", () => {
+  it("returns known lifetime value metrics for a viewer", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer-alpha", creator_id: "creator-alpha" })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total_tips_usdc).toBe(30);
+    expect(data.total_sub_months).toBe(3);
+    expect(data.ltv_usdc).toBe(45);
+    expect(data.cohort).toBe("steady");
+  });
+
+  it("returns zeroed metrics for an unseen viewer", async () => {
+    const res = await POST(
+      makeReq({ viewer_id: "viewer-novel", creator_id: "creator-alpha" })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.total_tips_usdc).toBe(0);
+    expect(data.total_sub_months).toBe(0);
+    expect(data.ltv_usdc).toBe(0);
+    expect(data.cohort).toBe("new");
+  });
+
+  it("rejects requests without a viewer_id", async () => {
+    const res = await POST(makeReq({ creator_id: "creator-alpha" }));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/viewer-lifetime-value/route.ts
+++ b/app/api/routesF/viewer-lifetime-value/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+
+type HistoryEntry = {
+  viewer_id: string;
+  creator_id: string;
+  tip_usdc: number;
+  sub_months: number;
+};
+
+type LtvBody = {
+  viewer_id?: unknown;
+  creator_id?: unknown;
+};
+
+const VIEWER_HISTORY: HistoryEntry[] = [
+  {
+    viewer_id: "viewer-alpha",
+    creator_id: "creator-alpha",
+    tip_usdc: 12,
+    sub_months: 1,
+  },
+  {
+    viewer_id: "viewer-alpha",
+    creator_id: "creator-alpha",
+    tip_usdc: 18,
+    sub_months: 2,
+  },
+  {
+    viewer_id: "viewer-alpha",
+    creator_id: "creator-beta",
+    tip_usdc: 5,
+    sub_months: 0,
+  },
+  {
+    viewer_id: "viewer-bravo",
+    creator_id: "creator-alpha",
+    tip_usdc: 0,
+    sub_months: 4,
+  },
+  {
+    viewer_id: "viewer-bravo",
+    creator_id: "creator-alpha",
+    tip_usdc: 8,
+    sub_months: 0,
+  },
+  {
+    viewer_id: "viewer-charlie",
+    creator_id: "creator-alpha",
+    tip_usdc: 120,
+    sub_months: 6,
+  },
+];
+
+const SUB_MONTH_VALUE_USDC = 5;
+
+function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function resolveCohort(totalTipsUsdc: number, totalSubMonths: number) {
+  if (totalTipsUsdc >= 100 || totalSubMonths >= 6) {
+    return "power";
+  }
+
+  if (totalTipsUsdc >= 25 || totalSubMonths >= 2) {
+    return "steady";
+  }
+
+  return "new";
+}
+
+export async function POST(request: Request) {
+  let body: LtvBody;
+
+  try {
+    body = (await request.json()) as LtvBody;
+  } catch {
+    return badRequest("Invalid JSON body.");
+  }
+
+  const viewerId = body.viewer_id;
+  const creatorId = body.creator_id;
+
+  if (typeof viewerId !== "string" || viewerId.trim() === "") {
+    return badRequest("viewer_id is required.");
+  }
+
+  if (typeof creatorId !== "string" || creatorId.trim() === "") {
+    return badRequest("creator_id is required.");
+  }
+
+  const history = VIEWER_HISTORY.filter(
+    entry => entry.viewer_id === viewerId && entry.creator_id === creatorId
+  );
+
+  const total_tips_usdc = history.reduce(
+    (total, entry) => total + entry.tip_usdc,
+    0
+  );
+  const total_sub_months = history.reduce(
+    (total, entry) => total + entry.sub_months,
+    0
+  );
+  const ltv_usdc = total_tips_usdc + total_sub_months * SUB_MONTH_VALUE_USDC;
+  const cohort = resolveCohort(total_tips_usdc, total_sub_months);
+
+  return NextResponse.json({
+    total_tips_usdc,
+    total_sub_months,
+    ltv_usdc,
+    cohort,
+  });
+}


### PR DESCRIPTION
Closes #1268
Closes #1275
Closes #1278
Closes #1280

## Summary
This PR adds the four `routesF` creator analytics endpoints requested in the StreamFi frontend task set and keeps each implementation fully self-contained inside `app/api/routesF/`.

### Added routes
- `view-to-sub-conversion`: computes unique viewer totals, new subscriptions, and conversion percentage over a configurable window.
- `follower-churn-analysis`: computes starting followers, gained, lost, ending, and churn rate over a configurable window.
- `viewer-lifetime-value`: aggregates viewer tip and subscription history into a simple LTV model with cohort classification.
- `peer-benchmark-comparison`: compares a creator against category peers and returns creator metrics, peer averages, and percentile placement.

### Notes
- Each route includes deterministic bundled seed data so the behavior is reproducible.
- Query and body validation return clear 400 responses for missing or invalid input.
- The implementations stay scoped to `app/api/routesF/` to preserve mergeability with the other practice tasks.

## Testing
- Not run, per request.
