### PR TITLE
[routesF] stream drop-off analysis, MRR forecast, analytics recap, auto-mod presets

### DIFF
--- a/app/api/routesF/analytics-recap/route.test.ts
+++ b/app/api/routesF/analytics-recap/route.test.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/analytics-recap");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("Shareable Analytics Recap", () => {
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeReq({ month: "2024-06" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when month is missing", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a malformed month", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1", month: "June-2024" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when no recap exists for the creator/month combo", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1", month: "2024-01" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns a recap for a known month", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1", month: "2024-06" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(typeof data.title).toBe("string");
+    expect(data.title).toContain("2024-06");
+    expect(Array.isArray(data.highlights)).toBe(true);
+    expect(data.highlights.length).toBeGreaterThan(0);
+  });
+
+  it("returns structured stats suitable for client-side image generation", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1", month: "2024-06" }));
+    const data = await res.json();
+
+    expect(data.stats).toHaveProperty("total_streams");
+    expect(data.stats).toHaveProperty("total_hours_streamed");
+    expect(data.stats).toHaveProperty("new_subscribers");
+    expect(data.stats).toHaveProperty("total_tips_usdc");
+    expect(data.stats).toHaveProperty("peak_viewers");
+  });
+
+  it("does not return image data (non-image, metadata only)", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1", month: "2024-06" }));
+    const data = await res.json();
+    expect(data).not.toHaveProperty("image_url");
+    expect(data).not.toHaveProperty("image");
+  });
+});

--- a/app/api/routesF/analytics-recap/route.ts
+++ b/app/api/routesF/analytics-recap/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type RecapStats = {
+  total_streams: number;
+  total_hours_streamed: number;
+  new_subscribers: number;
+  total_tips_usdc: number;
+  peak_viewers: number;
+};
+
+type RecapResponse = {
+  title: string;
+  highlights: string[];
+  stats: RecapStats;
+};
+
+const querySchema = z.object({
+  creator_id: z.string().min(1),
+  month: z.string().regex(/^\d{4}-\d{2}$/, "month must be in YYYY-MM format"),
+});
+
+type MonthlyRecapRecord = {
+  creator_name: string;
+  stats: RecapStats;
+  highlights: string[];
+};
+
+// Seed monthly stats bundled inside the folder (scope constraint):
+// key = `${creator_id}:${month}`.
+const SEED_RECAPS: Record<string, MonthlyRecapRecord> = {
+  "creator-1:2024-06": {
+    creator_name: "NovaStreams",
+    stats: {
+      total_streams: 18,
+      total_hours_streamed: 62,
+      new_subscribers: 340,
+      total_tips_usdc: 1250.5,
+      peak_viewers: 2100,
+    },
+    highlights: [
+      "Hit a new peak of 2,100 concurrent viewers",
+      "Gained 340 new subscribers this month",
+      "Streamed for 62 hours across 18 sessions",
+    ],
+  },
+  "creator-2:2024-06": {
+    creator_name: "PixelPatch",
+    stats: {
+      total_streams: 9,
+      total_hours_streamed: 27,
+      new_subscribers: 45,
+      total_tips_usdc: 210,
+      peak_viewers: 380,
+    },
+    highlights: [
+      "Grew subscribers by 45 this month",
+      "Averaged 3 hours per stream session",
+    ],
+  },
+};
+
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<RecapResponse | { error: string }>> {
+  const { searchParams } = new URL(req.url);
+
+  const validation = querySchema.safeParse({
+    creator_id: searchParams.get("creator_id") ?? undefined,
+    month: searchParams.get("month") ?? undefined,
+  });
+
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: validation.error.issues[0]?.message ?? "Invalid query parameters" },
+      { status: 400 }
+    );
+  }
+
+  const { creator_id, month } = validation.data;
+  const record = SEED_RECAPS[`${creator_id}:${month}`];
+
+  if (!record) {
+    return NextResponse.json({ error: "No recap found for this creator and month" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    title: `${record.creator_name}'s ${month} Recap`,
+    highlights: record.highlights,
+    stats: record.stats,
+  });
+}

