### PR TITLE
Feature/routes f implementations

### DIFF
--- a/app/api/routesF/autocomplete/data.ts
+++ b/app/api/routesF/autocomplete/data.ts
@@ -1,0 +1,18 @@
+export type SuggestionType = 'creator' | 'category' | 'tag';
+
+export type Suggestion = {
+  type: SuggestionType;
+  label: string;
+  score: number;
+};
+
+export const corpus: Suggestion[] = [
+  { type: 'creator', label: 'CryptoWhale', score: 100 },
+  { type: 'creator', label: 'CrypticGamer', score: 85 },
+  { type: 'category', label: 'Crypto Trading', score: 90 },
+  { type: 'tag', label: 'crypto', score: 95 },
+  { type: 'tag', label: 'bitcoin', score: 80 },
+  { type: 'creator', label: 'BitcoinMaxi', score: 75 },
+  { type: 'category', label: 'Just Chatting', score: 120 },
+  { type: 'tag', label: 'chat', score: 110 }
+];

--- a/app/api/routesF/autocomplete/route.test.ts
+++ b/app/api/routesF/autocomplete/route.test.ts
@@ -1,0 +1,39 @@
+import { GET } from './route';
+
+describe('Autocomplete Route', () => {
+  it('prioritizes prefix matches over substring matches', async () => {
+    // Both 'CryptoWhale' and 'CrypticGamer' and 'Crypto Trading' and 'crypto' start with 'crypt'
+    // 'BitcoinMaxi' doesn't have 'crypt'. Wait, let's search for 'cryp'
+    const req = new Request('http://localhost:3000/api/routesF/autocomplete?q=cryp&limit=5');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(200);
+    expect(data.suggestions.length).toBeGreaterThan(0);
+    // Highest score among prefix matches should be first
+    expect(data.suggestions[0].label).toBe('CryptoWhale'); // score 100
+  });
+
+  it('substring matches come after prefix matches', async () => {
+    // Add a corpus item dynamically or just rely on existing
+    // query: 'chat'
+    // 'Just Chatting' (category) -> substring match
+    // 'chat' (tag) -> prefix match
+    const req = new Request('http://localhost:3000/api/routesF/autocomplete?q=chat&limit=5');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(data.suggestions.length).toBe(2);
+    // 'chat' is a prefix match (starts with 'chat'), so it should be first, even though 'Just Chatting' has higher score
+    expect(data.suggestions[0].label).toBe('chat');
+    expect(data.suggestions[1].label).toBe('Just Chatting');
+  });
+
+  it('respects limit', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/autocomplete?q=c&limit=2');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(data.suggestions.length).toBe(2);
+  });
+});

--- a/app/api/routesF/autocomplete/route.ts
+++ b/app/api/routesF/autocomplete/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { corpus } from './data';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get('q');
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : 8;
+
+  if (!q) {
+    return NextResponse.json({ suggestions: [] });
+  }
+
+  const query = q.toLowerCase();
+
+  const prefixMatches = [];
+  const substringMatches = [];
+
+  for (const item of corpus) {
+    const labelLower = item.label.toLowerCase();
+    if (labelLower.startsWith(query)) {
+      prefixMatches.push(item);
+    } else if (labelLower.includes(query)) {
+      substringMatches.push(item);
+    }
+  }
+
+  prefixMatches.sort((a, b) => b.score - a.score);
+  substringMatches.sort((a, b) => b.score - a.score);
+
+  const suggestions = [...prefixMatches, ...substringMatches].slice(0, limit);
+
+  return NextResponse.json({ suggestions });
+}

