### PR TITLE
feat(routesF): add creator safety score, mod cert quiz, api quota, st…

### DIFF
--- a/app/api/routesF/api-quota/__tests__/quota.test.ts
+++ b/app/api/routesF/api-quota/__tests__/quota.test.ts
@@ -1,0 +1,80 @@
+import { buildQuotaResponse, ApiKeyUsage, getUsageByApiKey } from '../quotaData';
+
+describe('buildQuotaResponse', () => {
+  it('returns remaining = quota - calls when under quota', () => {
+    const usage: ApiKeyUsage = {
+      apiKey: 'sk-test-1',
+      owner: 'test',
+      hourlyQuota: 1000,
+      callsLastHour: 234,
+      lastResetAt: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    };
+
+    const result = buildQuotaResponse(usage);
+
+    expect(result.calls_last_hour).toBe(234);
+    expect(result.hourly_quota).toBe(1000);
+    expect(result.remaining).toBe(766);
+    expect(result.reset_at).toBeDefined();
+  });
+
+  it('returns remaining = 0 when at quota', () => {
+    const usage: ApiKeyUsage = {
+      apiKey: 'sk-test-2',
+      owner: 'test',
+      hourlyQuota: 200,
+      callsLastHour: 200,
+      lastResetAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    };
+
+    const result = buildQuotaResponse(usage);
+
+    expect(result.remaining).toBe(0);
+  });
+
+  it('returns remaining = 0 when over quota', () => {
+    const usage: ApiKeyUsage = {
+      apiKey: 'sk-test-3',
+      owner: 'test',
+      hourlyQuota: 100,
+      callsLastHour: 150,
+      lastResetAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    };
+
+    const result = buildQuotaResponse(usage);
+
+    expect(result.remaining).toBe(0);
+  });
+
+  it('reset_at is 1 hour after lastResetAt', () => {
+    const baseTime = new Date('2026-07-26T00:00:00Z');
+    const usage: ApiKeyUsage = {
+      apiKey: 'sk-test-4',
+      owner: 'test',
+      hourlyQuota: 500,
+      callsLastHour: 50,
+      lastResetAt: baseTime.toISOString(),
+    };
+
+    const result = buildQuotaResponse(usage);
+
+    const expectedReset = new Date(baseTime.getTime() + 60 * 60 * 1000).toISOString();
+    expect(result.reset_at).toBe(expectedReset);
+  });
+});
+
+describe('getUsageByApiKey', () => {
+  it('returns usage for a valid key', () => {
+    const result = getUsageByApiKey('sk-live-a1b2c3d4');
+
+    expect(result).not.toBeNull();
+    expect(result!.owner).toBe('streamer-1');
+    expect(result!.hourlyQuota).toBe(1000);
+  });
+
+  it('returns null for an invalid key', () => {
+    const result = getUsageByApiKey('sk-invalid-key');
+
+    expect(result).toBeNull();
+  });
+});

--- a/app/api/routesF/api-quota/quotaData.ts
+++ b/app/api/routesF/api-quota/quotaData.ts
@@ -1,0 +1,64 @@
+export interface ApiKeyUsage {
+  apiKey: string;
+  owner: string;
+  hourlyQuota: number;
+  callsLastHour: number;
+  lastResetAt: string;
+}
+
+const HOURLY_WINDOW_MS = 60 * 60 * 1000;
+
+const seedUsage: Record<string, ApiKeyUsage> = {
+  'sk-live-a1b2c3d4': {
+    apiKey: 'sk-live-a1b2c3d4',
+    owner: 'streamer-1',
+    hourlyQuota: 1000,
+    callsLastHour: 234,
+    lastResetAt: new Date(Date.now() - 15 * 60 * 1000).toISOString(), // 15 min ago
+  },
+  'sk-live-e5f6g7h8': {
+    apiKey: 'sk-live-e5f6g7h8',
+    owner: 'streamer-2',
+    hourlyQuota: 500,
+    callsLastHour: 498,
+    lastResetAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(), // 45 min ago
+  },
+  'sk-live-i9j0k1l2': {
+    apiKey: 'sk-live-i9j0k1l2',
+    owner: 'streamer-3',
+    hourlyQuota: 200,
+    callsLastHour: 200,
+    lastResetAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+  },
+  'sk-live-m3n4o5p6': {
+    apiKey: 'sk-live-m3n4o5p6',
+    owner: 'streamer-4',
+    hourlyQuota: 1000,
+    callsLastHour: 50,
+    lastResetAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  },
+};
+
+export function getUsageByApiKey(apiKey: string): ApiKeyUsage | null {
+  return seedUsage[apiKey] ?? null;
+}
+
+export interface QuotaResponse {
+  calls_last_hour: number;
+  hourly_quota: number;
+  remaining: number;
+  reset_at: string;
+}
+
+export function buildQuotaResponse(usage: ApiKeyUsage): QuotaResponse {
+  const resetAt = new Date(
+    new Date(usage.lastResetAt).getTime() + HOURLY_WINDOW_MS,
+  ).toISOString();
+
+  return {
+    calls_last_hour: usage.callsLastHour,
+    hourly_quota: usage.hourlyQuota,
+    remaining: Math.max(0, usage.hourlyQuota - usage.callsLastHour),
+    reset_at: resetAt,
+  };
+}