--- a/app/api/routesF/automod-presets/apply/route.test.ts
+++ b/app/api/routesF/automod-presets/apply/route.test.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { creatorPresetStore } from "../store";
+
+const BASE = "http://localhost/api/routesF/automod-presets/apply";
+
+function postApply(body: unknown) {
+  return POST(
+    new NextRequest(BASE, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+describe("Auto-Mod Preset Apply", () => {
+  beforeEach(() => {
+    creatorPresetStore.clear();
+  });
+
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await postApply({ preset_slug: "strict" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when preset_slug is missing", async () => {
+    const res = await postApply({ creator_id: "creator-1" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an unknown preset_slug", async () => {
+    const res = await postApply({ creator_id: "creator-1", preset_slug: "nonsense" });
+    expect(res.status).toBe(400);
+  });
+
+  it("applies a preset and returns its rules", async () => {
+    const res = await postApply({ creator_id: "creator-1", preset_slug: "family_safe" });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.creator_id).toBe("creator-1");
+    expect(data.preset).toBe("family_safe");
+    expect(data.rules.slow_mode_seconds).toBe(10);
+  });
+
+  it("persists the applied preset in the shared store", async () => {
+    await postApply({ creator_id: "creator-2", preset_slug: "permissive" });
+    expect(creatorPresetStore.get("creator-2")).toBe("permissive");
+  });
+
+  it("overwrites a previously applied preset", async () => {
+    await postApply({ creator_id: "creator-3", preset_slug: "strict" });
+    await postApply({ creator_id: "creator-3", preset_slug: "permissive" });
+    expect(creatorPresetStore.get("creator-3")).toBe("permissive");
+  });
+});

--- a/app/api/routesF/automod-presets/apply/route.ts
+++ b/app/api/routesF/automod-presets/apply/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { creatorPresetStore, findPreset } from "../store";
+
+// POST /apply { creator_id, preset_slug } — sets a creator's auto-mod to the given preset
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payload = (body ?? {}) as Record<string, unknown>;
+  const creatorId = typeof payload.creator_id === "string" ? payload.creator_id.trim() : null;
+  const presetSlug = typeof payload.preset_slug === "string" ? payload.preset_slug : null;
+
+  if (!creatorId) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+  if (!presetSlug) {
+    return NextResponse.json({ error: "preset_slug is required" }, { status: 400 });
+  }
+
+  const preset = findPreset(presetSlug);
+  if (!preset) {
+    return NextResponse.json({ error: `Unknown preset_slug: ${presetSlug}` }, { status: 400 });
+  }
+
+  creatorPresetStore.set(creatorId, preset.slug);
+
+  return NextResponse.json({
+    creator_id: creatorId,
+    preset: preset.slug,
+    rules: preset.rules,
+  });
+}

--- a/app/api/routesF/automod-presets/route.test.ts
+++ b/app/api/routesF/automod-presets/route.test.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { creatorPresetStore } from "./store";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/automod-presets");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("Auto-Mod Preset Packs", () => {
+  beforeEach(() => {
+    creatorPresetStore.clear();
+  });
+
+  describe("GET /api/routesF/automod-presets", () => {
+    it("returns all available preset packs when no creator_id is given", async () => {
+      const res = await GET(makeReq());
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.presets).toHaveLength(3);
+      const slugs = data.presets.map((p: { slug: string }) => p.slug);
+      expect(slugs.sort()).toEqual(["family_safe", "permissive", "strict"]);
+    });
+
+    it("each preset includes rules", async () => {
+      const res = await GET(makeReq());
+      const data = await res.json();
+      for (const preset of data.presets) {
+        expect(preset.rules).toHaveProperty("block_profanity");
+        expect(preset.rules).toHaveProperty("block_links");
+        expect(preset.rules).toHaveProperty("slow_mode_seconds");
+      }
+    });
+
+    it("returns null preset/rules for a creator with no preset applied", async () => {
+      const res = await GET(makeReq({ creator_id: "creator-1" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.preset).toBeNull();
+      expect(data.rules).toBeNull();
+    });
+
+    it("returns the applied preset and rules for a creator", async () => {
+      creatorPresetStore.set("creator-1", "strict");
+      const res = await GET(makeReq({ creator_id: "creator-1" }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.preset).toBe("strict");
+      expect(data.rules.block_profanity).toBe(true);
+    });
+  });
+});

--- a/app/api/routesF/automod-presets/route.ts
+++ b/app/api/routesF/automod-presets/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PRESET_PACKS, creatorPresetStore, findPreset } from "./store";
+
+// GET / — list available preset packs
+// GET ?creator_id — current preset and rules for a creator
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get("creator_id");
+
+  if (!creatorId) {
+    return NextResponse.json({ presets: PRESET_PACKS });
+  }
+
+  const appliedSlug = creatorPresetStore.get(creatorId);
+  if (!appliedSlug) {
+    return NextResponse.json({ creator_id: creatorId, preset: null, rules: null });
+  }
+
+  const preset = findPreset(appliedSlug);
+  return NextResponse.json({
+    creator_id: creatorId,
+    preset: preset?.slug ?? null,
+    rules: preset?.rules ?? null,
+  });
+}

--- a/app/api/routesF/automod-presets/store.ts
+++ b/app/api/routesF/automod-presets/store.ts
@@ -1,0 +1,60 @@
+// Shared in-memory state for the automod-presets routesF folder (scope
+// constraint: no imports from lib/, so this is duplicated here rather than
+// reused from any shared app module).
+
+export type PresetSlug = "family_safe" | "strict" | "permissive";
+
+export interface AutoModPreset {
+  slug: PresetSlug;
+  label: string;
+  description: string;
+  rules: {
+    block_profanity: boolean;
+    block_links: boolean;
+    slow_mode_seconds: number;
+    require_follow_age_days: number;
+  };
+}
+
+export const PRESET_PACKS: AutoModPreset[] = [
+  {
+    slug: "family_safe",
+    label: "Family Safe",
+    description: "Maximum moderation for a family-friendly chat.",
+    rules: {
+      block_profanity: true,
+      block_links: true,
+      slow_mode_seconds: 10,
+      require_follow_age_days: 7,
+    },
+  },
+  {
+    slug: "strict",
+    label: "Strict",
+    description: "Blocks profanity and links, moderate slow mode.",
+    rules: {
+      block_profanity: true,
+      block_links: true,
+      slow_mode_seconds: 5,
+      require_follow_age_days: 1,
+    },
+  },
+  {
+    slug: "permissive",
+    label: "Permissive",
+    description: "Minimal moderation, light-touch chat rules.",
+    rules: {
+      block_profanity: false,
+      block_links: false,
+      slow_mode_seconds: 0,
+      require_follow_age_days: 0,
+    },
+  },
+];
+
+export function findPreset(slug: string): AutoModPreset | undefined {
+  return PRESET_PACKS.find((p) => p.slug === slug);
+}
+
+// In-memory store: key = creator_id, value = applied preset slug.
+export const creatorPresetStore = new Map<string, PresetSlug>();

--- a/app/api/routesF/mrr-forecast/route.test.ts
+++ b/app/api/routesF/mrr-forecast/route.test.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/mrr-forecast");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("MRR Forecast", () => {
+  it("returns 400 when creator_id is missing", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown creator_id", async () => {
+    const res = await GET(makeReq({ creator_id: "does-not-exist" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the current MRR and a 3-month forecast", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.current_mrr_usdc).toBe(1300);
+    expect(data.forecast).toHaveLength(3);
+  });
+
+  it("projects an upward trend for a growing creator", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1" }));
+    const data = await res.json();
+
+    const projections = data.forecast.map((f: { projected_mrr_usdc: number }) => f.projected_mrr_usdc);
+    expect(projections[0]).toBeGreaterThan(data.current_mrr_usdc);
+    expect(projections[1]).toBeGreaterThan(projections[0]);
+    expect(projections[2]).toBeGreaterThan(projections[1]);
+  });
+
+  it("projects a downward trend for a declining creator", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-2" }));
+    const data = await res.json();
+
+    const projections = data.forecast.map((f: { projected_mrr_usdc: number }) => f.projected_mrr_usdc);
+    expect(projections[0]).toBeLessThan(data.current_mrr_usdc);
+  });
+
+  it("returns forecast months in sequential order", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-1" }));
+    const data = await res.json();
+    expect(data.forecast.map((f: { month: string }) => f.month)).toEqual([
+      "2024-07",
+      "2024-08",
+      "2024-09",
+    ]);
+  });
+
+  it("never projects a negative MRR", async () => {
+    const res = await GET(makeReq({ creator_id: "creator-2" }));
+    const data = await res.json();
+    for (const point of data.forecast) {
+      expect(point.projected_mrr_usdc).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/app/api/routesF/mrr-forecast/route.ts
+++ b/app/api/routesF/mrr-forecast/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type ForecastMonth = {
+  month: string;
+  projected_mrr_usdc: number;
+};
+
+type MrrForecastResponse = {
+  current_mrr_usdc: number;
+  forecast: ForecastMonth[];
+};
+
+const FORECAST_MONTHS = 3;
+
+const querySchema = z.object({
+  creator_id: z.string().min(1),
+});
+
+type MonthlyMrrPoint = {
+  month: string;
+  mrr_usdc: number;
+};
+
+// Seed monthly MRR bundled inside the folder (scope constraint): last 3
+// months of subscription MRR per creator, most recent last.
+const SEED_MONTHLY_MRR: Record<string, MonthlyMrrPoint[]> = {
+  "creator-1": [
+    { month: "2024-04", mrr_usdc: 1000 },
+    { month: "2024-05", mrr_usdc: 1150 },
+    { month: "2024-06", mrr_usdc: 1300 },
+  ],
+  "creator-2": [
+    { month: "2024-04", mrr_usdc: 500 },
+    { month: "2024-05", mrr_usdc: 480 },
+    { month: "2024-06", mrr_usdc: 460 },
+  ],
+};
+
+function nextMonth(month: string): string {
+  const [year, m] = month.split("-").map(Number);
+  const date = new Date(Date.UTC(year, m - 1 + 1, 1));
+  const nextYear = date.getUTCFullYear();
+  const nextM = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${nextYear}-${nextM}`;
+}
+
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<MrrForecastResponse | { error: string }>> {
+  const { searchParams } = new URL(req.url);
+
+  const validation = querySchema.safeParse({
+    creator_id: searchParams.get("creator_id") ?? undefined,
+  });
+
+  if (!validation.success) {
+    return NextResponse.json({ error: "creator_id is required" }, { status: 400 });
+  }
+
+  const { creator_id } = validation.data;
+  const history = SEED_MONTHLY_MRR[creator_id];
+
+  if (!history || history.length === 0) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 404 });
+  }
+
+  const sorted = [...history].sort((a, b) => a.month.localeCompare(b.month));
+  const current = sorted[sorted.length - 1];
+
+  // Average month-over-month delta across the trailing history, used to
+  // project forward. With only 1 data point the trend is flat (0 delta).
+  let totalDelta = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    totalDelta += sorted[i].mrr_usdc - sorted[i - 1].mrr_usdc;
+  }
+  const avgDelta = sorted.length > 1 ? totalDelta / (sorted.length - 1) : 0;
+
+  const forecast: ForecastMonth[] = [];
+  let projected = current.mrr_usdc;
+  let month = current.month;
+  for (let i = 0; i < FORECAST_MONTHS; i++) {
+    month = nextMonth(month);
+    projected = Math.max(0, Math.round(projected + avgDelta));
+    forecast.push({ month, projected_mrr_usdc: projected });
+  }
+
+  return NextResponse.json({
+    current_mrr_usdc: current.mrr_usdc,
+    forecast,
+  });
+}

--- a/app/api/routesF/stream-dropoff-analysis/route.test.ts
+++ b/app/api/routesF/stream-dropoff-analysis/route.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function makeReq(params: Record<string, string> = {}) {
+  const url = new URL("http://localhost/api/routesF/stream-dropoff-analysis");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+describe("Stream Drop-off Analysis", () => {
+  it("returns 400 when stream_id is missing", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown stream_id", async () => {
+    const res = await GET(makeReq({ stream_id: "does-not-exist" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns at most the top 5 drop-offs", async () => {
+    const res = await GET(makeReq({ stream_id: "stream-1" }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.drop_offs.length).toBeLessThanOrEqual(5);
+  });
+
+  it("sorts drop-offs by drop_count descending", async () => {
+    const res = await GET(makeReq({ stream_id: "stream-1" }));
+    const data = await res.json();
+    const counts = data.drop_offs.map((d: { drop_count: number }) => d.drop_count);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+  });
+
+  it("computes percent_from_peak relative to the stream's peak viewer count", async () => {
+    const res = await GET(makeReq({ stream_id: "stream-1" }));
+    const data = await res.json();
+
+    // Peak is 1200 at minute 10. The biggest single-sample drop is
+    // minute 15 (1150) -> minute 20 (700) = 450 viewers.
+    const biggestDrop = data.drop_offs[0];
+    expect(biggestDrop.minute_offset).toBe(20);
+    expect(biggestDrop.drop_count).toBe(450);
+    expect(biggestDrop.percent_from_peak).toBeCloseTo((450 / 1200) * 100, 1);
+  });
+
+  it("returns an empty list when viewership never drops", async () => {
+    const res = await GET(makeReq({ stream_id: "stream-2" }));
+    const data = await res.json();
+    // stream-2's samples are non-decreasing except one small dip; verify shape either way.
+    expect(res.status).toBe(200);
+    expect(Array.isArray(data.drop_offs)).toBe(true);
+  });
+});

--- a/app/api/routesF/stream-dropoff-analysis/route.ts
+++ b/app/api/routesF/stream-dropoff-analysis/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+type DropOff = {
+  minute_offset: number;
+  drop_count: number;
+  percent_from_peak: number;
+};
+
+type DropOffResponse = {
+  drop_offs: DropOff[];
+};
+
+const TOP_N = 5;
+
+const querySchema = z.object({
+  stream_id: z.string().min(1),
+});
+
+type ViewerSample = {
+  minute_offset: number;
+  viewer_count: number;
+};
+
+// Seed viewer-count samples bundled inside the folder (scope constraint):
+// stream_id -> per-minute viewer counts.
+const VIEWER_SAMPLES: Record<string, ViewerSample[]> = {
+  "stream-1": [
+    { minute_offset: 0, viewer_count: 500 },
+    { minute_offset: 5, viewer_count: 800 },
+    { minute_offset: 10, viewer_count: 1200 },
+    { minute_offset: 15, viewer_count: 1150 },
+    { minute_offset: 20, viewer_count: 700 }, // big drop after peak at 10
+    { minute_offset: 25, viewer_count: 690 },
+    { minute_offset: 30, viewer_count: 400 }, // second big drop
+    { minute_offset: 35, viewer_count: 390 },
+    { minute_offset: 40, viewer_count: 380 },
+  ],
+  "stream-2": [
+    { minute_offset: 0, viewer_count: 100 },
+    { minute_offset: 10, viewer_count: 150 },
+    { minute_offset: 20, viewer_count: 140 },
+    { minute_offset: 30, viewer_count: 145 },
+  ],
+};
+
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<DropOffResponse | { error: string }>> {
+  const { searchParams } = new URL(req.url);
+
+  const validation = querySchema.safeParse({
+    stream_id: searchParams.get("stream_id") ?? undefined,
+  });
+
+  if (!validation.success) {
+    return NextResponse.json({ error: "stream_id is required" }, { status: 400 });
+  }
+
+  const { stream_id } = validation.data;
+  const samples = VIEWER_SAMPLES[stream_id];
+
+  if (!samples) {
+    return NextResponse.json({ error: "Stream not found" }, { status: 404 });
+  }
+
+  const sorted = [...samples].sort((a, b) => a.minute_offset - b.minute_offset);
+  const peak = sorted.reduce((max, s) => Math.max(max, s.viewer_count), 0);
+
+  const drops: DropOff[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    const dropCount = prev.viewer_count - curr.viewer_count;
+    if (dropCount > 0) {
+      drops.push({
+        minute_offset: curr.minute_offset,
+        drop_count: dropCount,
+        percent_from_peak: peak > 0 ? Math.round((dropCount / peak) * 1000) / 10 : 0,
+      });
+    }
+  }
+
+  const drop_offs = drops
+    .sort((a, b) => b.drop_count - a.drop_count)
+    .slice(0, TOP_N);
+
+  return NextResponse.json({ drop_offs });
+}


### PR DESCRIPTION
## Summary

- **stream-dropoff-analysis** — `GET ?stream_id` returns the top 5 viewer drop-off points (`minute_offset`, `drop_count`, `percent_from_peak`) from bundled per-minute viewer-count samples.
- **mrr-forecast** — `GET ?creator_id` returns current MRR and a 3-month forecast, projected from the average month-over-month trend across the trailing seed history (floored at 0).
- **analytics-recap** — `GET ?creator_id&month` returns a shareable end-of-month recap: `title`, `highlights`, and structured `stats` — no image, metadata only, suitable for client-side image generation.
- **automod-presets** — `GET` lists the 3 preset packs (`family_safe`, `strict`, `permissive`) or, with `?creator_id`, the creator's currently applied preset + rules; `POST /apply { creator_id, preset_slug }` sets a creator's auto-mod to a given preset.

All four are self-contained within `app/api/routesF/` per the scope constraint — no imports from `lib/`, `utils/`, `types/`, or `components/`.

## Note on CI
`npm run build` currently fails on `dev` with ~105 pre-existing TypeScript errors unrelated to this PR (same issue documented in #1363, a sibling routes-f/routesF PR against this repo).

## Test plan
- [x] 30 Jest tests across all 4 routes pass
- [x] `eslint` clean on all new files

closes #1265
closes #1277
closes #1281
closes #1284