### PR TITLE
feat(routesF): viewer suspicion score, batch moderation, mod shift schedule, notification opt-in wizard

### DIFF
--- a/app/api/routes-f/featured-stream/mock-data.ts
+++ b/app/api/routes-f/featured-stream/mock-data.ts
@@ -5,7 +5,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_101",
     creator_username: "gaming_guru",
-    creator_display_name: "Alex "The Guru" Chen",
+    creator_display_name: "Alex \"The Guru\" Chen",
     stream_id: "stream_101_001",
     stream_title: "VALORANT Tournament Finals - Live Commentary",
     reason: "Top performer in this week's competitive gaming circuit",
@@ -41,7 +41,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_104",
     creator_username: "art_streamer",
-    creator_display_name: "Jamie "Sketch" Patel",
+    creator_display_name: "Jamie \"Sketch\" Patel",
     stream_id: "stream_104_001",
     stream_title: "Digital Portrait Painting - From Sketch to Final",
     reason: "Stunning visual art with interactive viewer suggestions",
@@ -65,7 +65,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_106",
     creator_username: "cooking_with_joy",
-    creator_display_name: "Joy "SpiceMaster" Zhang",
+    creator_display_name: "Joy \"SpiceMaster\" Zhang",
     stream_id: "stream_106_001",
     stream_title: "Authentic Thai Curry - Step by Step Cooking",
     reason: "Exceptional culinary content with detailed explanations",
@@ -77,7 +77,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_107",
     creator_username: "travel_vlogs",
-    creator_display_name: "Emma "Wanderlust" Thompson",
+    creator_display_name: "Emma \"Wanderlust\" Thompson",
     stream_id: "stream_107_001",
     stream_title: "Virtual Tour of Tokyo's Hidden Gems",
     reason: "Immersive travel experience with live Q&A",
@@ -101,7 +101,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_109",
     creator_username: "comedy_central",
-    creator_display_name: "Mike "Laughs" Johnson",
+    creator_display_name: "Mike \"Laughs\" Johnson",
     stream_id: "stream_109_001",
     stream_title: "Improv Comedy Hour - Audience Suggestions Welcome",
     reason: "Hilarious entertainment with high viewer interaction",
