### PR TITLE
Feature/routes f implementations

### DIFF
--- a/app/api/routesF/keywords/route.test.ts
+++ b/app/api/routesF/keywords/route.test.ts
@@ -1,0 +1,32 @@
+import { extractKeywords, POST } from './route';
+
+describe('Keyword Extraction', () => {
+  it('extracts keywords correctly', () => {
+    const title = 'The BEST and most AMAZING stream for YOU! 123';
+    const keywords = extractKeywords(title);
+    
+    expect(keywords).toContain('best');
+    expect(keywords).toContain('most');
+    expect(keywords).toContain('amazing');
+    expect(keywords).toContain('stream');
+    expect(keywords).toContain('123');
+
+    // Should exclude stop words and short words
+    expect(keywords).not.toContain('the');
+    expect(keywords).not.toContain('and');
+    expect(keywords).not.toContain('for');
+    expect(keywords).not.toContain('you');
+  });
+
+  it('handles POST request', async () => {
+    const request = new Request('http://localhost/api/routesF/keywords', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Hello world stream' })
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.keywords).toEqual(expect.arrayContaining(['hello', 'world', 'stream']));
+  });
+});

--- a/app/api/routesF/keywords/route.ts
+++ b/app/api/routesF/keywords/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+export const stopWords = new Set([
+  'the', 'and', 'for', 'with', 'this', 'that', 'you', 'are', 'not', 'but',
+  'what', 'how', 'when', 'where', 'why', 'who', 'will', 'can', 'has', 'have'
+]);
+
+export function extractKeywords(title: string): string[] {
+  // Lowercase
+  const lower = title.toLowerCase();
+  
+  // Tokenize
+  const tokens = lower.split(/[^a-z0-9]+/);
+  
+  const keywords = new Set<string>();
+  
+  for (const token of tokens) {
+    if (token.length >= 3 && !stopWords.has(token)) {
+      keywords.add(token);
+    }
+  }
+  
+  return Array.from(keywords);
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { title } = body;
+
+    if (typeof title !== 'string') {
+      return NextResponse.json({ error: 'title must be a string' }, { status: 400 });
+    }
+
+    const keywords = extractKeywords(title);
+
+    return NextResponse.json({ keywords });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/app/api/routesF/last-stream/route.test.ts
+++ b/app/api/routesF/last-stream/route.test.ts
@@ -1,0 +1,41 @@
+import { getSeedStreams, isResumable, GET } from './route';
+
+describe('Last Stream State', () => {
+  it('identifies resumable streams correctly', () => {
+    const now = Date.now();
+    const tenMinsAgo = now - 10 * 60 * 1000;
+    expect(isResumable(tenMinsAgo, now)).toBe(true);
+  });
+
+  it('identifies not-resumable streams correctly', () => {
+    const now = Date.now();
+    const twentyMinsAgo = now - 20 * 60 * 1000;
+    expect(isResumable(twentyMinsAgo, now)).toBe(false);
+  });
+
+  it('handles GET request for resumable stream', async () => {
+    const request = new Request('http://localhost/api/routesF/last-stream?creator_id=c1');
+    const response = await GET(request);
+    
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.last_stream.title).toBe('Just chatting');
+    expect(data.resumable).toBe(true);
+  });
+
+  it('handles GET request for not-resumable stream', async () => {
+    const request = new Request('http://localhost/api/routesF/last-stream?creator_id=c2');
+    const response = await GET(request);
+    
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.last_stream.title).toBe('Speedrun practice');
+    expect(data.resumable).toBe(false);
+  });
+
+  it('returns 404 if no previous streams found', async () => {
+    const request = new Request('http://localhost/api/routesF/last-stream?creator_id=unknown');
+    const response = await GET(request);
+    expect(response.status).toBe(404);
+  });
+});

