### PR TITLE
feat(routes-f/routesF): clip download, VOD download, creator annotations, fresh streams

### DIFF
--- a/app/api/routes-f/clip-download-request/__tests__/route.test.ts
+++ b/app/api/routes-f/clip-download-request/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from "next/server";
+import { POST, GET } from "../route";
+
+function makePost(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/clip-download-request", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/clip-download-request");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("POST /api/routes-f/clip-download-request", () => {
+  it("queues a clip download request", async () => {
+    const res = await POST(makePost({ clip_id: "clip-abc", requester_id: "user-1" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(202);
+    expect(data.status).toBe("queued");
+    expect(typeof data.request_id).toBe("string");
+    expect(data.request_id.length).toBeGreaterThan(0);
+  });
+
+  it("accepts optional format mp4", async () => {
+    const res = await POST(makePost({ clip_id: "clip-abc", requester_id: "user-1", format: "mp4" }));
+    expect(res.status).toBe(202);
+  });
+
+  it("accepts optional format gif", async () => {
+    const res = await POST(makePost({ clip_id: "clip-gif", requester_id: "user-2", format: "gif" }));
+    const data = await res.json();
+    expect(res.status).toBe(202);
+    expect(data.status).toBe("queued");
+  });
+
+  it("returns 400 when clip_id is missing", async () => {
+    const res = await POST(makePost({ requester_id: "user-1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when requester_id is missing", async () => {
+    const res = await POST(makePost({ clip_id: "clip-abc" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid format", async () => {
+    const res = await POST(makePost({ clip_id: "clip-abc", requester_id: "user-1", format: "avi" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/clip-download-request", {
+      method: "POST",
+      body: "not-json",
+      headers: { "Content-Type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("each request gets a unique request_id", async () => {
+    const res1 = await POST(makePost({ clip_id: "clip-x", requester_id: "user-x" }));
+    const res2 = await POST(makePost({ clip_id: "clip-x", requester_id: "user-x" }));
+    const data1 = await res1.json();
+    const data2 = await res2.json();
+    expect(data1.request_id).not.toBe(data2.request_id);
+  });
+});
+
+describe("GET /api/routes-f/clip-download-request", () => {
+  it("returns queued status immediately after POST", async () => {
+    const postRes = await POST(makePost({ clip_id: "clip-lookup", requester_id: "user-3" }));
+    const { request_id } = await postRes.json();
+
+    const getRes = await GET(makeGet({ request_id }));
+    const data = await getRes.json();
+
+    expect(getRes.status).toBe(200);
+    expect(data.request_id).toBe(request_id);
+    expect(data.status).toBe("queued");
+    expect(data.download_url).toBeUndefined();
+  });
+
+  it("returns 400 when request_id is missing", async () => {
+    const res = await GET(makeGet({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown request_id", async () => {
+    const res = await GET(makeGet({ request_id: "req-does-not-exist" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns ready status and download_url after auto-complete delay", async () => {
+    const postRes = await POST(makePost({ clip_id: "clip-delay", requester_id: "user-delay" }));
+    const { request_id } = await postRes.json();
+
+    await new Promise((r) => setTimeout(r, 5100));
+
+    const getRes = await GET(makeGet({ request_id }));
+    const data = await getRes.json();
+
+    expect(data.status).toBe("ready");
+    expect(typeof data.download_url).toBe("string");
+    expect(data.download_url).toContain("clip-delay");
+  }, 10000);
+
+  it("response has request_id, status, and optional download_url fields only", async () => {
+    const postRes = await POST(makePost({ clip_id: "clip-shape", requester_id: "user-shape" }));
+    const { request_id } = await postRes.json();
+
+    const getRes = await GET(makeGet({ request_id }));
+    const data = await getRes.json();
+
+    expect(data).toHaveProperty("request_id");
+    expect(data).toHaveProperty("status");
+    expect(["queued", "ready", "failed"]).toContain(data.status);
+  });
+});

--- a/app/api/routes-f/clip-download-request/route.ts
+++ b/app/api/routes-f/clip-download-request/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type ClipFormat = "mp4" | "gif";
+type RequestStatus = "queued" | "ready" | "failed";
+
+type DownloadRequest = {
+  request_id: string;
+  clip_id: string;
+  requester_id: string;
+  format: ClipFormat;
+  status: RequestStatus;
+  queued_at: number;
+  download_url?: string;
+};
+
+type PostBody = {
+  clip_id: string;
+  requester_id: string;
+  format?: ClipFormat;
+};
+
+const VALID_FORMATS: ClipFormat[] = ["mp4", "gif"];
+const AUTO_COMPLETE_MS = 5_000;
+
+const requests = new Map<string, DownloadRequest>();
+let counter = 0;
+
+function generateRequestId(): string {
+  counter += 1;
+  return `cdl-${Date.now()}-${counter}`;
+}
+
+function mockDownloadUrl(clipId: string, format: ClipFormat): string {
+  return `https://cdn.streamfi.io/clips/${clipId}/download.${format}?token=mock`;
+}
+
+function resolveStatus(req: DownloadRequest): DownloadRequest {
+  if (req.status === "queued" && Date.now() - req.queued_at >= AUTO_COMPLETE_MS) {
+    return { ...req, status: "ready", download_url: mockDownloadUrl(req.clip_id, req.format) };
+  }
+  return req;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { clip_id, requester_id, format = "mp4" } = (body ?? {}) as PostBody;
+
+  if (!clip_id || typeof clip_id !== "string") {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+  if (!requester_id || typeof requester_id !== "string") {
+    return NextResponse.json({ error: "requester_id is required" }, { status: 400 });
+  }
+  if (!VALID_FORMATS.includes(format)) {
+    return NextResponse.json({ error: "format must be mp4 or gif" }, { status: 400 });
+  }
+
+  const request_id = generateRequestId();
+  const entry: DownloadRequest = {
+    request_id,
+    clip_id,
+    requester_id,
+    format,
+    status: "queued",
+    queued_at: Date.now(),
+  };
+  requests.set(request_id, entry);
+
+  return NextResponse.json({ request_id, status: "queued" }, { status: 202 });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const request_id = searchParams.get("request_id");
+
+  if (!request_id) {
+    return NextResponse.json({ error: "request_id query param is required" }, { status: 400 });
+  }
+
+  const entry = requests.get(request_id);
+  if (!entry) {
+    return NextResponse.json({ error: "Request not found" }, { status: 404 });
+  }
+
+  const resolved = resolveStatus(entry);
+  requests.set(request_id, resolved);
+
+  const response: { request_id: string; status: RequestStatus; download_url?: string } = {
+    request_id: resolved.request_id,
+    status: resolved.status,
+  };
+  if (resolved.download_url) {
+    response.download_url = resolved.download_url;
+  }
+
+  return NextResponse.json(response);
+}

--- a/app/api/routes-f/vod-download-request/__tests__/route.test.ts
+++ b/app/api/routes-f/vod-download-request/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { NextRequest } from "next/server";
+import { POST, GET } from "../route";
+
+function makePost(body: unknown) {
+  return new NextRequest("http://localhost/api/routes-f/vod-download-request", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routes-f/vod-download-request");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("POST /api/routes-f/vod-download-request", () => {
+  it("queues a VOD download request", async () => {
+    const res = await POST(makePost({ vod_id: "vod-001", requester_id: "viewer-A" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(202);
+    expect(data.status).toBe("queued");
+    expect(typeof data.request_id).toBe("string");
+  });
+
+  it("returns 400 when vod_id is missing", async () => {
+    const res = await POST(makePost({ requester_id: "viewer-A" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when requester_id is missing", async () => {
+    const res = await POST(makePost({ vod_id: "vod-001" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/routes-f/vod-download-request", {
+      method: "POST",
+      body: "bad",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it("returns 409 when a pending request already exists for same viewer+vod", async () => {
+    const vod_id = "vod-dedup";
+    const requester_id = "viewer-dedup";
+
+    const first = await POST(makePost({ vod_id, requester_id }));
+    expect(first.status).toBe(202);
+
+    const second = await POST(makePost({ vod_id, requester_id }));
+    const secondData = await second.json();
+
+    expect(second.status).toBe(409);
+    expect(secondData).toHaveProperty("request_id");
+  });
+
+  it("allows a new request for same vod from a different viewer", async () => {
+    const vod_id = "vod-multi";
+    const res1 = await POST(makePost({ vod_id, requester_id: "viewer-P" }));
+    const res2 = await POST(makePost({ vod_id, requester_id: "viewer-Q" }));
+
+    expect(res1.status).toBe(202);
+    expect(res2.status).toBe(202);
+
+    const d1 = await res1.json();
+    const d2 = await res2.json();
+    expect(d1.request_id).not.toBe(d2.request_id);
+  });
+
+  it("allows a new request for same viewer for a different vod", async () => {
+    const requester_id = "viewer-R";
+    const res1 = await POST(makePost({ vod_id: "vod-R1", requester_id }));
+    const res2 = await POST(makePost({ vod_id: "vod-R2", requester_id }));
+
+    expect(res1.status).toBe(202);
+    expect(res2.status).toBe(202);
+  });
+});
+
+describe("GET /api/routes-f/vod-download-request", () => {
+  it("returns queued status immediately after POST", async () => {
+    const postRes = await POST(makePost({ vod_id: "vod-get-test", requester_id: "viewer-B" }));
+    const { request_id } = await postRes.json();
+
+    const getRes = await GET(makeGet({ request_id }));
+    const data = await getRes.json();
+
+    expect(getRes.status).toBe(200);
+    expect(data.request_id).toBe(request_id);
+    expect(data.status).toBe("queued");
+    expect(data.download_url).toBeUndefined();
+  });
+
+  it("returns 400 when request_id is missing", async () => {
+    const res = await GET(makeGet({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for unknown request_id", async () => {
+    const res = await GET(makeGet({ request_id: "vdl-unknown" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns ready status and download_url after auto-complete delay", async () => {
+    const postRes = await POST(makePost({ vod_id: "vod-ready-test", requester_id: "viewer-C" }));
+    const { request_id } = await postRes.json();
+
+    await new Promise((r) => setTimeout(r, 8100));
+
+    const getRes = await GET(makeGet({ request_id }));
+    const data = await getRes.json();
+
+    expect(data.status).toBe("ready");
+    expect(typeof data.download_url).toBe("string");
+    expect(data.download_url).toContain("vod-ready-test");
+  }, 15000);
+
+  it("status progression: queued then ready", async () => {
+    const postRes = await POST(makePost({ vod_id: "vod-progress", requester_id: "viewer-D" }));
+    const { request_id } = await postRes.json();
+
+    const early = await (await GET(makeGet({ request_id }))).json();
+    expect(early.status).toBe("queued");
+  });
+});

--- a/app/api/routes-f/vod-download-request/route.ts
+++ b/app/api/routes-f/vod-download-request/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type RequestStatus = "queued" | "ready" | "failed";
+
+type VodDownloadRequest = {
+  request_id: string;
+  vod_id: string;
+  requester_id: string;
+  status: RequestStatus;
+  queued_at: number;
+  download_url?: string;
+};
+
+type PostBody = {
+  vod_id: string;
+  requester_id: string;
+};
+
+const AUTO_COMPLETE_MS = 8_000;
+
+const requests = new Map<string, VodDownloadRequest>();
+const pendingByViewer = new Map<string, string>();
+
+let counter = 0;
+
+function generateRequestId(): string {
+  counter += 1;
+  return `vdl-${Date.now()}-${counter}`;
+}
+
+function pendingKey(requesterId: string, vodId: string): string {
+  return `${requesterId}::${vodId}`;
+}
+
+function mockDownloadUrl(vodId: string): string {
+  return `https://cdn.streamfi.io/vods/${vodId}/download.mp4?token=mock`;
+}
+
+function resolveStatus(req: VodDownloadRequest): VodDownloadRequest {
+  if (req.status === "queued" && Date.now() - req.queued_at >= AUTO_COMPLETE_MS) {
+    const resolved = { ...req, status: "ready" as RequestStatus, download_url: mockDownloadUrl(req.vod_id) };
+    pendingByViewer.delete(pendingKey(req.requester_id, req.vod_id));
+    return resolved;
+  }
+  return req;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { vod_id, requester_id } = (body ?? {}) as PostBody;
+
+  if (!vod_id || typeof vod_id !== "string") {
+    return NextResponse.json({ error: "vod_id is required" }, { status: 400 });
+  }
+  if (!requester_id || typeof requester_id !== "string") {
+    return NextResponse.json({ error: "requester_id is required" }, { status: 400 });
+  }
+
+  const key = pendingKey(requester_id, vod_id);
+  const existingId = pendingByViewer.get(key);
+  if (existingId) {
+    const existing = requests.get(existingId);
+    if (existing) {
+      const resolved = resolveStatus(existing);
+      requests.set(existingId, resolved);
+      if (resolved.status === "queued") {
+        return NextResponse.json(
+          { error: "A pending download request already exists", request_id: existingId },
+          { status: 409 }
+        );
+      }
+    }
+  }
+
+  const request_id = generateRequestId();
+  const entry: VodDownloadRequest = {
+    request_id,
+    vod_id,
+    requester_id,
+    status: "queued",
+    queued_at: Date.now(),
+  };
+  requests.set(request_id, entry);
+  pendingByViewer.set(key, request_id);
+
+  return NextResponse.json({ request_id, status: "queued" }, { status: 202 });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const request_id = searchParams.get("request_id");
+
+  if (!request_id) {
+    return NextResponse.json({ error: "request_id query param is required" }, { status: 400 });
+  }
+
+  const entry = requests.get(request_id);
+  if (!entry) {
+    return NextResponse.json({ error: "Request not found" }, { status: 404 });
+  }
+
+  const resolved = resolveStatus(entry);
+  requests.set(request_id, resolved);
+
+  const response: { request_id: string; status: RequestStatus; download_url?: string } = {
+    request_id: resolved.request_id,
+    status: resolved.status,
+  };
+  if (resolved.download_url) {
+    response.download_url = resolved.download_url;
+  }
+
+  return NextResponse.json(response);
+}

--- a/app/api/routesF/fresh-streams/route.test.ts
+++ b/app/api/routesF/fresh-streams/route.test.ts
@@ -1,0 +1,116 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/fresh-streams");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("Fresh Streams API", () => {
+  it("returns streams with required fields", async () => {
+    const res = await GET(makeReq());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(data.streams)).toBe(true);
+    expect(typeof data.total).toBe("number");
+    expect(typeof data.max_age_minutes).toBe("number");
+    expect(data.streams.length).toBe(data.total);
+  });
+
+  it("each stream has all required fields", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "60" }));
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(stream).toHaveProperty("stream_id");
+      expect(stream).toHaveProperty("creator_id");
+      expect(stream).toHaveProperty("creator_username");
+      expect(stream).toHaveProperty("title");
+      expect(stream).toHaveProperty("category");
+      expect(stream).toHaveProperty("viewer_count");
+      expect(stream).toHaveProperty("age_minutes");
+      expect(stream).toHaveProperty("started_at");
+    }
+  });
+
+  it("default max_age_minutes of 30 filters streams older than 30 min", async () => {
+    const res = await GET(makeReq());
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(stream.age_minutes).toBeLessThanOrEqual(30);
+    }
+    expect(data.max_age_minutes).toBe(30);
+  });
+
+  it("streams older than max_age_minutes are excluded", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "10" }));
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(stream.age_minutes).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("shorter window returns fewer streams than longer window", async () => {
+    const res5 = await GET(makeReq({ max_age_minutes: "5" }));
+    const res60 = await GET(makeReq({ max_age_minutes: "60" }));
+
+    const data5 = await res5.json();
+    const data60 = await res60.json();
+
+    expect(data5.total).toBeLessThanOrEqual(data60.total);
+  });
+
+  it("respects limit parameter", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "60", limit: "3" }));
+    const data = await res.json();
+
+    expect(data.streams.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns max_age_minutes matching the requested value", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "15" }));
+    const data = await res.json();
+
+    expect(data.max_age_minutes).toBe(15);
+  });
+
+  it("started_at is a valid ISO date string", async () => {
+    const res = await GET(makeReq());
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(() => new Date(stream.started_at).toISOString()).not.toThrow();
+    }
+  });
+
+  it("age_minutes values are non-negative integers", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "60" }));
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(stream.age_minutes).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(stream.age_minutes)).toBe(true);
+    }
+  });
+
+  it("returns empty list when max_age_minutes is 0 (clamps to default 30)", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "0" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.max_age_minutes).toBe(30);
+  });
+
+  it("viewer_count is non-negative for all streams", async () => {
+    const res = await GET(makeReq({ max_age_minutes: "60" }));
+    const data = await res.json();
+
+    for (const stream of data.streams) {
+      expect(stream.viewer_count).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/app/api/routesF/fresh-streams/route.ts
+++ b/app/api/routesF/fresh-streams/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type FreshStream = {
+  stream_id: string;
+  creator_id: string;
+  creator_username: string;
+  title: string;
+  category: string;
+  viewer_count: number;
+  age_minutes: number;
+  started_at: string;
+};
+
+type FreshStreamsResponse = {
+  streams: FreshStream[];
+  total: number;
+  max_age_minutes: number;
+};
+
+const querySchema = z.object({
+  max_age_minutes: z.string().optional().default("30").transform((val) => {
+    const num = parseInt(val, 10);
+    return isNaN(num) || num <= 0 ? 30 : Math.min(num, 60);
+  }),
+  limit: z.string().optional().default("20").transform((val) => {
+    const num = parseInt(val, 10);
+    return isNaN(num) || num <= 0 ? 20 : Math.min(num, 100);
+  }),
+});
+
+const STREAM_POOL: Array<Omit<FreshStream, "started_at">> = [
+  { stream_id: "s001", creator_id: "c001", creator_username: "PixelNinja", title: "Late Night Grind Session", category: "gaming", viewer_count: 42, age_minutes: 2 },
+  { stream_id: "s002", creator_id: "c002", creator_username: "StellarBeats", title: "Lo-Fi Coding Stream", category: "music", viewer_count: 118, age_minutes: 5 },
+  { stream_id: "s003", creator_id: "c003", creator_username: "CryptoTalk", title: "XLM Analysis Live", category: "finance", viewer_count: 230, age_minutes: 8 },
+  { stream_id: "s004", creator_id: "c004", creator_username: "ArtFlows", title: "Character Design — Ep 12", category: "art", viewer_count: 67, age_minutes: 12 },
+  { stream_id: "s005", creator_id: "c005", creator_username: "SpeedRunner", title: "Any% Attempt #88", category: "gaming", viewer_count: 504, age_minutes: 15 },
+  { stream_id: "s006", creator_id: "c006", creator_username: "DevStream", title: "Building a REST API from scratch", category: "tech", viewer_count: 89, age_minutes: 18 },
+  { stream_id: "s007", creator_id: "c007", creator_username: "ChefOnAir", title: "Sunday Pasta Night", category: "cooking", viewer_count: 155, age_minutes: 22 },
+  { stream_id: "s008", creator_id: "c008", creator_username: "FitWithKemi", title: "Morning HIIT — Day 5", category: "fitness", viewer_count: 73, age_minutes: 25 },
+  { stream_id: "s009", creator_id: "c009", creator_username: "NightOwl", title: "Chatting about nothing", category: "just-chatting", viewer_count: 310, age_minutes: 28 },
+  { stream_id: "s010", creator_id: "c010", creator_username: "QuizMaster", title: "Trivia Friday!", category: "games", viewer_count: 198, age_minutes: 35 },
+  { stream_id: "s011", creator_id: "c011", creator_username: "TechTutor", title: "React hooks deep dive", category: "tech", viewer_count: 61, age_minutes: 45 },
+  { stream_id: "s012", creator_id: "c012", creator_username: "BookNerd", title: "Reading Dune aloud", category: "education", viewer_count: 44, age_minutes: 55 },
+];
+
+const REFERENCE_TIME = new Date("2024-07-01T12:00:00Z");
+
+function toStartedAt(ageMinutes: number): string {
+  const d = new Date(REFERENCE_TIME.getTime() - ageMinutes * 60_000);
+  return d.toISOString();
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse<FreshStreamsResponse | { error: string }>> {
+  const { searchParams } = new URL(req.url);
+
+  const validation = querySchema.safeParse({
+    max_age_minutes: searchParams.get("max_age_minutes"),
+    limit: searchParams.get("limit"),
+  });
+
+  if (!validation.success) {
+    return NextResponse.json({ error: "Invalid query parameters" }, { status: 400 });
+  }
+
+  const { max_age_minutes, limit } = validation.data;
+
+  const streams = STREAM_POOL
+    .filter((s) => s.age_minutes <= max_age_minutes)
+    .slice(0, limit)
+    .map(({ age_minutes, ...s }) => ({
+      ...s,
+      age_minutes,
+      started_at: toStartedAt(age_minutes),
+    }));
+
+  return NextResponse.json({ streams, total: streams.length, max_age_minutes });
+}

--- a/app/api/routesF/vod-creator-annotations/route.test.ts
+++ b/app/api/routesF/vod-creator-annotations/route.test.ts
@@ -1,0 +1,164 @@
+import { NextRequest } from "next/server";
+import { POST, GET, DELETE } from "./route";
+
+function makePost(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/vod-creator-annotations", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeGet(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/routesF/vod-creator-annotations");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+function makeDelete(body: unknown) {
+  return new NextRequest("http://localhost/api/routesF/vod-creator-annotations", {
+    method: "DELETE",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("VOD Creator Annotations API", () => {
+  describe("POST", () => {
+    it("creates an annotation and returns annotation_id", async () => {
+      const res = await POST(makePost({ vod_id: "vod-1", time_seconds: 120, text: "Epic moment!" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(typeof data.annotation_id).toBe("string");
+      expect(data.annotation_id.length).toBeGreaterThan(0);
+    });
+
+    it("returns 400 when vod_id is missing", async () => {
+      const res = await POST(makePost({ time_seconds: 30, text: "hello" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when time_seconds is missing", async () => {
+      const res = await POST(makePost({ vod_id: "vod-1", text: "hello" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when text is empty", async () => {
+      const res = await POST(makePost({ vod_id: "vod-1", time_seconds: 10, text: "" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for negative time_seconds", async () => {
+      const res = await POST(makePost({ vod_id: "vod-1", time_seconds: -5, text: "oops" }));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new NextRequest("http://localhost/api/routesF/vod-creator-annotations", {
+        method: "POST",
+        body: "bad",
+        headers: { "Content-Type": "application/json" },
+      });
+      expect((await POST(req)).status).toBe(400);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns annotations for a vod sorted by time_seconds", async () => {
+      const vodId = "vod-sort-test";
+      await POST(makePost({ vod_id: vodId, time_seconds: 300, text: "Third" }));
+      await POST(makePost({ vod_id: vodId, time_seconds: 10, text: "First" }));
+      await POST(makePost({ vod_id: vodId, time_seconds: 150, text: "Second" }));
+
+      const res = await GET(makeGet({ vod_id: vodId }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.vod_id).toBe(vodId);
+      expect(data.annotations.length).toBeGreaterThanOrEqual(3);
+
+      const times = data.annotations.map((a: { time_seconds: number }) => a.time_seconds);
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i]).toBeGreaterThanOrEqual(times[i - 1]);
+      }
+    });
+
+    it("returns empty list for vod with no annotations", async () => {
+      const res = await GET(makeGet({ vod_id: "vod-empty-999" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.annotations).toHaveLength(0);
+      expect(data.total).toBe(0);
+    });
+
+    it("returns 400 when vod_id is missing", async () => {
+      const res = await GET(makeGet({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("each annotation has required fields", async () => {
+      const vodId = "vod-fields";
+      await POST(makePost({ vod_id: vodId, time_seconds: 60, text: "Check fields" }));
+
+      const res = await GET(makeGet({ vod_id: vodId }));
+      const { annotations } = await res.json();
+
+      for (const ann of annotations) {
+        expect(ann).toHaveProperty("annotation_id");
+        expect(ann).toHaveProperty("vod_id");
+        expect(ann).toHaveProperty("time_seconds");
+        expect(ann).toHaveProperty("text");
+        expect(ann).toHaveProperty("created_at");
+      }
+    });
+  });
+
+  describe("DELETE", () => {
+    it("deletes an annotation by annotation_id", async () => {
+      const postRes = await POST(makePost({ vod_id: "vod-del", time_seconds: 45, text: "Delete me" }));
+      const { annotation_id } = await postRes.json();
+
+      const delRes = await DELETE(makeDelete({ annotation_id }));
+      const delData = await delRes.json();
+
+      expect(delRes.status).toBe(200);
+      expect(delData.deleted).toBe(true);
+      expect(delData.annotation_id).toBe(annotation_id);
+    });
+
+    it("deleted annotation no longer appears in GET", async () => {
+      const vodId = "vod-del-verify";
+      const postRes = await POST(makePost({ vod_id: vodId, time_seconds: 90, text: "Going away" }));
+      const { annotation_id } = await postRes.json();
+
+      await DELETE(makeDelete({ annotation_id }));
+
+      const getRes = await GET(makeGet({ vod_id: vodId }));
+      const { annotations } = await getRes.json();
+
+      const found = annotations.find((a: { annotation_id: string }) => a.annotation_id === annotation_id);
+      expect(found).toBeUndefined();
+    });
+
+    it("returns 404 for non-existent annotation_id", async () => {
+      const res = await DELETE(makeDelete({ annotation_id: "ann-does-not-exist" }));
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when annotation_id is missing", async () => {
+      const res = await DELETE(makeDelete({}));
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid JSON", async () => {
+      const req = new NextRequest("http://localhost/api/routesF/vod-creator-annotations", {
+        method: "DELETE",
+        body: "bad",
+        headers: { "Content-Type": "application/json" },
+      });
+      expect((await DELETE(req)).status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/vod-creator-annotations/route.ts
+++ b/app/api/routesF/vod-creator-annotations/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type Annotation = {
+  annotation_id: string;
+  vod_id: string;
+  time_seconds: number;
+  text: string;
+  created_at: string;
+};
+
+const postSchema = z.object({
+  vod_id: z.string().min(1, "vod_id is required"),
+  time_seconds: z.number().int().min(0, "time_seconds must be a non-negative integer"),
+  text: z.string().min(1, "text is required").max(500, "text must be 500 characters or less"),
+});
+
+const deleteSchema = z.object({
+  annotation_id: z.string().min(1, "annotation_id is required"),
+});
+
+const store = new Map<string, Annotation>();
+let counter = 0;
+
+function generateAnnotationId(): string {
+  counter += 1;
+  return `ann-${Date.now()}-${counter}`;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = postSchema.safeParse(body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { vod_id, time_seconds, text } = validation.data;
+  const annotation_id = generateAnnotationId();
+
+  const annotation: Annotation = {
+    annotation_id,
+    vod_id,
+    time_seconds,
+    text,
+    created_at: new Date().toISOString(),
+  };
+
+  store.set(annotation_id, annotation);
+
+  return NextResponse.json({ annotation_id }, { status: 201 });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const vod_id = searchParams.get("vod_id");
+
+  if (!vod_id) {
+    return NextResponse.json({ error: "vod_id query param is required" }, { status: 400 });
+  }
+
+  const annotations = Array.from(store.values())
+    .filter((a) => a.vod_id === vod_id)
+    .sort((a, b) => a.time_seconds - b.time_seconds);
+
+  return NextResponse.json({ vod_id, annotations, total: annotations.length });
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = deleteSchema.safeParse(body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: validation.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { annotation_id } = validation.data;
+
+  if (!store.has(annotation_id)) {
+    return NextResponse.json({ error: "Annotation not found" }, { status: 404 });
+  }
+
+  store.delete(annotation_id);
+
+  return NextResponse.json({ deleted: true, annotation_id });
+}


### PR DESCRIPTION
## Summary

Adds four new API routes across `app/api/routes-f/` and `app/api/routesF/`. All implementations are fully self-contained with no imports from `lib/`, `utils/`, `types/`, or `components/`. Each route ships with a dedicated test file.

closes #1223
closes #1229
closes #1232
closes #1238

## Changes

- **#1223 — clip-download-request** (`app/api/routes-f/clip-download-request/`): Stateful POST + GET endpoint for requesting a downloadable clip. `POST { clip_id, requester_id, format?: "mp4" | "gif" }` returns `{ request_id, status: "queued" }` with HTTP 202. `GET ?request_id` polls the status. Requests auto-complete to `"ready"` after 5 seconds of synthetic delay, at which point `download_url` is included in the response. Each request gets a unique `request_id`; the module-level Map persists state between calls in the same process.

- **#1229 — vod-download-request** (`app/api/routes-f/vod-download-request/`): POST + GET for full VOD download requests. `POST { vod_id, requester_id }` → `{ request_id, status: "queued" }` (HTTP 202). Enforces **one pending request per (requester_id, vod_id)** pair: a second POST while one is still queued returns HTTP 409 with the existing `request_id`. Once a request auto-completes to `"ready"` (after 8s), the dedup key is cleared and a new request may be created. `GET ?request_id` returns current status and `download_url` when ready.

- **#1232 — vod-creator-annotations** (`app/api/routesF/vod-creator-annotations/`): Full CRUD for creator annotations on VODs. `POST { vod_id, time_seconds, text }` → `{ annotation_id }` (HTTP 201). `GET ?vod_id` returns all annotations for that VOD sorted ascending by `time_seconds`. `DELETE { annotation_id }` removes an annotation and returns `{ deleted: true, annotation_id }`. Validates with zod; returns 404 on missing annotation, 400 on bad input.

- **#1238 — fresh-streams** (`app/api/routesF/fresh-streams/`): `GET ?max_age_minutes=30&limit=20` returns live streams that started within the specified age window. Ships with a seeded pool of 12 streams with explicit `age_minutes` values (ranging 2–55 min), making the cutoff filter deterministic in tests. Each stream includes `stream_id`, `creator_username`, `title`, `category`, `viewer_count`, `age_minutes`, and `started_at` (computed from a fixed reference time). `max_age_minutes` clamps to 60; `limit` clamps to 100.

## Test plan

- **clip-download-request**: POST happy path (mp4/gif/default), validation errors, dedup of `request_id`, GET lifecycle (queued immediately, ready after 5s delay), 404 for unknown id.
- **vod-download-request**: POST happy path, 409 dedup for same viewer+vod, independent requests for different viewers/vods, GET lifecycle, 404 for unknown id.
- **vod-creator-annotations**: POST/GET/DELETE CRUD cycle, sort-by-time assertion, deleted annotation absent from subsequent GET, 404 delete, field presence checks.
- **fresh-streams**: default/custom `max_age_minutes` cutoff, shorter window ≤ longer window count, `limit` respected, field presence, `started_at` ISO validity, `age_minutes` non-negative integers.
- Not built locally; relying on CI for TypeScript compilation and test runs.