@@ -113,7 +113,7 @@ export const mockCreators: FeaturedStream[] = [
   {
     creator_id: "creator_110",
     creator_username: "book_club_live",
-    creator_display_name: "Claire "Reader" Bennett",
+    creator_display_name: "Claire \"Reader\" Bennett",
     stream_id: "stream_110_001",
     stream_title: "Book Club Discussion - Sci-Fi Classics Edition",
     reason: "Intellectual discussion with active community participation",

--- a/app/api/routesF/batch-moderation-action/route.test.ts
+++ b/app/api/routesF/batch-moderation-action/route.test.ts
@@ -1,0 +1,75 @@
+import { POST } from './route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/batch-moderation-action', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Batch Moderation Action API', () => {
+  it('should return 400 when creator_id is missing', async () => {
+    const res = await POST(makeRequest({ action: 'ban', viewer_ids: ['v1'] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for an invalid action', async () => {
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'mute', viewer_ids: ['v1'] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when viewer_ids is empty', async () => {
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'ban', viewer_ids: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when viewer_ids exceeds the 100 cap', async () => {
+    const viewer_ids = Array.from({ length: 101 }, (_, i) => `v${i}`);
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'ban', viewer_ids }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should accept exactly 100 viewer_ids', async () => {
+    const viewer_ids = Array.from({ length: 100 }, (_, i) => `v${i}`);
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'ban', viewer_ids }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.applied_count).toBe(100);
+  });
+
+  it('should apply a ban batch without requiring duration_seconds', async () => {
+    const res = await POST(
+      makeRequest({ creator_id: 'c1', action: 'ban', viewer_ids: ['v1', 'v2', 'v3'], reason: 'spam' })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.applied_count).toBe(3);
+  });
+
+  it('should require duration_seconds for a timeout action', async () => {
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'timeout', viewer_ids: ['v1'] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should apply a timeout batch when duration_seconds is provided', async () => {
+    const res = await POST(
+      makeRequest({ creator_id: 'c1', action: 'timeout', viewer_ids: ['v1', 'v2'], duration_seconds: 600 })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.applied_count).toBe(2);
+  });
+
+  it('should dedupe repeated viewer_ids in applied_count', async () => {
+    const res = await POST(makeRequest({ creator_id: 'c1', action: 'ban', viewer_ids: ['v1', 'v1', 'v2'] }));
+    const data = await res.json();
+    expect(data.applied_count).toBe(2);
+  });
+
+  it('should reject a non-positive duration_seconds for timeout', async () => {
+    const res = await POST(
+      makeRequest({ creator_id: 'c1', action: 'timeout', viewer_ids: ['v1'], duration_seconds: 0 })
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/routesF/batch-moderation-action/route.ts
+++ b/app/api/routesF/batch-moderation-action/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+
+const MAX_VIEWERS_PER_CALL = 100;
+const VALID_ACTIONS = ['ban', 'timeout'] as const;
+type ModerationAction = (typeof VALID_ACTIONS)[number];
+
+interface BatchModerationBody {
+  creator_id?: unknown;
+  action?: unknown;
+  viewer_ids?: unknown;
+  reason?: unknown;
+  duration_seconds?: unknown;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body: BatchModerationBody = await request.json().catch(() => null);
+
+    if (!body || typeof body.creator_id !== 'string' || body.creator_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid creator_id' }, { status: 400 });
+    }
+
+    if (typeof body.action !== 'string' || !VALID_ACTIONS.includes(body.action as ModerationAction)) {
+      return NextResponse.json({ error: 'action must be one of: ban, timeout' }, { status: 400 });
+    }
+
+    if (
+      !Array.isArray(body.viewer_ids) ||
+      body.viewer_ids.length === 0 ||
+      !body.viewer_ids.every((id) => typeof id === 'string' && id.trim().length > 0)
+    ) {
+      return NextResponse.json({ error: 'viewer_ids must be a non-empty array of strings' }, { status: 400 });
+    }
+
+    if (body.viewer_ids.length > MAX_VIEWERS_PER_CALL) {
+      return NextResponse.json(
+        { error: `viewer_ids exceeds max of ${MAX_VIEWERS_PER_CALL} per call` },
+        { status: 400 }
+      );
+    }
+
+    const action = body.action as ModerationAction;
+
+    if (action === 'timeout') {
+      if (typeof body.duration_seconds !== 'number' || body.duration_seconds <= 0) {
+        return NextResponse.json(
+          { error: 'duration_seconds must be a positive number for timeout action' },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (body.reason !== undefined && typeof body.reason !== 'string') {
+      return NextResponse.json({ error: 'reason must be a string' }, { status: 400 });
+    }
+
+    const uniqueViewerIds = Array.from(new Set(body.viewer_ids as string[]));
+
+    return NextResponse.json({ applied_count: uniqueViewerIds.length });
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/mod-shift-schedule/route.test.ts
+++ b/app/api/routesF/mod-shift-schedule/route.test.ts
@@ -1,0 +1,122 @@
+import { GET, POST } from './route';
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/mod-shift-schedule', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function getRequest(query: string) {
+  return new Request(`http://localhost/api/routesF/mod-shift-schedule?${query}`);
+}
+
+describe('Mod Shift Schedule API', () => {
+  describe('POST', () => {
+    it('should return 400 when creator_id is missing', async () => {
+      const res = await POST(postRequest({ mod_id: 'm1', day: 'monday', start_time: '09:00', end_time: '10:00' }));
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for an invalid day', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'c1', mod_id: 'm1', day: 'someday', start_time: '09:00', end_time: '10:00' })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for a malformed time', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'c1', mod_id: 'm1', day: 'monday', start_time: '9am', end_time: '10:00' })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when start_time equals end_time', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'c1', mod_id: 'm1', day: 'monday', start_time: '09:00', end_time: '09:00' })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('should create a shift and return a shift_id', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'creator_002', mod_id: 'mod_new', day: 'friday', start_time: '10:00', end_time: '18:00' })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data.shift_id).toBeDefined();
+    });
+
+    it('should reject an overlapping shift for the same mod on the same day', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'creator_001', mod_id: 'mod_alice', day: 'monday', start_time: '10:00', end_time: '11:00' })
+      );
+      expect(res.status).toBe(409);
+    });
+
+    it('should allow a non-overlapping shift for the same mod on the same day', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'creator_001', mod_id: 'mod_alice', day: 'monday', start_time: '18:00', end_time: '20:00' })
+      );
+      expect(res.status).toBe(201);
+    });
+
+    it('should allow overlapping shifts for different mods', async () => {
+      const res = await POST(
+        postRequest({ creator_id: 'creator_001', mod_id: 'mod_dave', day: 'monday', start_time: '10:00', end_time: '11:00' })
+      );
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('GET on-duty computation', () => {
+    it('should return the mod on duty mid-shift on monday', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=2023-01-02T12:00:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).toContain('mod_alice');
+    });
+
+    it('should exclude a mod before their shift starts', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=2023-01-02T08:00:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).not.toContain('mod_alice');
+    });
+
+    it('should keep a cross-midnight shift active late on its start day', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=2023-01-02T23:30:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).toContain('mod_bob');
+    });
+
+    it('should keep a cross-midnight shift active into the early hours of the next day', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=2023-01-03T02:00:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).toContain('mod_bob');
+      expect(data.on_duty_mods).not.toContain('mod_carol');
+    });
+
+    it('should hand off from a cross-midnight shift to the next mod at the boundary', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=2023-01-03T07:00:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).toContain('mod_carol');
+      expect(data.on_duty_mods).not.toContain('mod_bob');
+    });
+
+    it('should return 400 when creator_id is missing', async () => {
+      const res = await GET(getRequest('at=2023-01-02T12:00:00.000Z'));
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for an invalid at parameter', async () => {
+      const res = await GET(getRequest('creator_id=creator_001&at=not-a-date'));
+      expect(res.status).toBe(400);
+    });
+
+    it('should return an empty list for a creator with no shifts', async () => {
+      const res = await GET(getRequest('creator_id=creator_unknown&at=2023-01-02T12:00:00.000Z'));
+      const data = await res.json();
+      expect(data.on_duty_mods).toEqual([]);
+    });
+  });
+});