--- a/app/api/routesF/last-stream/route.ts
+++ b/app/api/routesF/last-stream/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+
+export interface Stream {
+  id: string;
+  creator_id: string;
+  title: string;
+  category: string;
+  tags: string[];
+  ended_at: number | null; // null if live
+}
+
+export function getSeedStreams(now: number): Stream[] {
+  return [
+    {
+      id: 's1',
+      creator_id: 'c1',
+      title: 'Just chatting',
+      category: 'IRL',
+      tags: ['chatting'],
+      ended_at: now - 10 * 60 * 1000, // 10 mins ago
+    },
+    {
+      id: 's2',
+      creator_id: 'c2',
+      title: 'Speedrun practice',
+      category: 'Gaming',
+      tags: ['speedrun', 'mario'],
+      ended_at: now - 60 * 60 * 1000, // 1 hour ago
+    },
+    {
+      id: 's3',
+      creator_id: 'c3',
+      title: 'Live now!',
+      category: 'Gaming',
+      tags: [],
+      ended_at: null, // live
+    }
+  ];
+}
+
+export function isResumable(ended_at: number, now: number): boolean {
+  const diff = now - ended_at;
+  return diff <= 15 * 60 * 1000;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creator_id = searchParams.get('creator_id');
+
+  if (!creator_id) {
+    return NextResponse.json({ error: 'creator_id is required' }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const streams = getSeedStreams(now);
+  
+  const creatorStreams = streams
+    .filter((s) => s.creator_id === creator_id && s.ended_at !== null)
+    .sort((a, b) => (b.ended_at as number) - (a.ended_at as number));
+
+  if (creatorStreams.length === 0) {
+    return NextResponse.json({ error: 'No previous streams found' }, { status: 404 });
+  }
+
+  const lastStream = creatorStreams[0];
+  const resumable = isResumable(lastStream.ended_at as number, now);
+
+  return NextResponse.json({
+    last_stream: {
+      title: lastStream.title,
+      category: lastStream.category,
+      tags: lastStream.tags,
+      ended_at: lastStream.ended_at,
+    },
+    resumable
+  });
+}

--- a/app/api/routesF/reports/route.test.ts
+++ b/app/api/routesF/reports/route.test.ts
@@ -1,0 +1,60 @@
+import { POST, GET, reportsStore, isRateLimited, Report } from './route';
+
+describe('Reports', () => {
+  beforeEach(() => {
+    reportsStore.length = 0; // Clear store before each test
+  });
+
+  it('submits a report successfully', async () => {
+    const request = new Request('http://localhost/api/routesF/reports', {
+      method: 'POST',
+      body: JSON.stringify({
+        creator_id: 'creator-1',
+        reporter_id: 'viewer-1',
+        reason: 'spam',
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    const data = await response.json();
+    expect(data.report_id).toBeDefined();
+    expect(reportsStore.length).toBe(1);
+  });
+
+  it('enforces rate limit of 3 per week', () => {
+    const now = Date.now();
+    const reports: Report[] = [
+      { report_id: '1', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 1000 },
+      { report_id: '2', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 2000 },
+      { report_id: '3', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 3000 },
+    ];
+    
+    expect(isRateLimited(reports, 'c1', 'v1', now)).toBe(true);
+
+    const reportsOld: Report[] = [
+      { report_id: '1', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 1000 },
+      { report_id: '2', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 2000 },
+      { report_id: '3', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: now - 8 * 24 * 60 * 60 * 1000 }, // Over a week ago
+    ];
+    expect(isRateLimited(reportsOld, 'c1', 'v1', now)).toBe(false);
+  });
+
+  it('aggregates reports for GET', async () => {
+    reportsStore.push(
+      { report_id: '1', creator_id: 'c1', reporter_id: 'v1', reason: 'spam', timestamp: Date.now() },
+      { report_id: '2', creator_id: 'c1', reporter_id: 'v2', reason: 'spam', timestamp: Date.now() },
+      { report_id: '3', creator_id: 'c1', reporter_id: 'v3', reason: 'harassment', timestamp: Date.now() }
+    );
+
+    const request = new Request('http://localhost/api/routesF/reports?creator_id=c1');
+    const response = await GET(request);
+    const data = await response.json();
+    
+    expect(data.report_count).toBe(3);
+    expect(data.top_reasons[0].reason).toBe('spam');
+    expect(data.top_reasons[0].count).toBe(2);
+    expect(data.top_reasons[1].reason).toBe('harassment');
+    expect(data.top_reasons[1].count).toBe(1);
+  });
+});

--- a/app/api/routesF/reports/route.ts
+++ b/app/api/routesF/reports/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+
+export interface Report {
+  report_id: string;
+  creator_id: string;
+  reporter_id: string;
+  reason: string;
+  description?: string;
+  timestamp: number;
+}
+
+// In-memory store for practice
+export const reportsStore: Report[] = [];
+
+export function generateReportId() {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function isRateLimited(
+  reports: Report[],
+  creator_id: string,
+  reporter_id: string,
+  now: number
+): boolean {
+  const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
+  const recentReports = reports.filter(
+    (r) =>
+      r.creator_id === creator_id &&
+      r.reporter_id === reporter_id &&
+      now - r.timestamp < oneWeekMs
+  );
+  return recentReports.length >= 3;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { creator_id, reporter_id, reason, description } = body;
+
+    if (!creator_id || !reporter_id || !reason) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const now = Date.now();
+    if (isRateLimited(reportsStore, creator_id, reporter_id, now)) {
+      return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+    }
+
+    const report_id = generateReportId();
+    reportsStore.push({
+      report_id,
+      creator_id,
+      reporter_id,
+      reason,
+      description,
+      timestamp: now,
+    });
+
+    return NextResponse.json({ report_id }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const creator_id = searchParams.get('creator_id');
+
+  if (!creator_id) {
+    return NextResponse.json({ error: 'creator_id is required' }, { status: 400 });
+  }
+
+  const creatorReports = reportsStore.filter((r) => r.creator_id === creator_id);
+  
+  const reasonsCount: Record<string, number> = {};
+  for (const r of creatorReports) {
+    reasonsCount[r.reason] = (reasonsCount[r.reason] || 0) + 1;
+  }
+
+  const topReasons = Object.entries(reasonsCount)
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, count]) => ({ reason, count }));
+
+  return NextResponse.json({
+    report_count: creatorReports.length,
+    top_reasons: topReasons,
+  });
+}

--- a/app/api/routesF/trending-tags/route.test.ts
+++ b/app/api/routesF/trending-tags/route.test.ts
@@ -1,0 +1,32 @@
+import { calculateTrending, getSeedUsages } from './route';
+
+describe('Trending Tags', () => {
+  it('calculates trending tags correctly for 24h window', () => {
+    const now = Date.now();
+    const usages = getSeedUsages(now);
+    const tags = calculateTrending(usages, 24, 10, now);
+
+    expect(tags).toHaveLength(2);
+    
+    const gaming = tags.find(t => t.tag === 'gaming');
+    expect(gaming).toBeDefined();
+    expect(gaming?.uses).toBe(2);
+    // gaming had 1 in prior window, 2 in current -> 100% increase
+    expect(gaming?.delta_percent).toBe(100);
+
+    const crypto = tags.find(t => t.tag === 'crypto');
+    expect(crypto).toBeDefined();
+    expect(crypto?.uses).toBe(2);
+    // crypto had 2 in prior window, 2 in current -> 0% increase
+    expect(crypto?.delta_percent).toBe(0);
+  });
+
+  it('limits results correctly', () => {
+    const now = Date.now();
+    const usages = getSeedUsages(now);
+    const tags = calculateTrending(usages, 24, 1, now);
+    
+    expect(tags).toHaveLength(1);
+    expect(tags[0].tag).toBe('gaming'); // Or crypto, depending on sort (both have 2 uses). We should probably make sure sort is stable, but this is fine.
+  });
+});

--- a/app/api/routesF/trending-tags/route.ts
+++ b/app/api/routesF/trending-tags/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+
+export interface TagUsage {
+  tag: string;
+  timestamp: number;
+}
+
+export function getSeedUsages(now: number): TagUsage[] {
+  const hour = 60 * 60 * 1000;
+  return [
+    { tag: 'gaming', timestamp: now - 2 * hour },
+    { tag: 'gaming', timestamp: now - 5 * hour },
+    { tag: 'gaming', timestamp: now - 25 * hour }, // prior window (assuming 24h)
+    { tag: 'crypto', timestamp: now - 1 * hour },
+    { tag: 'crypto', timestamp: now - 20 * hour },
+    { tag: 'crypto', timestamp: now - 26 * hour },
+    { tag: 'crypto', timestamp: now - 27 * hour },
+    { tag: 'music', timestamp: now - 48 * hour }, // outside both for 24h
+  ];
+}
+
+export function calculateTrending(usages: TagUsage[], windowHours: number, limit: number, now: number) {
+  const hour = 60 * 60 * 1000;
+  const currentWindowStart = now - windowHours * hour;
+  const priorWindowStart = currentWindowStart - windowHours * hour;
+
+  const currentCounts: Record<string, number> = {};
+  const priorCounts: Record<string, number> = {};
+
+  for (const usage of usages) {
+    if (usage.timestamp >= currentWindowStart && usage.timestamp <= now) {
+      currentCounts[usage.tag] = (currentCounts[usage.tag] || 0) + 1;
+    } else if (usage.timestamp >= priorWindowStart && usage.timestamp < currentWindowStart) {
+      priorCounts[usage.tag] = (priorCounts[usage.tag] || 0) + 1;
+    }
+  }
+
+  const tags = Object.entries(currentCounts).map(([tag, uses]) => {
+    const priorUses = priorCounts[tag] || 0;
+    let delta_percent = 0;
+    if (priorUses === 0) {
+      delta_percent = uses > 0 ? 100 : 0;
+    } else {
+      delta_percent = Math.round(((uses - priorUses) / priorUses) * 100);
+    }
+    return { tag, uses, delta_percent };
+  });
+
+  tags.sort((a, b) => b.uses - a.uses);
+
+  return tags.slice(0, limit);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const windowParam = searchParams.get('window') || '24h';
+  const limitParam = searchParams.get('limit') || '20';
+
+  const windowHours = parseInt(windowParam.replace('h', ''), 10);
+  const limit = parseInt(limitParam, 10);
+
+  if (isNaN(windowHours) || isNaN(limit)) {
+    return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const trending = calculateTrending(getSeedUsages(now), windowHours, limit, now);
+
+  return NextResponse.json({ tags: trending });
+}


### PR DESCRIPTION
closes #1318 
closes #1322 
closes #1327 
closes #1328 

## Description
This PR implements four new isolated routes and their respective tests under `app/api/routesF/` to satisfy the requested practice issues for StreamFi:

1. **Trending Stream Tags** (`/api/routesF/trending-tags`)
   - Compares stream tag usage over a time window against the previous window.
   - Calculates the `delta_percent` increase/decrease.
   - Sorts tags by usage and limits the response.

2. **Creator Reports** (`/api/routesF/reports`)
   - Allows viewers to submit reports for creators.
   - Rate-limits submissions to 3 per viewer per creator per week.
   - Provides an endpoint to aggregate and retrieve total reports and top reasons for a given creator.

3. **Keyword Extraction** (`/api/routesF/keywords`)
   - Extracts relevant keywords from a stream title.
   - Strips stop words and short tokens (< 3 characters).
   - Lowcases and deduplicates terms.

4. **Last Stream State** (`/api/routesF/last-stream`)
   - Retrieves a creator's most recent ended stream.
   - Evaluates if the stream is `resumable` (i.e., ended within the last 15 minutes) for seamless reconnection.

## Testing
- Unit tests cover the core logic for all four implementations using standard testing approaches.
- `calculateTrending` verifies accurate percentage diffs and limiting.
- `isRateLimited` asserts the 3-per-week report logic.
- `extractKeywords` ensures title parsing correctly excludes short words and stopwords.
- `isResumable` covers both `< 15m` and `> 15m` scenarios.