--- a/app/api/routesF/follower-chart/data.ts
+++ b/app/api/routesF/follower-chart/data.ts
@@ -1,0 +1,26 @@
+export type FollowEvent = {
+  type: 'follow' | 'unfollow';
+  creator_id: string;
+  timestamp: number;
+};
+
+// Helper to create dates in the past
+const daysAgo = (days: number) => {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  d.setHours(12, 0, 0, 0); // normalize time
+  return d.getTime();
+};
+
+export const seedEvents: FollowEvent[] = [
+  { type: 'follow', creator_id: 'creator_1', timestamp: daysAgo(5) },
+  { type: 'follow', creator_id: 'creator_1', timestamp: daysAgo(5) },
+  { type: 'unfollow', creator_id: 'creator_1', timestamp: daysAgo(5) },
+  
+  { type: 'follow', creator_id: 'creator_1', timestamp: daysAgo(2) },
+  { type: 'follow', creator_id: 'creator_1', timestamp: daysAgo(2) },
+  { type: 'follow', creator_id: 'creator_1', timestamp: daysAgo(2) },
+  
+  { type: 'unfollow', creator_id: 'creator_1', timestamp: daysAgo(1) },
+  { type: 'unfollow', creator_id: 'creator_1', timestamp: daysAgo(1) },
+];

--- a/app/api/routesF/follower-chart/route.test.ts
+++ b/app/api/routesF/follower-chart/route.test.ts
@@ -1,0 +1,42 @@
+import { GET } from './route';
+
+describe('Follower Chart Route', () => {
+  it('returns zero-filled series for given days', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/follower-chart?creator_id=creator_1&days=7');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(200);
+    expect(data.series).toBeDefined();
+    expect(data.series.length).toBe(7); // 7 days of data
+    
+    // Verify zero fill on today (no seed events for exactly today if today's date doesn't match)
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const todayStr = today.toISOString().split('T')[0];
+    
+    const todayEntry = data.series.find((s: any) => s.date === todayStr);
+    expect(todayEntry).toBeDefined();
+    expect(todayEntry.gained).toBe(0);
+    expect(todayEntry.lost).toBe(0);
+    expect(todayEntry.net).toBe(0);
+  });
+
+  it('aggregates events correctly', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/follower-chart?creator_id=creator_1&days=7');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    // Find a day that has seed data (e.g. 2 days ago)
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    twoDaysAgo.setHours(12, 0, 0, 0);
+    const dateStr = twoDaysAgo.toISOString().split('T')[0];
+    
+    const entry = data.series.find((s: any) => s.date === dateStr);
+    expect(entry).toBeDefined();
+    expect(entry.gained).toBe(3); // 3 follow events in seed data
+    expect(entry.lost).toBe(0);
+    expect(entry.net).toBe(3);
+  });
+});

--- a/app/api/routesF/follower-chart/route.ts
+++ b/app/api/routesF/follower-chart/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { seedEvents } from './data';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creator_id = searchParams.get('creator_id');
+  const daysParam = searchParams.get('days');
+  const days = daysParam ? parseInt(daysParam, 10) : 30;
+
+  if (!creator_id) {
+    return NextResponse.json({ error: 'Missing creator_id' }, { status: 400 });
+  }
+
+  const seriesMap = new Map<string, { date: string; gained: number; lost: number; net: number }>();
+  
+  const today = new Date();
+  today.setHours(12, 0, 0, 0);
+
+  // Zero-fill the days
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().split('T')[0];
+    seriesMap.set(dateStr, { date: dateStr, gained: 0, lost: 0, net: 0 });
+  }
+
+  // Aggregate events
+  for (const event of seedEvents) {
+    if (event.creator_id !== creator_id) continue;
+    
+    const d = new Date(event.timestamp);
+    const dateStr = d.toISOString().split('T')[0];
+    
+    if (seriesMap.has(dateStr)) {
+      const entry = seriesMap.get(dateStr)!;
+      if (event.type === 'follow') {
+        entry.gained += 1;
+        entry.net += 1;
+      } else {
+        entry.lost += 1;
+        entry.net -= 1;
+      }
+    }
+  }
+
+  return NextResponse.json({ series: Array.from(seriesMap.values()) });
+}