--- a/app/api/routesF/mod-shift-schedule/route.ts
+++ b/app/api/routesF/mod-shift-schedule/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { ModShift, seedShifts } from './seed-data';
+import { dayAndMinutesFromDate, isOnDutyAt, isValidDay, isValidTime, shiftsOverlap } from './shift-utils';
+
+const shifts: ModShift[] = [...seedShifts];
+let nextShiftSeq = 1;
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body.creator_id !== 'string' || body.creator_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid creator_id' }, { status: 400 });
+    }
+
+    if (typeof body.mod_id !== 'string' || body.mod_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid mod_id' }, { status: 400 });
+    }
+
+    if (!isValidDay(body.day)) {
+      return NextResponse.json({ error: 'Invalid day' }, { status: 400 });
+    }
+
+    if (!isValidTime(body.start_time) || !isValidTime(body.end_time)) {
+      return NextResponse.json({ error: 'start_time and end_time must be HH:MM' }, { status: 400 });
+    }
+
+    if (body.start_time === body.end_time) {
+      return NextResponse.json({ error: 'start_time and end_time must differ' }, { status: 400 });
+    }
+
+    const candidate = {
+      day: body.day,
+      start_time: body.start_time,
+      end_time: body.end_time,
+    };
+
+    const conflict = shifts.some(
+      (existing) => existing.mod_id === body.mod_id && shiftsOverlap(existing, candidate)
+    );
+
+    if (conflict) {
+      return NextResponse.json(
+        { error: 'This shift overlaps with an existing shift for the same mod' },
+        { status: 409 }
+      );
+    }
+
+    const shift_id = `shift_${nextShiftSeq++}`;
+    shifts.push({
+      shift_id,
+      creator_id: body.creator_id,
+      mod_id: body.mod_id,
+      day: body.day,
+      start_time: body.start_time,
+      end_time: body.end_time,
+    });
+
+    return NextResponse.json({ shift_id }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const creatorId = searchParams.get('creator_id');
+    const at = searchParams.get('at');
+
+    if (!creatorId || creatorId.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid creator_id parameter' }, { status: 400 });
+    }
+
+    let atDate = new Date();
+    if (at) {
+      const parsed = new Date(at);
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json({ error: 'Invalid at parameter' }, { status: 400 });
+      }
+      atDate = parsed;
+    }
+
+    const { day, minutesOfDay } = dayAndMinutesFromDate(atDate);
+
+    const onDutyMods = Array.from(
+      new Set(
+        shifts
+          .filter((shift) => shift.creator_id === creatorId && isOnDutyAt(shift, day, minutesOfDay))
+          .map((shift) => shift.mod_id)
+      )
+    );
+
+    return NextResponse.json({ on_duty_mods: onDutyMods });
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/mod-shift-schedule/seed-data.ts
+++ b/app/api/routesF/mod-shift-schedule/seed-data.ts
@@ -1,0 +1,47 @@
+export interface ModShift {
+  shift_id: string;
+  creator_id: string;
+  mod_id: string;
+  day: DayOfWeek;
+  start_time: string;
+  end_time: string;
+}
+
+export const DAYS_OF_WEEK = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+] as const;
+
+export type DayOfWeek = (typeof DAYS_OF_WEEK)[number];
+
+export const seedShifts: ModShift[] = [
+  {
+    shift_id: 'shift_seed_001',
+    creator_id: 'creator_001',
+    mod_id: 'mod_alice',
+    day: 'monday',
+    start_time: '09:00',
+    end_time: '17:00',
+  },
+  {
+    shift_id: 'shift_seed_002',
+    creator_id: 'creator_001',
+    mod_id: 'mod_bob',
+    day: 'monday',
+    start_time: '22:00',
+    end_time: '06:00',
+  },
+  {
+    shift_id: 'shift_seed_003',
+    creator_id: 'creator_001',
+    mod_id: 'mod_carol',
+    day: 'tuesday',
+    start_time: '06:00',
+    end_time: '14:00',
+  },
+];

