### PR TITLE
[routes-f] clip embed preview, creator mentions, viewership growth, featured VOD moment

### DIFF
--- a/app/api/routes-f/clip-creator-mentions/route.test.ts
+++ b/app/api/routes-f/clip-creator-mentions/route.test.ts
@@ -1,0 +1,83 @@
+import { POST, KNOWN_CREATORS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-creator-mentions";
+
+async function postMentions(body: unknown) {
+  const res = await POST(
+    new NextRequest(BASE, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  );
+  return { res, data: await res.json() };
+}
+
+describe("Clip Creator Mentions", () => {
+  describe("POST /api/routes-f/clip-creator-mentions", () => {
+    it("should return 400 when clip_id is missing", async () => {
+      const { res } = await postMentions({ title: "Hello @pixelpatch" });
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 when title is missing", async () => {
+      const { res } = await postMentions({ clip_id: "clip-1" });
+      expect(res.status).toBe(400);
+    });
+
+    it("should extract a known creator mention from the title", async () => {
+      const { res, data } = await postMentions({
+        clip_id: "clip-1",
+        title: "Shoutout to @pixelpatch for the assist",
+      });
+      expect(res.status).toBe(200);
+      expect(data.mentions).toEqual(["pixelpatch"]);
+    });
+
+    it("should extract mentions from the description too", async () => {
+      const { data } = await postMentions({
+        clip_id: "clip-1",
+        title: "Clutch round",
+        description: "ft. @walletwiz and @raidmaster",
+      });
+      expect(data.mentions.sort()).toEqual(["raidmaster", "walletwiz"]);
+    });
+
+    it("should ignore unknown handles that aren't in the creators list", async () => {
+      const { data } = await postMentions({
+        clip_id: "clip-1",
+        title: "Thanks @randomviewer123",
+      });
+      expect(data.mentions).toEqual([]);
+    });
+
+    it("should skip a mention of the clip's own creator", async () => {
+      const { data } = await postMentions({
+        clip_id: "clip-1", // owned by novastreams
+        title: "Big shoutout @novastreams @pixelpatch",
+      });
+      expect(data.mentions).toEqual(["pixelpatch"]);
+    });
+
+    it("should de-duplicate repeated mentions", async () => {
+      const { data } = await postMentions({
+        clip_id: "clip-2",
+        title: "@walletwiz @walletwiz @walletwiz",
+      });
+      expect(data.mentions).toEqual(["walletwiz"]);
+    });
+
+    it("should return an empty mentions array when there are none", async () => {
+      const { res, data } = await postMentions({
+        clip_id: "clip-1",
+        title: "No mentions here",
+      });
+      expect(res.status).toBe(200);
+      expect(data.mentions).toEqual([]);
+    });
+
+    it("sanity: KNOWN_CREATORS is non-empty", () => {
+      expect(KNOWN_CREATORS.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/api/routes-f/clip-creator-mentions/route.ts
+++ b/app/api/routes-f/clip-creator-mentions/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Known creators bundled per the routes-f scope constraint, used to validate
+// @-mentions extracted from a clip's title/description.
+export const KNOWN_CREATORS = [
+  "novastreams",
+  "pixelpatch",
+  "walletwiz",
+  "raidmaster",
+  "clutchqueen",
+];
+
+// Maps seed clip_ids to their owning creator, so a mention of the clip's own
+// creator can be skipped even though the request body doesn't carry
+// creator_id directly.
+export const SEED_CLIP_OWNERS: Record<string, string> = {
+  "clip-1": "novastreams",
+  "clip-2": "pixelpatch",
+  "clip-3": "walletwiz",
+};
+
+const MENTION_PATTERN = /@([a-z0-9_]+)/gi;
+
+function extractMentions(text: string): string[] {
+  const matches = text.matchAll(MENTION_PATTERN);
+  const found = new Set<string>();
+  for (const match of matches) {
+    found.add(match[1].toLowerCase());
+  }
+  return [...found];
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+
+  if (!body || typeof body.clip_id !== "string" || !body.clip_id.trim()) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  if (typeof body.title !== "string" || !body.title.trim()) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const description = typeof body.description === "string" ? body.description : "";
+  const combinedText = `${body.title} ${description}`;
+
+  const ownerCreatorId = SEED_CLIP_OWNERS[body.clip_id] ?? null;
+
+  const mentions = extractMentions(combinedText)
+    .filter((handle) => KNOWN_CREATORS.includes(handle))
+    .filter((handle) => handle !== ownerCreatorId);
+
+  return NextResponse.json({ mentions });
+}

--- a/app/api/routes-f/clip-embed-preview/route.test.ts
+++ b/app/api/routes-f/clip-embed-preview/route.test.ts
@@ -1,0 +1,52 @@
+import { GET, SEED_CLIPS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-embed-preview";
+
+async function fetchPreview(query = "") {
+  const res = await GET(new NextRequest(`${BASE}${query}`));
+  return { res, data: await res.json() };
+}
+
+describe("Clip Embed Preview", () => {
+  describe("GET /api/routes-f/clip-embed-preview", () => {
+    it("should return 400 when clip_id is missing", async () => {
+      const { res } = await fetchPreview();
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 404 for an unknown clip_id", async () => {
+      const { res } = await fetchPreview("?clip_id=does-not-exist");
+      expect(res.status).toBe(404);
+    });
+
+    it("should return oembed-shaped data for a public clip", async () => {
+      const publicClip = SEED_CLIPS.find((c) => c.privacy === "public")!;
+      const { res, data } = await fetchPreview(`?clip_id=${publicClip.clip_id}`);
+
+      expect(res.status).toBe(200);
+      expect(data.type).toBe("video");
+      expect(data.title).toBe(publicClip.title);
+      expect(data.author_name).toBe(publicClip.creator_name);
+      expect(data.thumbnail_url).toBe(publicClip.thumbnail_url);
+      expect(typeof data.html).toBe("string");
+      expect(data.html).toContain("iframe");
+    });
+
+    it("should include twitter:card meta hints", async () => {
+      const publicClip = SEED_CLIPS.find((c) => c.privacy === "public")!;
+      const { data } = await fetchPreview(`?clip_id=${publicClip.clip_id}`);
+
+      expect(data.twitter_card).toBe("player");
+      expect(data.twitter_title).toBe(publicClip.title);
+      expect(data.twitter_image).toBe(publicClip.thumbnail_url);
+      expect(typeof data.twitter_player).toBe("string");
+    });
+
+    it("should return 403 for a subscribers-only clip", async () => {
+      const privateClip = SEED_CLIPS.find((c) => c.privacy === "subscribers-only")!;
+      const { res } = await fetchPreview(`?clip_id=${privateClip.clip_id}`);
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/app/api/routes-f/clip-embed-preview/route.ts
+++ b/app/api/routes-f/clip-embed-preview/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface SeedClip {
+  clip_id: string;
+  creator_id: string;
+  creator_name: string;
+  title: string;
+  thumbnail_url: string;
+  duration_seconds: number;
+  privacy: "public" | "unlisted" | "subscribers-only";
+}
+
+// Seed clips bundled per the routes-f scope constraint.
+export const SEED_CLIPS: SeedClip[] = [
+  {
+    clip_id: "clip-1",
+    creator_id: "creator-1",
+    creator_name: "NovaStreams",
+    title: "Insane clutch round",
+    thumbnail_url: "https://cdn.streamfi.example/clips/clip-1/thumb.jpg",
+    duration_seconds: 12,
+    privacy: "public",
+  },
+  {
+    clip_id: "clip-2",
+    creator_id: "creator-2",
+    creator_name: "PixelPatch",
+    title: "Speedrun world record",
+    thumbnail_url: "https://cdn.streamfi.example/clips/clip-2/thumb.jpg",
+    duration_seconds: 95,
+    privacy: "public",
+  },
+  {
+    clip_id: "clip-3",
+    creator_id: "creator-3",
+    creator_name: "WalletWiz",
+    title: "Tutorial: wallet setup",
+    thumbnail_url: "https://cdn.streamfi.example/clips/clip-3/thumb.jpg",
+    duration_seconds: 240,
+    privacy: "subscribers-only",
+  },
+];
+
+const CLIP_BASE_URL = "https://streamfi.example/clips";
+
+function findClip(clipId: string): SeedClip | undefined {
+  return SEED_CLIPS.find((clip) => clip.clip_id === clipId);
+}
+
+function buildOembedHtml(clip: SeedClip): string {
+  const clipUrl = `${CLIP_BASE_URL}/${clip.clip_id}`;
+  return `<iframe src="${clipUrl}/embed" width="600" height="338" frameborder="0" allowfullscreen title="${clip.title}"></iframe>`;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  const clip = findClip(clipId);
+  if (!clip) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+  }
+
+  if (clip.privacy === "subscribers-only") {
+    return NextResponse.json(
+      { error: "This clip is not available for public embedding" },
+      { status: 403 }
+    );
+  }
+
+  const clipUrl = `${CLIP_BASE_URL}/${clip.clip_id}`;
+
+  return NextResponse.json({
+    type: "video",
+    version: "1.0",
+    title: clip.title,
+    author_name: clip.creator_name,
+    author_url: `https://streamfi.example/${clip.creator_id}`,
+    provider_name: "StreamFi",
+    provider_url: "https://streamfi.example",
+    thumbnail_url: clip.thumbnail_url,
+    thumbnail_width: 1280,
+    thumbnail_height: 720,
+    html: buildOembedHtml(clip),
+    width: 600,
+    height: 338,
+    // Twitter/Discord card hints, alongside the standard oEmbed shape above.
+    twitter_card: "player",
+    twitter_title: clip.title,
+    twitter_image: clip.thumbnail_url,
+    twitter_player: `${clipUrl}/embed`,
+    twitter_player_width: 600,
+    twitter_player_height: 338,
+  });
+}

--- a/app/api/routes-f/clip-viewership-growth/route.test.ts
+++ b/app/api/routes-f/clip-viewership-growth/route.test.ts
@@ -1,0 +1,47 @@
+import { GET, SEED_HOURLY_VIEWS } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routes-f/clip-viewership-growth";
+
+async function fetchGrowth(query = "") {
+  const res = await GET(new NextRequest(`${BASE}${query}`));
+  return { res, data: await res.json() };
+}
+
+describe("Clip Viewership Growth", () => {
+  describe("GET /api/routes-f/clip-viewership-growth", () => {
+    it("should return 400 when clip_id is missing", async () => {
+      const { res } = await fetchGrowth();
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 404 for an unknown clip_id", async () => {
+      const { res } = await fetchGrowth("?clip_id=does-not-exist");
+      expect(res.status).toBe(404);
+    });
+
+    it("should return a series with the same length as the seed samples", async () => {
+      const { res, data } = await fetchGrowth("?clip_id=clip-1");
+      expect(res.status).toBe(200);
+      expect(data.series).toHaveLength(SEED_HOURLY_VIEWS["clip-1"].length);
+    });
+
+    it("should compute correct cumulative views", async () => {
+      const { data } = await fetchGrowth("?clip_id=clip-1");
+      const cumulative = data.series.map((s: { views_cumulative: number }) => s.views_cumulative);
+      expect(cumulative).toEqual([120, 200, 245, 275]);
+    });
+
+    it("should preserve the views_this_hour value per sample", async () => {
+      const { data } = await fetchGrowth("?clip_id=clip-2");
+      const perHour = data.series.map((s: { views_this_hour: number }) => s.views_this_hour);
+      expect(perHour).toEqual([500, 320, 200, 150, 90]);
+    });
+
+    it("should return series sorted by hour_offset ascending", async () => {
+      const { data } = await fetchGrowth("?clip_id=clip-2");
+      const offsets = data.series.map((s: { hour_offset: number }) => s.hour_offset);
+      expect(offsets).toEqual([...offsets].sort((a, b) => a - b));
+    });
+  });
+});

--- a/app/api/routes-f/clip-viewership-growth/route.ts
+++ b/app/api/routes-f/clip-viewership-growth/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface HourlySample {
+  hour_offset: number;
+  views_this_hour: number;
+}
+
+// Seed hourly-view samples per clip, bundled per the routes-f scope constraint.
+export const SEED_HOURLY_VIEWS: Record<string, HourlySample[]> = {
+  "clip-1": [
+    { hour_offset: 0, views_this_hour: 120 },
+    { hour_offset: 1, views_this_hour: 80 },
+    { hour_offset: 2, views_this_hour: 45 },
+    { hour_offset: 3, views_this_hour: 30 },
+  ],
+  "clip-2": [
+    { hour_offset: 0, views_this_hour: 500 },
+    { hour_offset: 1, views_this_hour: 320 },
+    { hour_offset: 2, views_this_hour: 200 },
+    { hour_offset: 3, views_this_hour: 150 },
+    { hour_offset: 4, views_this_hour: 90 },
+  ],
+};
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clipId = searchParams.get("clip_id");
+
+  if (!clipId) {
+    return NextResponse.json({ error: "clip_id is required" }, { status: 400 });
+  }
+
+  const samples = SEED_HOURLY_VIEWS[clipId];
+  if (!samples) {
+    return NextResponse.json({ error: "Clip not found" }, { status: 404 });
+  }
+
+  let cumulative = 0;
+  const series = samples
+    .slice()
+    .sort((a, b) => a.hour_offset - b.hour_offset)
+    .map((sample) => {
+      cumulative += sample.views_this_hour;
+      return {
+        hour_offset: sample.hour_offset,
+        views_cumulative: cumulative,
+        views_this_hour: sample.views_this_hour,
+      };
+    });
+
+  return NextResponse.json({ series });
+}

--- a/app/api/routesF/featured-vod-moment/route.test.ts
+++ b/app/api/routesF/featured-vod-moment/route.test.ts
@@ -1,0 +1,125 @@
+import { GET, POST, featuredMomentsStore } from "./route";
+import { NextRequest } from "next/server";
+
+const BASE = "http://localhost/api/routesF/featured-vod-moment";
+
+function postMoment(body: unknown) {
+  return POST(
+    new NextRequest(BASE, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+function getMoments(query: string) {
+  return GET(new NextRequest(`${BASE}${query}`));
+}
+
+describe("Featured VOD Moment", () => {
+  beforeEach(() => {
+    featuredMomentsStore.clear();
+  });
+
+  describe("POST /api/routesF/featured-vod-moment", () => {
+    it("should return 400 when vod_id is missing", async () => {
+      const res = await postMoment({ start_seconds: 0, end_seconds: 10, title: "x" });
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 when end_seconds is not after start_seconds", async () => {
+      const res = await postMoment({
+        vod_id: "vod-1",
+        start_seconds: 30,
+        end_seconds: 10,
+        title: "Bad clip",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 when title is missing", async () => {
+      const res = await postMoment({ vod_id: "vod-1", start_seconds: 0, end_seconds: 10 });
+      expect(res.status).toBe(400);
+    });
+
+    it("should create a featured moment and return a featured_id", async () => {
+      const res = await postMoment({
+        vod_id: "vod-1",
+        start_seconds: 120,
+        end_seconds: 180,
+        title: "Best play of the stream",
+      });
+      const data = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(typeof data.featured_id).toBe("string");
+    });
+
+    it("should cap featured moments at 3 per VOD", async () => {
+      for (let i = 0; i < 3; i++) {
+        const res = await postMoment({
+          vod_id: "vod-cap",
+          start_seconds: i * 10,
+          end_seconds: i * 10 + 5,
+          title: `Moment ${i}`,
+        });
+        expect(res.status).toBe(201);
+      }
+
+      const fourth = await postMoment({
+        vod_id: "vod-cap",
+        start_seconds: 40,
+        end_seconds: 45,
+        title: "One too many",
+      });
+      expect(fourth.status).toBe(409);
+    });
+  });
+
+  describe("GET /api/routesF/featured-vod-moment", () => {
+    it("should return 400 when vod_id is missing", async () => {
+      const res = await getMoments("");
+      expect(res.status).toBe(400);
+    });
+
+    it("should return an empty list for a VOD with no featured moments", async () => {
+      const res = await getMoments("?vod_id=vod-empty");
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.moments).toEqual([]);
+    });
+
+    it("should list previously created featured moments for a VOD", async () => {
+      await postMoment({
+        vod_id: "vod-2",
+        start_seconds: 5,
+        end_seconds: 15,
+        title: "First highlight",
+      });
+      await postMoment({
+        vod_id: "vod-2",
+        start_seconds: 100,
+        end_seconds: 110,
+        title: "Second highlight",
+      });
+
+      const res = await getMoments("?vod_id=vod-2");
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.moments).toHaveLength(2);
+      expect(data.moments[0].title).toBe("First highlight");
+      expect(data.moments[1].title).toBe("Second highlight");
+    });
+
+    it("should not mix moments across different VODs", async () => {
+      await postMoment({ vod_id: "vod-a", start_seconds: 0, end_seconds: 5, title: "A moment" });
+      await postMoment({ vod_id: "vod-b", start_seconds: 0, end_seconds: 5, title: "B moment" });
+
+      const resA = await getMoments("?vod_id=vod-a");
+      const dataA = await resA.json();
+      expect(dataA.moments).toHaveLength(1);
+      expect(dataA.moments[0].title).toBe("A moment");
+    });
+  });
+});

--- a/app/api/routesF/featured-vod-moment/route.ts
+++ b/app/api/routesF/featured-vod-moment/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface FeaturedMoment {
+  featured_id: string;
+  vod_id: string;
+  start_seconds: number;
+  end_seconds: number;
+  title: string;
+  created_at: string;
+}
+
+const MAX_FEATURED_PER_VOD = 3;
+
+// In-memory store: key = vod_id, value = featured moments for that VOD.
+export const featuredMomentsStore = new Map<string, FeaturedMoment[]>();
+
+let nextId = 1;
+
+function generateFeaturedId(): string {
+  return `featured-${nextId++}`;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payload = (body ?? {}) as Record<string, unknown>;
+  const vodId = typeof payload.vod_id === "string" ? payload.vod_id.trim() : null;
+  const startSeconds = payload.start_seconds;
+  const endSeconds = payload.end_seconds;
+  const title = typeof payload.title === "string" ? payload.title.trim() : null;
+
+  if (!vodId) {
+    return NextResponse.json({ error: "vod_id is required" }, { status: 400 });
+  }
+  if (typeof startSeconds !== "number" || !Number.isFinite(startSeconds) || startSeconds < 0) {
+    return NextResponse.json(
+      { error: "start_seconds must be a non-negative number" },
+      { status: 400 }
+    );
+  }
+  if (typeof endSeconds !== "number" || !Number.isFinite(endSeconds) || endSeconds <= startSeconds) {
+    return NextResponse.json(
+      { error: "end_seconds must be a number greater than start_seconds" },
+      { status: 400 }
+    );
+  }
+  if (!title) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const existing = featuredMomentsStore.get(vodId) ?? [];
+  if (existing.length >= MAX_FEATURED_PER_VOD) {
+    return NextResponse.json(
+      { error: `A VOD may have at most ${MAX_FEATURED_PER_VOD} featured moments` },
+      { status: 409 }
+    );
+  }
+
+  const moment: FeaturedMoment = {
+    featured_id: generateFeaturedId(),
+    vod_id: vodId,
+    start_seconds: startSeconds,
+    end_seconds: endSeconds,
+    title,
+    created_at: new Date().toISOString(),
+  };
+
+  featuredMomentsStore.set(vodId, [...existing, moment]);
+
+  return NextResponse.json({ featured_id: moment.featured_id }, { status: 201 });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const vodId = searchParams.get("vod_id");
+
+  if (!vodId) {
+    return NextResponse.json({ error: "vod_id is required" }, { status: 400 });
+  }
+
+  const moments = featuredMomentsStore.get(vodId) ?? [];
+  return NextResponse.json({ moments });
+}


### PR DESCRIPTION
## Summary

- **clip-embed-preview** (`routes-f`) — `GET ?clip_id` returns an oembed-shaped preview (`type`, `title`, `author_name`, `thumbnail_url`, `html`) plus `twitter:card` hints for social embeds. Returns 404 for unknown clips, 403 for subscribers-only clips.
- **clip-creator-mentions** (`routes-f`) — `POST { clip_id, title, description? }` extracts `@`-mentions from the title/description, validates against a bundled known-creators list, and skips a mention of the clip's own creator.
- **clip-viewership-growth** (`routes-f`) — `GET ?clip_id` returns hourly view samples as a cumulative series (`hour_offset`, `views_cumulative`, `views_this_hour`).
- **featured-vod-moment** (`routesF`) — `POST { vod_id, start_seconds, end_seconds, title }` creates an editorial highlight moment for a VOD (max 3 per VOD, returns 409 past the cap); `GET ?vod_id` lists a VOD's featured moments.

All four are self-contained within their `app/api/routes-f/` or `app/api/routesF/` subfolder per the scope constraint — no imports from `lib/`, `utils/`, `types/`, or `components/`.

## Note on CI
`npm run build` currently fails on `dev` with ~105 pre-existing TypeScript errors (missing `_lib/validate` module, `NextResponse` type mismatches) across route files unrelated to this PR — verified the same error count with these 4 new files removed. `dev`'s own CI/CD Pipeline is already red on GitHub for the same reason.

## Test plan
- [x] 29 Jest tests across all 4 routes pass
- [x] `eslint` clean on all new files

closes #1224
closes #1225
closes #1228
closes #1233