--- a/app/api/routesF/recent-searches/route.test.ts
+++ b/app/api/routesF/recent-searches/route.test.ts
@@ -1,0 +1,60 @@
+import { GET, POST, DELETE } from './route';
+import { clearHistory } from './store';
+
+describe('Recent Searches Route', () => {
+  afterEach(() => {
+    clearHistory('viewer_1');
+  });
+
+  it('records and returns recent searches, deduping correctly', async () => {
+    // Record 'crypto'
+    let req = new Request('http://localhost:3000/api/routesF/recent-searches', {
+      method: 'POST',
+      body: JSON.stringify({ viewer_id: 'viewer_1', query: 'crypto' })
+    });
+    await POST(req);
+
+    // Record 'gaming'
+    req = new Request('http://localhost:3000/api/routesF/recent-searches', {
+      method: 'POST',
+      body: JSON.stringify({ viewer_id: 'viewer_1', query: 'gaming' })
+    });
+    await POST(req);
+
+    // Record 'crypto' again (should dedup and move to front)
+    req = new Request('http://localhost:3000/api/routesF/recent-searches', {
+      method: 'POST',
+      body: JSON.stringify({ viewer_id: 'viewer_1', query: 'crypto' })
+    });
+    await POST(req);
+
+    // Get recent searches
+    req = new Request('http://localhost:3000/api/routesF/recent-searches?viewer_id=viewer_1&limit=10');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(200);
+    expect(data.searches.length).toBe(2);
+    expect(data.searches[0].query).toBe('crypto'); // Most recent
+    expect(data.searches[1].query).toBe('gaming');
+  });
+
+  it('clears history', async () => {
+    let req = new Request('http://localhost:3000/api/routesF/recent-searches', {
+      method: 'POST',
+      body: JSON.stringify({ viewer_id: 'viewer_1', query: 'crypto' })
+    });
+    await POST(req);
+
+    req = new Request('http://localhost:3000/api/routesF/recent-searches?viewer_id=viewer_1', {
+      method: 'DELETE'
+    });
+    const deleteRes = await DELETE(req);
+    expect(deleteRes.status).toBe(200);
+
+    req = new Request('http://localhost:3000/api/routesF/recent-searches?viewer_id=viewer_1');
+    const getRes = await GET(req);
+    const data = await getRes.json();
+    expect(data.searches.length).toBe(0);
+  });
+});

--- a/app/api/routesF/recent-searches/route.ts
+++ b/app/api/routesF/recent-searches/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { recordSearch, getRecentSearches, clearHistory } from './store';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const viewer_id = searchParams.get('viewer_id');
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : 10;
+
+  if (!viewer_id) {
+    return NextResponse.json({ error: 'Missing viewer_id' }, { status: 400 });
+  }
+
+  const searches = getRecentSearches(viewer_id, limit);
+  return NextResponse.json({ searches });
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { viewer_id, query } = body;
+
+    if (!viewer_id || !query) {
+      return NextResponse.json({ error: 'Missing viewer_id or query' }, { status: 400 });
+    }
+
+    recordSearch(viewer_id, query);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const viewer_id = searchParams.get('viewer_id');
+
+  if (!viewer_id) {
+    return NextResponse.json({ error: 'Missing viewer_id' }, { status: 400 });
+  }
+
+  clearHistory(viewer_id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/routesF/recent-searches/store.ts
+++ b/app/api/routesF/recent-searches/store.ts
@@ -1,0 +1,41 @@
+export type SearchHistory = {
+  viewer_id: string;
+  query: string;
+  timestamp: number;
+};
+
+// In-memory store
+export const searchStore = new Map<string, SearchHistory[]>();
+
+export const MAX_HISTORY_PER_VIEWER = 50;
+
+export function recordSearch(viewer_id: string, query: string) {
+  if (!searchStore.has(viewer_id)) {
+    searchStore.set(viewer_id, []);
+  }
+
+  const history = searchStore.get(viewer_id)!;
+  
+  // Dedup: remove existing if matches query
+  const existingIndex = history.findIndex(h => h.query === query);
+  if (existingIndex !== -1) {
+    history.splice(existingIndex, 1);
+  }
+
+  // Add to front
+  history.unshift({ viewer_id, query, timestamp: Date.now() });
+
+  // Cap at 50
+  if (history.length > MAX_HISTORY_PER_VIEWER) {
+    history.length = MAX_HISTORY_PER_VIEWER; // Truncate
+  }
+}
+
+export function getRecentSearches(viewer_id: string, limit: number = 10) {
+  const history = searchStore.get(viewer_id) || [];
+  return history.slice(0, limit);
+}
+
+export function clearHistory(viewer_id: string) {
+  searchStore.delete(viewer_id);
+}

--- a/app/api/routesF/stream-summary/data.ts
+++ b/app/api/routesF/stream-summary/data.ts
@@ -1,0 +1,20 @@
+export const seedStreams = [
+  {
+    id: 'stream_1',
+    title: 'Late Night Crypto Trading',
+    creator: 'CryptoWhale',
+    duration_minutes: 125,
+    peak_viewers: 4500,
+    top_moment_url: 'https://mux.com/v/crypto_moment1',
+    cta_url: 'https://streamfi.io/cryptowhale'
+  },
+  {
+    id: 'stream_2',
+    title: 'Gaming with followers',
+    creator: 'GamerX',
+    duration_minutes: 240,
+    peak_viewers: 1200,
+    top_moment_url: 'https://mux.com/v/gamerx_moment',
+    cta_url: 'https://streamfi.io/gamerx'
+  }
+];

--- a/app/api/routesF/stream-summary/route.test.ts
+++ b/app/api/routesF/stream-summary/route.test.ts
@@ -1,0 +1,37 @@
+import { GET } from './route';
+
+describe('Stream Summary Route', () => {
+  it('returns stream data for valid stream_id', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/stream-summary?stream_id=stream_1');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(200);
+    expect(data).toMatchObject({
+      title: 'Late Night Crypto Trading',
+      creator: 'CryptoWhale',
+      duration_minutes: 125,
+      peak_viewers: 4500,
+      top_moment_url: 'https://mux.com/v/crypto_moment1',
+      cta_url: 'https://streamfi.io/cryptowhale'
+    });
+  });
+
+  it('returns 400 when stream_id is missing', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/stream-summary');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(400);
+    expect(data.error).toBe('Missing stream_id');
+  });
+
+  it('returns 404 for unknown stream_id', async () => {
+    const req = new Request('http://localhost:3000/api/routesF/stream-summary?stream_id=unknown');
+    const res = await GET(req);
+    const data = await res.json();
+    
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Stream not found');
+  });
+});