--- a/app/api/routesF/api-quota/route.ts
+++ b/app/api/routesF/api-quota/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUsageByApiKey, buildQuotaResponse } from './quotaData';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const apiKey = searchParams.get('api_key');
+
+  if (!apiKey) {
+    return NextResponse.json({ error: 'api_key is required' }, { status: 400 });
+  }
+
+  const usage = getUsageByApiKey(apiKey);
+
+  if (!usage) {
+    return NextResponse.json({ error: 'Invalid API key' }, { status: 404 });
+  }
+
+  const response = buildQuotaResponse(usage);
+
+  return NextResponse.json(response);
+}

--- a/app/api/routesF/creator-safety/__tests__/safetyScore.test.ts
+++ b/app/api/routesF/creator-safety/__tests__/safetyScore.test.ts
@@ -1,0 +1,84 @@
+import { calculateSafetyScore } from '../calculateSafetyScore';
+import { SafetyReport, ModAction, CreatorActivity } from '../safetyData';
+
+describe('calculateSafetyScore', () => {
+  it('returns 100 for a creator with no reports, no mod actions, and good activity', () => {
+    const reports: SafetyReport[] = [];
+    const modActions: ModAction[] = [];
+    const activity: CreatorActivity = { totalStreams: 200, avgViewers: 500, reportsResolved: 0, reportsTotal: 0 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    expect(result.score).toBeGreaterThanOrEqual(90);
+    expect(result.factors.length).toBe(4);
+  });
+
+  it('returns lower score for a creator with high-severity reports', () => {
+    const reports: SafetyReport[] = [
+      { id: 'r1', creatorId: 'c1', reason: 'Hate speech', severity: 'high', createdAt: '2026-07-01T00:00:00Z' },
+      { id: 'r2', creatorId: 'c1', reason: 'Harassment', severity: 'high', createdAt: '2026-07-02T00:00:00Z' },
+    ];
+    const modActions: ModAction[] = [];
+    const activity: CreatorActivity = { totalStreams: 100, avgViewers: 200, reportsResolved: 0, reportsTotal: 2 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    expect(result.score).toBeLessThan(70);
+  });
+
+  it('applies a ban penalty to the score', () => {
+    const reports: SafetyReport[] = [];
+    const modActions: ModAction[] = [
+      { id: 'm1', creatorId: 'c1', type: 'ban', createdAt: '2026-07-01T00:00:00Z' },
+    ];
+    const activity: CreatorActivity = { totalStreams: 50, avgViewers: 100, reportsResolved: 0, reportsTotal: 0 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    expect(result.score).toBeLessThan(100);
+    expect(result.score).toBeLessThanOrEqual(88);
+  });
+
+  it('gives high score to a clean creator with lots of streams', () => {
+    const reports: SafetyReport[] = [];
+    const modActions: ModAction[] = [];
+    const activity: CreatorActivity = { totalStreams: 500, avgViewers: 1000, reportsResolved: 0, reportsTotal: 0 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    expect(result.score).toBeGreaterThanOrEqual(95);
+  });
+
+  it('factors include all four expected names', () => {
+    const reports: SafetyReport[] = [];
+    const modActions: ModAction[] = [];
+    const activity: CreatorActivity = { totalStreams: 50, avgViewers: 100, reportsResolved: 0, reportsTotal: 0 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    const names = result.factors.map((f) => f.name);
+    expect(names).toContain('report_history');
+    expect(names).toContain('mod_action_history');
+    expect(names).toContain('resolution_ratio');
+    expect(names).toContain('activity_bonus');
+  });
+
+  it('handles extreme negatives: severe reports and bans reduce score significantly', () => {
+    const reports: SafetyReport[] = [
+      { id: 'r1', creatorId: 'c1', reason: 'Hate speech', severity: 'high', createdAt: '2026-07-01T00:00:00Z' },
+      { id: 'r2', creatorId: 'c1', reason: 'Harassment', severity: 'high', createdAt: '2026-07-02T00:00:00Z' },
+      { id: 'r3', creatorId: 'c1', reason: 'Violence', severity: 'high', createdAt: '2026-07-03T00:00:00Z' },
+      { id: 'r4', creatorId: 'c1', reason: 'Spam', severity: 'high', createdAt: '2026-07-04T00:00:00Z' },
+      { id: 'r5', creatorId: 'c1', reason: 'Scam', severity: 'high', createdAt: '2026-07-05T00:00:00Z' },
+    ];
+    const modActions: ModAction[] = [
+      { id: 'm1', creatorId: 'c1', type: 'ban', createdAt: '2026-07-06T00:00:00Z' },
+      { id: 'm2', creatorId: 'c1', type: 'timeout', createdAt: '2026-07-07T00:00:00Z' },
+    ];
+    const activity: CreatorActivity = { totalStreams: 5, avgViewers: 10, reportsResolved: 0, reportsTotal: 5 };
+
+    const result = calculateSafetyScore(reports, modActions, activity);
+
+    expect(result.score).toBeLessThanOrEqual(25);
+  });
+});

--- a/app/api/routesF/creator-safety/calculateSafetyScore.ts
+++ b/app/api/routesF/creator-safety/calculateSafetyScore.ts
@@ -1,0 +1,78 @@
+import {
+  SafetyReport,
+  ModAction,
+  CreatorActivity,
+  SafetyFactor,
+  SafetyScoreResult,
+} from './safetyData';
+
+const SEVERITY_PENALTIES: Record<string, number> = {
+  low: 5,
+  medium: 10,
+  high: 20,
+};
+
+const MOD_ACTION_PENALTIES: Record<string, number> = {
+  ban: 25,
+  warn: 10,
+  timeout: 15,
+  appeal: 5, // appealing a ban slightly reduces penalty impact
+};
+
+/**
+ * Compute a creator's safety score (0–100) and factor breakdown.
+ * Higher score = safer.
+ */
+export function calculateSafetyScore(
+  reports: SafetyReport[],
+  modActions: ModAction[],
+  activity: CreatorActivity,
+): SafetyScoreResult {
+  // --- Factor 1: Report severity penalty (weight: ~40%) ---
+  let reportPenalty = 0;
+  for (const r of reports) {
+    reportPenalty += SEVERITY_PENALTIES[r.severity] ?? 10;
+  }
+  const reportScore = Math.max(0, 100 - reportPenalty);
+
+  // --- Factor 2: Mod action penalty (weight: ~30%) ---
+  let actionPenalty = 0;
+  for (const a of modActions) {
+    actionPenalty += MOD_ACTION_PENALTIES[a.type] ?? 10;
+  }
+  for (const a of modActions) {
+    if (a.type === 'appeal') {
+      // appeal reduces the ban impact by 30%
+      actionPenalty -= MOD_ACTION_PENALTIES.ban * 0.3;
+    }
+  }
+  const actionScore = Math.max(0, 100 - Math.max(0, actionPenalty));
+
+  // --- Factor 3: Resolution ratio (weight: ~20%) ---
+  const resolutionRatio =
+    activity.reportsTotal > 0
+      ? activity.reportsResolved / activity.reportsTotal
+      : 1;
+  const resolutionScore = Math.round(resolutionRatio * 100);
+
+  // --- Factor 4: Activity bonus (weight: ~10%) ---
+  // More streams = more community engagement, small bonus
+  const streamBonus = Math.min(10, Math.floor(activity.totalStreams / 20));
+  const activityScore = Math.min(100, 50 + streamBonus);
+
+  // --- Aggregate: weighted average ---
+  const rawScore =
+    reportScore * 0.4 + actionScore * 0.3 + resolutionScore * 0.2 + activityScore * 0.1;
+
+  const finalScore = Math.max(0, Math.min(100, Math.round(rawScore)));
+
+  // Compute each factor's contribution to the final score
+  const factors: SafetyFactor[] = [
+    { name: 'report_history', contribution: Math.round(reportScore * 0.4) },
+    { name: 'mod_action_history', contribution: Math.round(actionScore * 0.3) },
+    { name: 'resolution_ratio', contribution: Math.round(resolutionScore * 0.2) },
+    { name: 'activity_bonus', contribution: Math.round(activityScore * 0.1) },
+  ];
+
+  return { score: finalScore, factors };
+}

--- a/app/api/routesF/creator-safety/route.ts
+++ b/app/api/routesF/creator-safety/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReportsForCreator, getModActionsForCreator, getActivityForCreator } from './safetyData';
+import { calculateSafetyScore } from './calculateSafetyScore';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const creatorId = searchParams.get('creator_id');
+
+  if (!creatorId) {
+    return NextResponse.json({ error: 'creator_id is required' }, { status: 400 });
+  }
+
+  const reports = getReportsForCreator(creatorId);
+  const modActions = getModActionsForCreator(creatorId);
+  const activity = getActivityForCreator(creatorId);
+
+  const result = calculateSafetyScore(reports, modActions, activity);
+
+  return NextResponse.json(result);
+}

--- a/app/api/routesF/creator-safety/safetyData.ts
+++ b/app/api/routesF/creator-safety/safetyData.ts
@@ -1,0 +1,66 @@
+export interface SafetyReport {
+  id: string;
+  creatorId: string;
+  reason: string;
+  severity: 'low' | 'medium' | 'high';
+  createdAt: string;
+}
+
+export interface ModAction {
+  id: string;
+  creatorId: string;
+  type: 'ban' | 'warn' | 'timeout' | 'appeal';
+  createdAt: string;
+}
+
+export interface CreatorActivity {
+  totalStreams: number;
+  avgViewers: number;
+  reportsResolved: number;
+  reportsTotal: number;
+}
+
+export interface SafetyFactor {
+  name: string;
+  contribution: number;
+}
+
+export interface SafetyScoreResult {
+  score: number;
+  factors: SafetyFactor[];
+}
+
+const seedReports: SafetyReport[] = [
+  { id: 'sr-001', creatorId: 'creator-1', reason: 'Hate speech', severity: 'high', createdAt: '2026-07-01T10:00:00Z' },
+  { id: 'sr-002', creatorId: 'creator-1', reason: 'Spam', severity: 'low', createdAt: '2026-07-05T14:30:00Z' },
+  { id: 'sr-003', creatorId: 'creator-1', reason: 'Harassment', severity: 'medium', createdAt: '2026-07-10T09:15:00Z' },
+  { id: 'sr-004', creatorId: 'creator-2', reason: 'Misleading title', severity: 'low', createdAt: '2026-07-02T11:00:00Z' },
+  { id: 'sr-005', creatorId: 'creator-3', reason: 'Copyright violation', severity: 'high', createdAt: '2026-07-08T16:45:00Z' },
+  { id: 'sr-006', creatorId: 'creator-3', reason: 'Inappropriate content', severity: 'high', createdAt: '2026-07-12T08:30:00Z' },
+];
+
+const seedModActions: ModAction[] = [
+  { id: 'ma-001', creatorId: 'creator-2', type: 'warn', createdAt: '2026-06-15T12:00:00Z' },
+  { id: 'ma-002', creatorId: 'creator-1', type: 'ban', createdAt: '2026-07-11T10:00:00Z' },
+  { id: 'ma-003', creatorId: 'creator-1', type: 'appeal', createdAt: '2026-07-13T10:00:00Z' },
+];
+
+const seedActivities: Record<string, CreatorActivity> = {
+  'creator-1': { totalStreams: 45, avgViewers: 120, reportsResolved: 1, reportsTotal: 3 },
+  'creator-2': { totalStreams: 120, avgViewers: 340, reportsResolved: 1, reportsTotal: 1 },
+  'creator-3': { totalStreams: 10, avgViewers: 25, reportsResolved: 0, reportsTotal: 2 },
+  'creator-4': { totalStreams: 200, avgViewers: 850, reportsResolved: 0, reportsTotal: 0 },
+  'creator-5': { totalStreams: 67, avgViewers: 210, reportsResolved: 2, reportsTotal: 1 },
+};
+
+export function getReportsForCreator(creatorId: string): SafetyReport[] {
+  return seedReports.filter((r) => r.creatorId === creatorId);
+}
+
+export function getModActionsForCreator(creatorId: string): ModAction[] {
+  return seedModActions.filter((a) => a.creatorId === creatorId);
+}
+
+export function getActivityForCreator(creatorId: string): CreatorActivity {
+  return seedActivities[creatorId] ?? { totalStreams: 0, avgViewers: 0, reportsResolved: 0, reportsTotal: 0 };
+}

--- a/app/api/routesF/mod-cert/__tests__/quiz.test.ts
+++ b/app/api/routesF/mod-cert/__tests__/quiz.test.ts
@@ -1,0 +1,62 @@
+import { gradeQuiz, getQuestions } from '../quizData';
+
+describe('gradeQuiz', () => {
+  it('returns passed=true with score >= 80 for all correct answers', () => {
+    const questions = getQuestions();
+    const correctAnswers = questions.map((q) => q.correctIndex);
+
+    const result = gradeQuiz(correctAnswers);
+
+    expect(result.score).toBe(100);
+    expect(result.passed).toBe(true);
+  });
+
+  it('returns passed=true when exactly 80% (4 out of 5 correct)', () => {
+    const questions = getQuestions();
+    // First 4 correct, last one wrong
+    const answers = questions.slice(0, 4).map((q) => q.correctIndex).concat(
+      questions[4].correctIndex === 0 ? 1 : 0,
+    );
+
+    const result = gradeQuiz(answers);
+
+    expect(result.score).toBe(80);
+    expect(result.passed).toBe(true);
+  });
+
+  it('returns passed=false when score is below 80%', () => {
+    // Only 2 out of 5 correct (40%)
+    const answers = [0, 1, 0, 1, 0];
+
+    const result = gradeQuiz(answers);
+
+    expect(result.score).toBeLessThan(80);
+    expect(result.passed).toBe(false);
+  });
+
+  it('returns passed=false for empty answers', () => {
+    const result = gradeQuiz([]);
+
+    expect(result.score).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('returns passed=false when answers length mismatches questions', () => {
+    const result = gradeQuiz([0, 1]);
+
+    expect(result.score).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('getQuestions returns 5 questions with all required fields', () => {
+    const questions = getQuestions();
+
+    expect(questions.length).toBe(5);
+    for (const q of questions) {
+      expect(q.id).toBeDefined();
+      expect(q.text).toBeDefined();
+      expect(q.options.length).toBe(4);
+      expect(q.correctIndex).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/app/api/routesF/mod-cert/quizData.ts
+++ b/app/api/routesF/mod-cert/quizData.ts
@@ -1,0 +1,98 @@
+export interface Question {
+  id: string;
+  text: string;
+  options: string[];
+  correctIndex: number;
+}
+
+export interface QuizSubmission {
+  creator_id: string;
+  mod_id: string;
+  answers: number[];
+}
+
+export interface QuizResult {
+  score: number;
+  passed: boolean;
+  certified_at: string | null;
+}
+
+const seedQuestions: Question[] = [
+  {
+    id: 'q1',
+    text: 'What should you do if you see hate speech in chat?',
+    options: [
+      'Ignore it',
+      'Warn the user and delete the message',
+      'Ban the entire channel',
+      'Join in',
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: 'q2',
+    text: 'How long should you wait before timing out a repeat offender?',
+    options: [
+      'Immediately timeout',
+      'Give 3 warnings first',
+      'Only after the stream ends',
+      'Never timeout',
+    ],
+    correctIndex: 0,
+  },
+  {
+    id: 'q3',
+    text: 'Which content is NOT allowed on StreamFi?',
+    options: [
+      'Gaming streams',
+      'Music production',
+      'Explicit adult content',
+      'Coding tutorials',
+    ],
+    correctIndex: 2,
+  },
+  {
+    id: 'q4',
+    text: 'What is the proper way to handle a DMCA claim?',
+    options: [
+      'Delete the VOD and ignore',
+      'Report to StreamFi support and remove the content',
+      'Ban the reporter',
+      'Continue streaming',
+    ],
+    correctIndex: 1,
+  },
+  {
+    id: 'q5',
+    text: 'Can moderators accept bribes from streamers?',
+    options: [
+      'Yes, if it\'s a small amount',
+      'No, never',
+      'Only if the streamer asks nicely',
+      'Yes, but only in crypto',
+    ],
+    correctIndex: 1,
+  },
+];
+
+export function getQuestions(): Question[] {
+  return seedQuestions;
+}
+
+export function gradeQuiz(answers: number[]): { score: number; passed: boolean } {
+  if (answers.length !== seedQuestions.length) {
+    return { score: 0, passed: false };
+  }
+
+  let correct = 0;
+  for (let i = 0; i < seedQuestions.length; i++) {
+    if (answers[i] === seedQuestions[i].correctIndex) {
+      correct++;
+    }
+  }
+
+  const score = Math.round((correct / seedQuestions.length) * 100);
+  const passed = score >= 80;
+
+  return { score, passed };
+}

--- a/app/api/routesF/mod-cert/route.ts
+++ b/app/api/routesF/mod-cert/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getQuestions, gradeQuiz } from './quizData';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const creatorId = searchParams.get('creator_id');
+
+  if (!creatorId) {
+    return NextResponse.json({ error: 'creator_id is required' }, { status: 400 });
+  }
+
+  const questions = getQuestions();
+  // Return questions without the correct answers
+  const sanitized = questions.map(({ id, text, options }) => ({ id, text, options }));
+
+  return NextResponse.json({ creator_id: creatorId, questions: sanitized });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { creator_id, mod_id, answers } = body;
+
+    if (!creator_id || !mod_id || !Array.isArray(answers)) {
+      return NextResponse.json(
+        { error: 'creator_id, mod_id, and answers array are required' },
+        { status: 400 },
+      );
+    }
+
+    const { score, passed } = gradeQuiz(answers);
+    const certified_at = passed ? new Date().toISOString() : null;
+
+    return NextResponse.json({ score, passed, certified_at });
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/stream-color/__tests__/colorTag.test.ts
+++ b/app/api/routesF/stream-color/__tests__/colorTag.test.ts
@@ -1,0 +1,78 @@
+import { isValidHexColor, getColorTag, setColorTag, deleteColorTag } from '../colorData';
+
+describe('isValidHexColor', () => {
+  it('accepts 6-digit hex with #', () => {
+    expect(isValidHexColor('#FF5733')).toBe(true);
+    expect(isValidHexColor('#aabbcc')).toBe(true);
+    expect(isValidHexColor('#AABBCC')).toBe(true);
+  });
+
+  it('accepts 3-digit hex with #', () => {
+    expect(isValidHexColor('#FFF')).toBe(true);
+    expect(isValidHexColor('#abc')).toBe(true);
+    expect(isValidHexColor('#ABC')).toBe(true);
+  });
+
+  it('rejects hex without #', () => {
+    expect(isValidHexColor('FF5733')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidHexColor('')).toBe(false);
+  });
+
+  it('rejects invalid hex characters', () => {
+    expect(isValidHexColor('#GG5733')).toBe(false);
+    expect(isValidHexColor('#12345')).toBe(false);
+    expect(isValidHexColor('#1234567')).toBe(false);
+  });
+});
+
+describe('setColorTag', () => {
+  it('sets a new color tag and returns it', () => {
+    const tag = setColorTag('test-stream-1', '#FF0000');
+    expect(tag.streamId).toBe('test-stream-1');
+    expect(tag.colorHex).toBe('#FF0000');
+    expect(tag.createdAt).toBeDefined();
+  });
+
+  it('overwrites an existing tag', () => {
+    setColorTag('test-stream-2', '#00FF00');
+    const updated = setColorTag('test-stream-2', '#0000FF');
+    expect(updated.colorHex).toBe('#0000FF');
+  });
+
+  it('makes tag retrievable via getColorTag', () => {
+    setColorTag('test-stream-3', '#FF00FF');
+    const retrieved = getColorTag('test-stream-3');
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.colorHex).toBe('#FF00FF');
+  });
+});
+
+describe('deleteColorTag', () => {
+  it('deletes an existing tag', () => {
+    setColorTag('test-delete-stream', '#123456');
+    const deleted = deleteColorTag('test-delete-stream');
+    expect(deleted).toBe(true);
+    expect(getColorTag('test-delete-stream')).toBeNull();
+  });
+
+  it('returns false for non-existent tag', () => {
+    const deleted = deleteColorTag('non-existent-stream');
+    expect(deleted).toBe(false);
+  });
+});
+
+describe('getColorTag', () => {
+  it('returns null for non-existent stream', () => {
+    const tag = getColorTag('non-existent-stream');
+    expect(tag).toBeNull();
+  });
+
+  it('returns seed tag for stream-1', () => {
+    const tag = getColorTag('stream-1');
+    expect(tag).not.toBeNull();
+    expect(tag!.colorHex).toBe('#FF5733');
+  });
+});

--- a/app/api/routesF/stream-color/colorData.ts
+++ b/app/api/routesF/stream-color/colorData.ts
@@ -1,0 +1,44 @@
+export interface ColorTag {
+  streamId: string;
+  colorHex: string;
+  createdAt: string;
+}
+
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+
+const seedColorTags: Map<string, ColorTag> = new Map([
+  [
+    'stream-1',
+    { streamId: 'stream-1', colorHex: '#FF5733', createdAt: '2026-07-20T10:00:00Z' },
+  ],
+  [
+    'stream-2',
+    { streamId: 'stream-2', colorHex: '#33FF57', createdAt: '2026-07-21T14:30:00Z' },
+  ],
+  [
+    'stream-3',
+    { streamId: 'stream-3', colorHex: '#3357FF', createdAt: '2026-07-22T09:15:00Z' },
+  ],
+]);
+
+export function getColorTag(streamId: string): ColorTag | null {
+  return seedColorTags.get(streamId) ?? null;
+}
+
+export function setColorTag(streamId: string, colorHex: string): ColorTag {
+  const tag: ColorTag = {
+    streamId,
+    colorHex,
+    createdAt: new Date().toISOString(),
+  };
+  seedColorTags.set(streamId, tag);
+  return tag;
+}
+
+export function deleteColorTag(streamId: string): boolean {
+  return seedColorTags.delete(streamId);
+}
+
+export function isValidHexColor(color: string): boolean {
+  return HEX_COLOR_REGEX.test(color);
+}

--- a/app/api/routesF/stream-color/route.ts
+++ b/app/api/routesF/stream-color/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getColorTag, setColorTag, deleteColorTag, isValidHexColor } from './colorData';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const streamId = searchParams.get('stream_id');
+
+  if (!streamId) {
+    return NextResponse.json({ error: 'stream_id is required' }, { status: 400 });
+  }
+
+  const tag = getColorTag(streamId);
+  if (!tag) {
+    return NextResponse.json({ error: 'No color tag found for this stream' }, { status: 404 });
+  }
+
+  return NextResponse.json(tag);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { stream_id, color_hex } = body;
+
+    if (!stream_id || !color_hex) {
+      return NextResponse.json(
+        { error: 'stream_id and color_hex are required' },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidHexColor(color_hex)) {
+      return NextResponse.json(
+        { error: 'Invalid hex color. Must be #RGB or #RRGGBB format' },
+        { status: 400 },
+      );
+    }
+
+    const tag = setColorTag(stream_id, color_hex);
+    return NextResponse.json(tag, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const streamId = searchParams.get('stream_id');
+
+  if (!streamId) {
+    return NextResponse.json({ error: 'stream_id is required' }, { status: 400 });
+  }
+
+  const existed = deleteColorTag(streamId);
+  if (!existed) {
+    return NextResponse.json({ error: 'No color tag found for this stream' }, { status: 404 });
+  }
+
+  return NextResponse.json({ message: 'Color tag cleared', stream_id: streamId });
+}


### PR DESCRIPTION
…ream color tag

closes #1297 - Creator Safety Score
- GET ?creator_id returns { score: 0-100, factors: [{ name, contribution }] }
- Weighted scoring: report_history (40%), mod_action_history (30%), resolution_ratio (20%), activity_bonus (10%)
- Bundle seed safety signals (reports, mod actions, activity)
- Tests verify factor breakdown and scoring

closes #1292 - Mod Certification Quiz
- GET ?creator_id returns questions, POST /submit grades answers
- Passing threshold 80%
- Bundle seed questions (5 questions inside folder)
- Tests cover pass/fail scenarios

closes #1307 - API Usage Quota View
- GET ?api_key returns { calls_last_hour, hourly_quota, remaining, reset_at }
- Bundle seed key -> usage data (4 keys)
- Tests cover under, at, and over quota

closes #1309 - Stream Color Tag
- POST { stream_id, color_hex } sets tag, GET ?stream_id returns, DELETE clears
- Validates hex color (#RGB or #RRGGBB)
- Tests cover set, invalid hex, clear, non-existent