--- a/app/api/routesF/mod-shift-schedule/shift-utils.ts
+++ b/app/api/routesF/mod-shift-schedule/shift-utils.ts
@@ -1,0 +1,73 @@
+import { DAYS_OF_WEEK, DayOfWeek, ModShift } from './seed-data';
+
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+export function isValidDay(day: unknown): day is DayOfWeek {
+  return typeof day === 'string' && (DAYS_OF_WEEK as readonly string[]).includes(day);
+}
+
+export function isValidTime(time: unknown): time is string {
+  return typeof time === 'string' && TIME_RE.test(time);
+}
+
+export function toMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function crossesMidnight(shift: Pick<ModShift, 'start_time' | 'end_time'>): boolean {
+  return toMinutes(shift.start_time) >= toMinutes(shift.end_time);
+}
+
+export function shiftsOverlap(a: Pick<ModShift, 'day' | 'start_time' | 'end_time'>, b: Pick<ModShift, 'day' | 'start_time' | 'end_time'>): boolean {
+  const dayIndexA = DAYS_OF_WEEK.indexOf(a.day);
+  const dayIndexB = DAYS_OF_WEEK.indexOf(b.day);
+  const sameDay = dayIndexA === dayIndexB;
+  const bIsNextDay = (dayIndexA + 1) % 7 === dayIndexB;
+  const aIsNextDay = (dayIndexB + 1) % 7 === dayIndexA;
+
+  if (!sameDay && !bIsNextDay && !aIsNextDay) return false;
+
+  const aStart = toMinutes(a.start_time);
+  const aEnd = crossesMidnight(a) ? toMinutes(a.end_time) + 1440 : toMinutes(a.end_time);
+  let bStart = toMinutes(b.start_time);
+  let bEnd = crossesMidnight(b) ? toMinutes(b.end_time) + 1440 : toMinutes(b.end_time);
+
+  if (bIsNextDay) {
+    bStart += 1440;
+    bEnd += 1440;
+  } else if (aIsNextDay) {
+    bStart -= 1440;
+    bEnd -= 1440;
+  }
+
+  return aStart < bEnd && bStart < aEnd;
+}
+
+export function isOnDutyAt(shift: ModShift, day: DayOfWeek, minutesOfDay: number): boolean {
+  const start = toMinutes(shift.start_time);
+  const end = toMinutes(shift.end_time);
+  const wraps = start >= end;
+
+  if (shift.day === day) {
+    if (!wraps) {
+      return minutesOfDay >= start && minutesOfDay < end;
+    }
+    return minutesOfDay >= start;
+  }
+
+  const dayIndex = DAYS_OF_WEEK.indexOf(day);
+  const previousDay = DAYS_OF_WEEK[(dayIndex + 6) % 7];
+  if (wraps && shift.day === previousDay) {
+    return minutesOfDay < end;
+  }
+
+  return false;
+}
+
+export function dayAndMinutesFromDate(date: Date): { day: DayOfWeek; minutesOfDay: number } {
+  return {
+    day: DAYS_OF_WEEK[date.getUTCDay()],
+    minutesOfDay: date.getUTCHours() * 60 + date.getUTCMinutes(),
+  };
+}