--- a/app/api/routesF/stream-summary/route.ts
+++ b/app/api/routesF/stream-summary/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { seedStreams } from './data';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const stream_id = searchParams.get('stream_id');
+
+  if (!stream_id) {
+    return NextResponse.json({ error: 'Missing stream_id' }, { status: 400 });
+  }
+
+  const stream = seedStreams.find(s => s.id === stream_id);
+  
+  if (!stream) {
+    return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(stream);
+}


### PR DESCRIPTION
closes #1324 
closes #1323 
closes #1325 
closes #1326 

## Summary
This PR implements four independent route handlers inside `app/api/routesF/` as part of the StreamFi practice implementations. All code, data, and tests are scoped entirely within their respective subfolders to ensure they remain independent and mergeable.

## Changes

1. **Stream Summary (`app/api/routesF/stream-summary/`)**
   - Implemented `GET` route to return stream stats (title, creator, duration, peak viewers, top moment, CTA).
   - Bundled mock stream data.
   - Added tests verifying route returns correctly assembled data and handles missing/invalid `stream_id`.

2. **Follower Chart (`app/api/routesF/follower-chart/`)**
   - Implemented `GET` route returning daily gained/lost follower net totals.
   - Bundled mock follow/unfollow events.
   - Ensured missing days are zero-filled.
   - Added tests verifying zero-fill behavior and accurate event aggregation totals.

3. **Autocomplete (`app/api/routesF/autocomplete/`)**
   - Implemented `GET` route returning autocomplete suggestions (creator, category, tag).
   - Bundled a static suggestion corpus.
   - Implemented priority matching logic: prefix matches are prioritized over substring matches, sorted internally by score.
   - Added tests covering prefix vs substring priority limit constraints.

4. **Recent Searches (`app/api/routesF/recent-searches/`)**
   - Implemented `POST` to track queries and `GET` to fetch the recent searches.
   - Implemented `DELETE` to clear a specific viewer's history.
   - Used an in-memory store capping at 50 per viewer, deduplicating older searches by moving repeated queries to the front.
   - Added tests covering history storage, history clear, and deduplication logic.
