### PR TITLE
feat(routesF): friends-watching, underrated-creators, streams-hosted-by-user, mute-notification-category

### DIFF
--- a/app/api/routesF/friends-watching/route.test.ts
+++ b/app/api/routesF/friends-watching/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from './route'
+import { NextRequest } from 'next/server'
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/routesF/friends-watching')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new NextRequest(url.toString())
+}
+
+describe('GET /api/routesF/friends-watching', () => {
+  it('returns streams with friend watchers for a known viewer', async () => {
+    const res = await GET(makeRequest({ viewer_id: 'user-01' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.viewer_id).toBe('user-01')
+    expect(Array.isArray(data.streams)).toBe(true)
+    expect(data.total).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns streams with friend info attached', async () => {
+    const res = await GET(makeRequest({ viewer_id: 'user-03' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    if (data.streams.length > 0) {
+      expect(data.streams[0]).toHaveProperty('stream')
+      expect(data.streams[0]).toHaveProperty('friends_watching')
+      expect(data.streams[0]).toHaveProperty('friend_count')
+      expect(Array.isArray(data.streams[0].friends_watching)).toBe(true)
+    }
+  })
+
+  it('sorts by friend_count descending', async () => {
+    const res = await GET(makeRequest({ viewer_id: 'user-03' }))
+    const data = await res.json()
+
+    for (let i = 0; i < data.streams.length - 1; i++) {
+      expect(data.streams[i].friend_count).toBeGreaterThanOrEqual(data.streams[i + 1].friend_count)
+    }
+  })
+
+  it('returns empty streams for unknown viewer', async () => {
+    const res = await GET(makeRequest({ viewer_id: 'unknown-user' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.streams).toHaveLength(0)
+    expect(data.total).toBe(0)
+  })
+
+  it('respects limit parameter', async () => {
+    const res = await GET(makeRequest({ viewer_id: 'user-03', limit: '1' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.streams.length).toBeLessThanOrEqual(1)
+  })
+
+  it('returns 400 when viewer_id is missing', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/routesF/friends-watching'))
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/routesF/friends-watching/route.ts
+++ b/app/api/routesF/friends-watching/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const schema = z.object({
+  viewer_id: z.string().min(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+})
+
+const FRIENDS: Record<string, string[]> = {
+  'user-01': ['alice', 'bob', 'carol'],
+  'user-02': ['dave', 'eve'],
+  'user-03': ['frank', 'alice', 'carol', 'dave'],
+  'user-04': ['grace', 'heidi'],
+  'user-05': ['ivan', 'judy', 'mallory'],
+}
+
+const LIVE_STREAMS = [
+  { stream_id: 'str-101', title: 'Coding with TypeScript', streamer: 'streamer_ts', category: 'tech' },
+  { stream_id: 'str-102', title: 'Gaming Highlights', streamer: 'gamer_pro', category: 'gaming' },
+  { stream_id: 'str-103', title: 'Music Production Live', streamer: 'beatmaker', category: 'music' },
+  { stream_id: 'str-104', title: 'Crypto Market Analysis', streamer: 'crypto_guru', category: 'finance' },
+  { stream_id: 'str-105', title: 'Art & Illustration', streamer: 'art_wizard', category: 'creative' },
+  { stream_id: 'str-106', title: 'Cooking Masterclass', streamer: 'chef_streams', category: 'lifestyle' },
+]
+
+const FRIEND_STREAM_ASSIGNMENTS: Record<string, string[]> = {
+  alice: ['str-101', 'str-103'],
+  bob: ['str-102'],
+  carol: ['str-104'],
+  dave: ['str-101', 'str-105'],
+  eve: ['str-106'],
+  frank: ['str-102', 'str-103'],
+  grace: ['str-101'],
+  heidi: ['str-104', 'str-106'],
+  ivan: ['str-105'],
+  judy: ['str-101', 'str-102'],
+  mallory: ['str-103'],
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const parsed = schema.safeParse({
+    viewer_id: searchParams.get('viewer_id'),
+    limit: searchParams.get('limit') ?? 20,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'viewer_id is required', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { viewer_id, limit } = parsed.data
+  const friendList = FRIENDS[viewer_id] ?? []
+
+  const streamMap = new Map<string, Set<string>>()
+
+  for (const friend of friendList) {
+    const watching = FRIEND_STREAM_ASSIGNMENTS[friend] ?? []
+    for (const streamId of watching) {
+      if (!streamMap.has(streamId)) streamMap.set(streamId, new Set())
+      streamMap.get(streamId)!.add(friend)
+    }
+  }
+
+  const streams = Array.from(streamMap.entries())
+    .map(([streamId, watchingFriends]) => {
+      const streamInfo = LIVE_STREAMS.find((s) => s.stream_id === streamId)!
+      return {
+        stream: streamInfo,
+        friends_watching: Array.from(watchingFriends),
+        friend_count: watchingFriends.size,
+      }
+    })
+    .sort((a, b) => b.friend_count - a.friend_count)
+    .slice(0, limit)
+
+  return NextResponse.json({
+    viewer_id,
+    streams,
+    total: streams.length,
+  })
+}

--- a/app/api/routesF/mute-notification-category/route.test.ts
+++ b/app/api/routesF/mute-notification-category/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { GET, POST } from './route'
+import { NextRequest } from 'next/server'
+
+function makeGet(viewerId: string): NextRequest {
+  return new NextRequest(`http://localhost/api/routesF/mute-notification-category?viewer_id=${viewerId}`)
+}
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/routesF/mute-notification-category', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('GET /api/routesF/mute-notification-category', () => {
+  it('returns muted and active categories for viewer', async () => {
+    const res = await GET(makeGet('viewer-get-test'))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.viewer_id).toBe('viewer-get-test')
+    expect(Array.isArray(data.muted_categories)).toBe(true)
+    expect(Array.isArray(data.active_categories)).toBe(true)
+    expect(Array.isArray(data.all_categories)).toBe(true)
+  })
+
+  it('returns 400 when viewer_id is missing', async () => {
+    const res = await GET(new NextRequest('http://localhost/api/routesF/mute-notification-category'))
+    expect(res.status).toBe(400)
+  })
+
+  it('starts with no muted categories for new viewer', async () => {
+    const res = await GET(makeGet('fresh-viewer-123'))
+    const data = await res.json()
+    expect(data.muted_categories).toHaveLength(0)
+    expect(data.active_categories).toHaveLength(data.all_categories.length)
+  })
+})
+
+describe('POST /api/routesF/mute-notification-category', () => {
+  const UNIQUE_VIEWER = 'mute-post-test-viewer-' + Date.now()
+
+  it('mutes a category successfully', async () => {
+    const res = await POST(makePost({ viewer_id: UNIQUE_VIEWER, category: 'new_follower', action: 'mute' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.category).toBe('new_follower')
+    expect(data.action).toBe('mute')
+    expect(data.muted_categories).toContain('new_follower')
+  })
+
+  it('unmutes a muted category', async () => {
+    const viewerId = 'unmute-test-' + Date.now()
+    await POST(makePost({ viewer_id: viewerId, category: 'tip_received', action: 'mute' }))
+    const res = await POST(makePost({ viewer_id: viewerId, category: 'tip_received', action: 'unmute' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.muted_categories).not.toContain('tip_received')
+  })
+
+  it('returns 409 when trying to mute an already-muted category', async () => {
+    const viewerId = 'conflict-test-' + Date.now()
+    await POST(makePost({ viewer_id: viewerId, category: 'stream_live', action: 'mute' }))
+    const res = await POST(makePost({ viewer_id: viewerId, category: 'stream_live', action: 'mute' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 409 when trying to unmute a category that is not muted', async () => {
+    const res = await POST(makePost({ viewer_id: 'no-mutes-' + Date.now(), category: 'raid', action: 'unmute' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 400 for invalid category', async () => {
+    const res = await POST(makePost({ viewer_id: 'any', category: 'invalid_cat', action: 'mute' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid action', async () => {
+    const res = await POST(makePost({ viewer_id: 'any', category: 'raid', action: 'toggle' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when body is malformed JSON', async () => {
+    const res = await POST(new NextRequest('http://localhost/api/routesF/mute-notification-category', {
+      method: 'POST',
+      body: 'not json',
+    }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/routesF/mute-notification-category/route.ts
+++ b/app/api/routesF/mute-notification-category/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const VALID_CATEGORIES = [
+  'new_follower',
+  'stream_live',
+  'stream_end',
+  'tip_received',
+  'mention',
+  'chat_message',
+  'subscription',
+  'raid',
+] as const
+
+type NotificationCategory = typeof VALID_CATEGORIES[number]
+
+const getSchema = z.object({
+  viewer_id: z.string().min(1),
+})
+
+const postSchema = z.object({
+  viewer_id: z.string().min(1),
+  category: z.enum(VALID_CATEGORIES),
+  action: z.enum(['mute', 'unmute']),
+})
+
+const mutedCategories = new Map<string, Set<NotificationCategory>>()
+
+function getMuted(viewerId: string): Set<NotificationCategory> {
+  if (!mutedCategories.has(viewerId)) mutedCategories.set(viewerId, new Set())
+  return mutedCategories.get(viewerId)!
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const parsed = getSchema.safeParse({ viewer_id: searchParams.get('viewer_id') })
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'viewer_id is required', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { viewer_id } = parsed.data
+  const muted = Array.from(getMuted(viewer_id))
+  const active = VALID_CATEGORIES.filter((c) => !muted.includes(c))
+
+  return NextResponse.json({
+    viewer_id,
+    muted_categories: muted,
+    active_categories: active,
+    all_categories: VALID_CATEGORIES,
+  })
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = postSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten(), validCategories: VALID_CATEGORIES },
+      { status: 400 },
+    )
+  }
+
+  const { viewer_id, category, action } = parsed.data
+  const muted = getMuted(viewer_id)
+
+  const alreadyMuted = muted.has(category)
+
+  if (action === 'mute') {
+    if (alreadyMuted) {
+      return NextResponse.json({ error: `Category '${category}' is already muted` }, { status: 409 })
+    }
+    muted.add(category)
+  } else {
+    if (!alreadyMuted) {
+      return NextResponse.json({ error: `Category '${category}' is not muted` }, { status: 409 })
+    }
+    muted.delete(category)
+  }
+
+  return NextResponse.json({
+    viewer_id,
+    category,
+    action,
+    muted_categories: Array.from(muted),
+  })
+}

--- a/app/api/routesF/streams-hosted-by-user/route.test.ts
+++ b/app/api/routesF/streams-hosted-by-user/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from './route'
+import { NextRequest } from 'next/server'
+
+function makeRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/routesF/streams-hosted-by-user')
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  }
+  return new NextRequest(url.toString())
+}
+
+describe('GET /api/routesF/streams-hosted-by-user', () => {
+  it('returns hosted streams for a known host', async () => {
+    const res = await GET(makeRequest({ host_username: 'streamer_ts' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.host_username).toBe('streamer_ts')
+    expect(data.streams.length).toBeGreaterThan(0)
+  })
+
+  it('returns correct stream shape', async () => {
+    const res = await GET(makeRequest({ host_username: 'streamer_ts' }))
+    const data = await res.json()
+    const stream = data.streams[0]
+
+    expect(stream).toHaveProperty('stream_id')
+    expect(stream).toHaveProperty('primary_creator')
+    expect(stream).toHaveProperty('title')
+    expect(stream).toHaveProperty('role')
+    expect(stream).toHaveProperty('playback_id')
+    expect(stream).toHaveProperty('started_at')
+  })
+
+  it('role is one of co-host, guest, or raid-host', async () => {
+    const res = await GET(makeRequest({ host_username: 'beatmaker' }))
+    const data = await res.json()
+
+    const validRoles = ['co-host', 'guest', 'raid-host']
+    for (const stream of data.streams) {
+      expect(validRoles).toContain(stream.role)
+    }
+  })
+
+  it('returns empty streams for unknown host', async () => {
+    const res = await GET(makeRequest({ host_username: 'nobody' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.streams).toHaveLength(0)
+    expect(data.total).toBe(0)
+  })
+
+  it('returns 400 when host_username is missing', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns multiple streams for hosts with more than one', async () => {
+    const res = await GET(makeRequest({ host_username: 'beatmaker' }))
+    const data = await res.json()
+    expect(data.streams.length).toBe(2)
+    expect(data.total).toBe(2)
+  })
+})

--- a/app/api/routesF/streams-hosted-by-user/route.ts
+++ b/app/api/routesF/streams-hosted-by-user/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const schema = z.object({
+  host_username: z.string().min(1),
+})
+
+interface HostedStream {
+  stream_id: string
+  primary_creator: string
+  title: string
+  category: string
+  role: 'co-host' | 'guest' | 'raid-host'
+  playback_id: string
+  started_at: string
+}
+
+const HOST_STREAMS: Record<string, HostedStream[]> = {
+  streamer_ts: [
+    {
+      stream_id: 'str-201',
+      primary_creator: 'coder_live',
+      title: 'Full-Stack with Next.js',
+      category: 'tech',
+      role: 'co-host',
+      playback_id: 'pb-201',
+      started_at: '2024-07-01T10:00:00Z',
+    },
+    {
+      stream_id: 'str-202',
+      primary_creator: 'devhacks',
+      title: 'Open Source Sprint',
+      category: 'tech',
+      role: 'guest',
+      playback_id: 'pb-202',
+      started_at: '2024-07-01T14:00:00Z',
+    },
+  ],
+  gamer_pro: [
+    {
+      stream_id: 'str-203',
+      primary_creator: 'ultimate_gamer',
+      title: 'Pro League Showdown',
+      category: 'gaming',
+      role: 'co-host',
+      playback_id: 'pb-203',
+      started_at: '2024-07-01T18:00:00Z',
+    },
+  ],
+  beatmaker: [
+    {
+      stream_id: 'str-204',
+      primary_creator: 'sound_lab',
+      title: 'Trap Beats Session',
+      category: 'music',
+      role: 'guest',
+      playback_id: 'pb-204',
+      started_at: '2024-07-01T20:00:00Z',
+    },
+    {
+      stream_id: 'str-205',
+      primary_creator: 'lo_fi_hub',
+      title: 'Lo-fi Chill Vibes',
+      category: 'music',
+      role: 'raid-host',
+      playback_id: 'pb-205',
+      started_at: '2024-07-01T22:00:00Z',
+    },
+  ],
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const parsed = schema.safeParse({ host_username: searchParams.get('host_username') })
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'host_username is required', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { host_username } = parsed.data
+  const streams = HOST_STREAMS[host_username] ?? []
+
+  return NextResponse.json({
+    host_username,
+    streams,
+    total: streams.length,
+  })
+}

--- a/app/api/routesF/underrated-creators/route.test.ts
+++ b/app/api/routesF/underrated-creators/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from './route'
+import { NextRequest } from 'next/server'
+
+function makeRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/routesF/underrated-creators')
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  }
+  return new NextRequest(url.toString())
+}
+
+describe('GET /api/routesF/underrated-creators', () => {
+  it('returns a list of creators', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(Array.isArray(data.creators)).toBe(true)
+    expect(data.creators.length).toBeGreaterThan(0)
+  })
+
+  it('returns correct creator shape', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+    const creator = data.creators[0]
+
+    expect(creator).toHaveProperty('username')
+    expect(creator).toHaveProperty('display_name')
+    expect(creator).toHaveProperty('followers')
+    expect(creator).toHaveProperty('score')
+    expect(creator).toHaveProperty('tips_per_viewer')
+    expect(creator).toHaveProperty('chat_msgs_per_viewer')
+  })
+
+  it('sorts by score descending', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+
+    for (let i = 0; i < data.creators.length - 1; i++) {
+      expect(data.creators[i].score).toBeGreaterThanOrEqual(data.creators[i + 1].score)
+    }
+  })
+
+  it('score equals tips_per_viewer + chat_msgs_per_viewer', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+
+    for (const c of data.creators) {
+      expect(c.score).toBeCloseTo(c.tips_per_viewer + c.chat_msgs_per_viewer, 2)
+    }
+  })
+
+  it('respects limit parameter', async () => {
+    const res = await GET(makeRequest({ limit: '3' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.creators).toHaveLength(3)
+    expect(data.total).toBe(3)
+  })
+
+  it('defaults to limit 20', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+    expect(data.creators.length).toBeLessThanOrEqual(20)
+  })
+
+  it('includes scoring_method in response', async () => {
+    const res = await GET(makeRequest())
+    const data = await res.json()
+    expect(data.scoring_method).toBeDefined()
+  })
+})

--- a/app/api/routesF/underrated-creators/route.ts
+++ b/app/api/routesF/underrated-creators/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const schema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+})
+
+interface Creator {
+  username: string
+  display_name: string
+  followers: number
+  avg_viewers: number
+  tips_per_viewer: number
+  chat_msgs_per_viewer: number
+  score: number
+  categories: string[]
+}
+
+const CREATORS_POOL: Omit<Creator, 'score'>[] = [
+  { username: 'hidden_gem_1', display_name: 'PixelWave', followers: 320, avg_viewers: 45, tips_per_viewer: 0.8, chat_msgs_per_viewer: 12.5, categories: ['gaming'] },
+  { username: 'hidden_gem_2', display_name: 'SoundForge', followers: 180, avg_viewers: 28, tips_per_viewer: 1.2, chat_msgs_per_viewer: 18.0, categories: ['music'] },
+  { username: 'hidden_gem_3', display_name: 'CodeNight', followers: 540, avg_viewers: 62, tips_per_viewer: 0.5, chat_msgs_per_viewer: 9.8, categories: ['tech'] },
+  { username: 'hidden_gem_4', display_name: 'ArtEon', followers: 210, avg_viewers: 33, tips_per_viewer: 1.5, chat_msgs_per_viewer: 22.3, categories: ['creative'] },
+  { username: 'hidden_gem_5', display_name: 'ChefRoam', followers: 390, avg_viewers: 55, tips_per_viewer: 0.9, chat_msgs_per_viewer: 14.1, categories: ['lifestyle'] },
+  { username: 'hidden_gem_6', display_name: 'ZenFit', followers: 140, avg_viewers: 19, tips_per_viewer: 2.0, chat_msgs_per_viewer: 26.5, categories: ['fitness'] },
+  { username: 'hidden_gem_7', display_name: 'NightOwlDev', followers: 670, avg_viewers: 78, tips_per_viewer: 0.4, chat_msgs_per_viewer: 8.2, categories: ['tech'] },
+  { username: 'hidden_gem_8', display_name: 'BeatLab', followers: 250, avg_viewers: 41, tips_per_viewer: 1.1, chat_msgs_per_viewer: 16.7, categories: ['music'] },
+  { username: 'hidden_gem_9', display_name: 'StrategyCore', followers: 310, avg_viewers: 37, tips_per_viewer: 0.7, chat_msgs_per_viewer: 11.4, categories: ['gaming'] },
+  { username: 'hidden_gem_10', display_name: 'CraftStudio', followers: 190, avg_viewers: 24, tips_per_viewer: 1.8, chat_msgs_per_viewer: 20.9, categories: ['creative'] },
+  { username: 'hidden_gem_11', display_name: 'MindSpace', followers: 420, avg_viewers: 51, tips_per_viewer: 0.6, chat_msgs_per_viewer: 13.0, categories: ['lifestyle'] },
+  { username: 'hidden_gem_12', display_name: 'SpeedRun', followers: 280, avg_viewers: 43, tips_per_viewer: 1.0, chat_msgs_per_viewer: 15.8, categories: ['gaming'] },
+]
+
+const RATED_CREATORS = CREATORS_POOL.map((c) => ({
+  ...c,
+  score: parseFloat((c.tips_per_viewer + c.chat_msgs_per_viewer).toFixed(2)),
+})).sort((a, b) => b.score - a.score)
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const parsed = schema.safeParse({ limit: searchParams.get('limit') ?? 20 })
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid parameters', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { limit } = parsed.data
+  const creators = RATED_CREATORS.slice(0, limit)
+
+  return NextResponse.json({
+    creators,
+    total: creators.length,
+    scoring_method: 'tips_per_viewer + chat_msgs_per_viewer',
+  })
+}


### PR DESCRIPTION
## Summary

Adds four new self-contained routesF API endpoints covering social stream discovery, creator scoring, host presence, and per-viewer notification category muting. All endpoints use seeded deterministic data with no external imports — same pattern as existing routesF routes.

closes #1236
closes #1242
closes #1247
closes #1251

## Changes

- **#1236 — Friends watching** (`GET /api/routesF/friends-watching`): Returns live streams where the viewer's friends are watching. Requires `viewer_id` query param; accepts optional `limit` (default 20, max 50). Results sorted by `friend_count` descending, with `friends_watching` array on each stream entry.

- **#1242 — Underrated creators** (`GET /api/routesF/underrated-creators`): Returns creators ranked by engagement score = `tips_per_viewer + chat_msgs_per_viewer`. Seeded pool of 12 creators. Accepts `limit` param. Each result includes the full scoring breakdown and score value.

- **#1247 — Streams hosted by user** (`GET /api/routesF/streams-hosted-by-user`): Returns streams where the given user appears as `co-host`, `guest`, or `raid-host`. Requires `host_username`. Returns `primary_creator`, `role`, `playback_id`, and `started_at` per stream.

- **#1251 — Mute notification category** (`GET /api/routesF/mute-notification-category` + `POST`): GET returns viewer's current muted and active category sets. POST accepts `{ viewer_id, category, action: "mute"|"unmute" }`. Returns 409 on duplicate mute or unmuting a non-muted category. Supports all 8 notification category types.

## Test plan

- 4 vitest test files added (one per route), covering: happy paths, edge cases (unknown viewer_id, unknown host), pagination, sorting invariants, score formula verification, conflict states (409), and invalid input (400).
- Friends-watching test confirms sort order and correct friend list attachment.
- Underrated-creators test verifies score = tips + chat for every creator in the response.