--- a/app/api/routesF/notification-optin-wizard/advance/route.test.ts
+++ b/app/api/routesF/notification-optin-wizard/advance/route.test.ts
@@ -1,0 +1,72 @@
+import { POST } from './route';
+
+function postRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/notification-optin-wizard/advance', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Notification Opt-in Wizard advance', () => {
+  it('should return 400 when viewer_id is missing', async () => {
+    const res = await POST(postRequest({ step: 'channels' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when step is missing', async () => {
+    const res = await POST(postRequest({ viewer_id: 'viewer_a' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should reject advancing with the wrong step', async () => {
+    const res = await POST(postRequest({ viewer_id: 'viewer_b', step: 'frequency' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('should walk a viewer through the full wizard to completion', async () => {
+    const viewer_id = 'viewer_c';
+
+    const step1 = await POST(postRequest({ viewer_id, step: 'channels', choice: 'push' }));
+    const data1 = await step1.json();
+    expect(data1.step).toBe('frequency');
+    expect(data1.choices.channels).toBe('push');
+    expect(data1.completed).toBe(false);
+
+    const step2 = await POST(postRequest({ viewer_id, step: 'frequency', choice: 'daily' }));
+    const data2 = await step2.json();
+    expect(data2.step).toBe('categories');
+
+    const step3 = await POST(postRequest({ viewer_id, step: 'categories', choice: 'sports' }));
+    const data3 = await step3.json();
+    expect(data3.step).toBe('review');
+
+    const step4 = await POST(postRequest({ viewer_id, step: 'review', choice: 'confirm' }));
+    const data4 = await step4.json();
+    expect(data4.step).toBeNull();
+    expect(data4.completed).toBe(true);
+    expect(data4.choices).toEqual({
+      channels: 'push',
+      frequency: 'daily',
+      categories: 'sports',
+      review: 'confirm',
+    });
+  });
+
+  it('should reject advancing an already completed wizard', async () => {
+    const viewer_id = 'viewer_d';
+    await POST(postRequest({ viewer_id, step: 'channels' }));
+    await POST(postRequest({ viewer_id, step: 'frequency' }));
+    await POST(postRequest({ viewer_id, step: 'categories' }));
+    await POST(postRequest({ viewer_id, step: 'review' }));
+
+    const res = await POST(postRequest({ viewer_id, step: 'channels' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('should allow advancing a step without providing a choice', async () => {
+    const res = await POST(postRequest({ viewer_id: 'viewer_e', step: 'channels' }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.choices.channels).toBeUndefined();
+  });
+});

--- a/app/api/routesF/notification-optin-wizard/advance/route.ts
+++ b/app/api/routesF/notification-optin-wizard/advance/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { advanceWizard } from '../wizard-state';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body.viewer_id !== 'string' || body.viewer_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid viewer_id' }, { status: 400 });
+    }
+
+    if (typeof body.step !== 'string' || body.step.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid step' }, { status: 400 });
+    }
+
+    if (body.choice !== undefined && typeof body.choice !== 'string') {
+      return NextResponse.json({ error: 'choice must be a string' }, { status: 400 });
+    }
+
+    const { state, error } = advanceWizard(body.viewer_id, body.step, body.choice);
+
+    if (error) {
+      return NextResponse.json({ error }, { status: 409 });
+    }
+
+    return NextResponse.json(state);
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/notification-optin-wizard/reset/route.test.ts
+++ b/app/api/routesF/notification-optin-wizard/reset/route.test.ts
@@ -1,0 +1,50 @@
+import { POST as advancePOST } from '../advance/route';
+import { POST as resetPOST } from './route';
+
+function advanceRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/notification-optin-wizard/advance', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function resetRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/notification-optin-wizard/reset', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Notification Opt-in Wizard reset', () => {
+  it('should return 400 when viewer_id is missing', async () => {
+    const res = await resetPOST(resetRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('should restart a wizard that had progressed partway through', async () => {
+    const viewer_id = 'viewer_reset_1';
+    await advancePOST(advanceRequest({ viewer_id, step: 'channels', choice: 'email' }));
+    await advancePOST(advanceRequest({ viewer_id, step: 'frequency', choice: 'weekly' }));
+
+    const res = await resetPOST(resetRequest({ viewer_id }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ step: 'channels', choices: {}, completed: false });
+  });
+
+  it('should restart a fully completed wizard', async () => {
+    const viewer_id = 'viewer_reset_2';
+    await advancePOST(advanceRequest({ viewer_id, step: 'channels' }));
+    await advancePOST(advanceRequest({ viewer_id, step: 'frequency' }));
+    await advancePOST(advanceRequest({ viewer_id, step: 'categories' }));
+    await advancePOST(advanceRequest({ viewer_id, step: 'review' }));
+
+    const res = await resetPOST(resetRequest({ viewer_id }));
+    const data = await res.json();
+    expect(data.completed).toBe(false);
+    expect(data.step).toBe('channels');
+
+    const advanceAgain = await advancePOST(advanceRequest({ viewer_id, step: 'channels', choice: 'sms' }));
+    expect(advanceAgain.status).toBe(200);
+  });
+});

--- a/app/api/routesF/notification-optin-wizard/reset/route.ts
+++ b/app/api/routesF/notification-optin-wizard/reset/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { resetWizard } from '../wizard-state';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body.viewer_id !== 'string' || body.viewer_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid viewer_id' }, { status: 400 });
+    }
+
+    const state = resetWizard(body.viewer_id);
+
+    return NextResponse.json(state);
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/notification-optin-wizard/route.test.ts
+++ b/app/api/routesF/notification-optin-wizard/route.test.ts
@@ -1,0 +1,19 @@
+import { GET } from './route';
+
+function getRequest(query: string) {
+  return new Request(`http://localhost/api/routesF/notification-optin-wizard?${query}`);
+}
+
+describe('Notification Opt-in Wizard GET', () => {
+  it('should return 400 when viewer_id is missing', async () => {
+    const res = await GET(getRequest(''));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return the initial state for a fresh viewer', async () => {
+    const res = await GET(getRequest('viewer_id=viewer_fresh_1'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ step: 'channels', choices: {}, completed: false });
+  });
+});

--- a/app/api/routesF/notification-optin-wizard/route.ts
+++ b/app/api/routesF/notification-optin-wizard/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { getWizardState } from './wizard-state';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const viewerId = searchParams.get('viewer_id');
+
+    if (!viewerId || viewerId.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid viewer_id parameter' }, { status: 400 });
+    }
+
+    const state = getWizardState(viewerId);
+
+    return NextResponse.json(state);
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/notification-optin-wizard/wizard-state.ts
+++ b/app/api/routesF/notification-optin-wizard/wizard-state.ts
@@ -1,0 +1,60 @@
+export const WIZARD_STEPS = ['channels', 'frequency', 'categories', 'review'] as const;
+export type WizardStep = (typeof WIZARD_STEPS)[number];
+
+export interface WizardState {
+  step: WizardStep | null;
+  choices: Record<string, string>;
+  completed: boolean;
+}
+
+function initialState(): WizardState {
+  return { step: WIZARD_STEPS[0], choices: {}, completed: false };
+}
+
+const wizardStates = new Map<string, WizardState>();
+
+export function getWizardState(viewerId: string): WizardState {
+  const existing = wizardStates.get(viewerId);
+  if (existing) return existing;
+  return initialState();
+}
+
+export function advanceWizard(
+  viewerId: string,
+  step: string,
+  choice: string | undefined
+): { state: WizardState; error?: string } {
+  const current = getWizardState(viewerId);
+
+  if (current.completed || current.step === null) {
+    return { state: current, error: 'Wizard already completed' };
+  }
+
+  if (step !== current.step) {
+    return { state: current, error: `Expected step "${current.step}" but received "${step}"` };
+  }
+
+  const choices = { ...current.choices };
+  if (choice !== undefined) {
+    choices[step] = choice;
+  }
+
+  const currentIndex = WIZARD_STEPS.indexOf(current.step);
+  const nextIndex = currentIndex + 1;
+  const isLastStep = nextIndex >= WIZARD_STEPS.length;
+
+  const next: WizardState = {
+    step: isLastStep ? null : WIZARD_STEPS[nextIndex],
+    choices,
+    completed: isLastStep,
+  };
+
+  wizardStates.set(viewerId, next);
+  return { state: next };
+}
+
+export function resetWizard(viewerId: string): WizardState {
+  const fresh = initialState();
+  wizardStates.set(viewerId, fresh);
+  return fresh;
+}

--- a/app/api/routesF/viewer-suspicion-score/route.test.ts
+++ b/app/api/routesF/viewer-suspicion-score/route.test.ts
@@ -1,0 +1,78 @@
+import { POST } from './route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/routesF/viewer-suspicion-score', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Viewer Suspicion Score API', () => {
+  it('should return 400 when viewer_id is missing', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when viewer_id is empty string', async () => {
+    const res = await POST(makeRequest({ viewer_id: '   ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 404 for unknown viewer_id', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'does_not_exist' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('should return low score with no factors for a clean long-standing viewer', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'viewer_001' }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.score).toBe(0);
+    expect(data.factors).toEqual([]);
+  });
+
+  it('should flag a brand new silent account', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'viewer_002' }));
+    const data = await res.json();
+    expect(data.factors).toContain('new_account');
+    expect(data.factors).toContain('silent_new_viewer');
+    expect(data.score).toBeGreaterThan(0);
+  });
+
+  it('should return a high score for a viewer with many negative signals', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'viewer_003' }));
+    const data = await res.json();
+    expect(data.factors).toEqual(
+      expect.arrayContaining([
+        'new_account',
+        'reported_by_viewers',
+        'excessive_caps',
+        'link_spam',
+        'repetitive_messages',
+      ])
+    );
+    expect(data.score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('should cap score at 100', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'viewer_003' }));
+    const data = await res.json();
+    expect(data.score).toBeLessThanOrEqual(100);
+  });
+
+  it('should flag prior ban history independently of account age', async () => {
+    const res = await POST(makeRequest({ viewer_id: 'viewer_005' }));
+    const data = await res.json();
+    expect(data.factors).toContain('prior_ban_history');
+    expect(data.factors).not.toContain('new_account');
+  });
+
+  it('should keep score within 0-100 bounds for all seeded viewers', async () => {
+    for (const id of ['viewer_001', 'viewer_002', 'viewer_003', 'viewer_004', 'viewer_005']) {
+      const res = await POST(makeRequest({ viewer_id: id }));
+      const data = await res.json();
+      expect(data.score).toBeGreaterThanOrEqual(0);
+      expect(data.score).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/app/api/routesF/viewer-suspicion-score/route.ts
+++ b/app/api/routesF/viewer-suspicion-score/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { viewerSignals, ViewerSignals } from './seed-data';
+
+interface ScoreFactor {
+  factor: string;
+  points: number;
+}
+
+function computeSuspicionScore(signals: ViewerSignals): { score: number; factors: string[] } {
+  const hits: ScoreFactor[] = [];
+
+  if (signals.account_age_days < 3) {
+    hits.push({ factor: 'new_account', points: 30 });
+  } else if (signals.account_age_days < 7) {
+    hits.push({ factor: 'recent_account', points: 15 });
+  }
+
+  if (signals.reports_count > 0) {
+    hits.push({ factor: 'reported_by_viewers', points: Math.min(signals.reports_count * 8, 40) });
+  }
+
+  if (signals.caps_ratio > 0.7) {
+    hits.push({ factor: 'excessive_caps', points: 10 });
+  }
+
+  if (signals.link_spam_count > 0) {
+    hits.push({ factor: 'link_spam', points: 15 });
+  }
+
+  if (signals.duplicate_message_ratio > 0.5) {
+    hits.push({ factor: 'repetitive_messages', points: 10 });
+  }
+
+  if (signals.chat_messages_count === 0 && signals.account_age_days <= 1) {
+    hits.push({ factor: 'silent_new_viewer', points: 10 });
+  }
+
+  if (signals.prior_ban) {
+    hits.push({ factor: 'prior_ban_history', points: 25 });
+  }
+
+  const total = hits.reduce((sum, h) => sum + h.points, 0);
+  const score = Math.max(0, Math.min(100, total));
+
+  return { score, factors: hits.map((h) => h.factor) };
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body.viewer_id !== 'string' || body.viewer_id.trim().length === 0) {
+      return NextResponse.json({ error: 'Missing or invalid viewer_id' }, { status: 400 });
+    }
+
+    const signals = viewerSignals[body.viewer_id];
+
+    if (!signals) {
+      return NextResponse.json({ error: 'Viewer not found' }, { status: 404 });
+    }
+
+    const { score, factors } = computeSuspicionScore(signals);
+
+    return NextResponse.json({ score, factors });
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/routesF/viewer-suspicion-score/seed-data.ts
+++ b/app/api/routesF/viewer-suspicion-score/seed-data.ts
@@ -1,0 +1,63 @@
+export interface ViewerSignals {
+  viewer_id: string;
+  account_age_days: number;
+  chat_messages_count: number;
+  caps_ratio: number;
+  link_spam_count: number;
+  duplicate_message_ratio: number;
+  reports_count: number;
+  prior_ban: boolean;
+}
+
+export const viewerSignals: Record<string, ViewerSignals> = {
+  viewer_001: {
+    viewer_id: 'viewer_001',
+    account_age_days: 900,
+    chat_messages_count: 4200,
+    caps_ratio: 0.05,
+    link_spam_count: 0,
+    duplicate_message_ratio: 0.02,
+    reports_count: 0,
+    prior_ban: false,
+  },
+  viewer_002: {
+    viewer_id: 'viewer_002',
+    account_age_days: 1,
+    chat_messages_count: 0,
+    caps_ratio: 0,
+    link_spam_count: 0,
+    duplicate_message_ratio: 0,
+    reports_count: 0,
+    prior_ban: false,
+  },
+  viewer_003: {
+    viewer_id: 'viewer_003',
+    account_age_days: 2,
+    chat_messages_count: 40,
+    caps_ratio: 0.85,
+    link_spam_count: 6,
+    duplicate_message_ratio: 0.7,
+    reports_count: 5,
+    prior_ban: false,
+  },
+  viewer_004: {
+    viewer_id: 'viewer_004',
+    account_age_days: 365,
+    chat_messages_count: 800,
+    caps_ratio: 0.1,
+    link_spam_count: 0,
+    duplicate_message_ratio: 0.05,
+    reports_count: 2,
+    prior_ban: false,
+  },
+  viewer_005: {
+    viewer_id: 'viewer_005',
+    account_age_days: 40,
+    chat_messages_count: 150,
+    caps_ratio: 0.3,
+    link_spam_count: 1,
+    duplicate_message_ratio: 0.15,
+    reports_count: 1,
+    prior_ban: true,
+  },
+};


### PR DESCRIPTION
## Summary
- `viewer-suspicion-score`: POST endpoint computing a 0-100 suspicion score from account age, chat behavior, and report signals
- `batch-moderation-action`: POST endpoint applying ban/timeout to up to 100 viewers in one call
- `mod-shift-schedule`: POST to schedule mod shifts (with overlap rejection) and GET to compute on-duty mods, including cross-midnight shifts
- `notification-optin-wizard`: GET for wizard state, POST /advance and POST /reset for a viewer's notification opt-in onboarding flow

All files scoped to `app/api/routesF/`, each feature self-contained per the task's independence constraint.

Also includes an unrelated 1-line fix (`routes-f/featured-stream/mock-data.ts`) for unescaped quotes that broke `tsc --noEmit`/`npm run build` repo-wide on `dev` — needed to get the pre-commit hook passing for this PR.

Closes #1290, Closes #1291, Closes #1293, Closes #1316

## Test plan
- [x] `npx jest` on all 4 new folders — 46/46 passing
- [x] `tsc --noEmit` clean for the 4 new folders