### PR TITLE
feat(routesF): language filter, diversity picks, mood filter, quiet hours config

### DIFF
--- a/app/api/routesF/diversity-boosted-picks/route.test.ts
+++ b/app/api/routesF/diversity-boosted-picks/route.test.ts
@@ -1,0 +1,75 @@
+import { GET, selectDiverse, SEED_CREATORS } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/diversity-boosted-picks';
+
+function countByCategory(creators: { category: string }[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const c of creators) {
+    counts[c.category] = (counts[c.category] ?? 0) + 1;
+  }
+  return counts;
+}
+
+describe('selectDiverse', () => {
+  it('never selects more than 2 per category when the requested count allows spreading out', () => {
+    const result = selectDiverse(SEED_CREATORS, 6);
+    const counts = countByCategory(result);
+    expect(Object.values(counts).every((n) => n <= 2)).toBe(true);
+    expect(result).toHaveLength(6);
+  });
+
+  it('picks exactly one per category when count equals the number of categories', () => {
+    const result = selectDiverse(SEED_CREATORS, 4);
+    const counts = countByCategory(result);
+    expect(counts).toEqual({ gaming: 1, music: 1, cooking: 1, art: 1 });
+  });
+
+  it('backfills beyond the 2-per-category cap once every category has contributed its share', () => {
+    const result = selectDiverse(SEED_CREATORS, 12);
+    expect(result).toHaveLength(12);
+    // All 12 seed creators are used up, so with only 4 categories some
+    // category necessarily has 3 — this is exactly the case the backfill
+    // pass exists for.
+    const counts = countByCategory(result);
+    expect(Object.values(counts).some((n) => n === 3)).toBe(true);
+  });
+
+  it('never returns more creators than requested even if the pool is larger', () => {
+    const result = selectDiverse(SEED_CREATORS, 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it('returns every creator when count exceeds the pool size', () => {
+    const result = selectDiverse(SEED_CREATORS, 100);
+    expect(result).toHaveLength(SEED_CREATORS.length);
+  });
+});
+
+describe('GET /api/routesF/diversity-boosted-picks', () => {
+  it('returns a diverse creator set for a valid viewer_id', async () => {
+    const res = await GET(new NextRequest(`${BASE}?viewer_id=v1`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.creators).toHaveLength(12);
+  });
+
+  it('respects the count parameter', async () => {
+    const res = await GET(new NextRequest(`${BASE}?viewer_id=v1&count=6`));
+    const data = await res.json();
+    expect(data.creators).toHaveLength(6);
+    const counts = countByCategory(data.creators);
+    expect(Object.values(counts).every((n) => n <= 2)).toBe(true);
+  });
+
+  it('returns 400 when viewer_id is missing', async () => {
+    const res = await GET(new NextRequest(BASE));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an invalid count', async () => {
+    expect((await GET(new NextRequest(`${BASE}?viewer_id=v1&count=0`))).status).toBe(400);
+    expect((await GET(new NextRequest(`${BASE}?viewer_id=v1&count=abc`))).status).toBe(400);
+    expect((await GET(new NextRequest(`${BASE}?viewer_id=v1&count=51`))).status).toBe(400);
+  });
+});

--- a/app/api/routesF/diversity-boosted-picks/route.ts
+++ b/app/api/routesF/diversity-boosted-picks/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface SeedCreator {
+  creator_id: string;
+  name: string;
+  category: string;
+  language: string;
+}
+
+// Seed creator pool with category/language, bundled per the routesF scope
+// constraint. Four categories x three creators each, so the default
+// count=12 exercises both the round-robin cap and the backfill path below.
+export const SEED_CREATORS: SeedCreator[] = [
+  { creator_id: 'c-gaming-1', name: 'Gaming One', category: 'gaming', language: 'en' },
+  { creator_id: 'c-gaming-2', name: 'Gaming Two', category: 'gaming', language: 'es' },
+  { creator_id: 'c-gaming-3', name: 'Gaming Three', category: 'gaming', language: 'en' },
+  { creator_id: 'c-music-1', name: 'Music One', category: 'music', language: 'en' },
+  { creator_id: 'c-music-2', name: 'Music Two', category: 'music', language: 'fr' },
+  { creator_id: 'c-music-3', name: 'Music Three', category: 'music', language: 'en' },
+  { creator_id: 'c-cooking-1', name: 'Cooking One', category: 'cooking', language: 'es' },
+  { creator_id: 'c-cooking-2', name: 'Cooking Two', category: 'cooking', language: 'en' },
+  { creator_id: 'c-cooking-3', name: 'Cooking Three', category: 'cooking', language: 'en' },
+  { creator_id: 'c-art-1', name: 'Art One', category: 'art', language: 'en' },
+  { creator_id: 'c-art-2', name: 'Art Two', category: 'art', language: 'fr' },
+  { creator_id: 'c-art-3', name: 'Art Three', category: 'art', language: 'en' },
+];
+
+const MAX_PER_CATEGORY = 2;
+const DEFAULT_COUNT = 12;
+const MAX_COUNT = 50;
+
+/**
+ * Selects up to `count` creators from `pool`, preferring diversity: at most
+ * MAX_PER_CATEGORY are taken per category in a first pass (round-robin
+ * across categories, in the order each category first appears in `pool`),
+ * and only if `count` still isn't met does a second pass backfill
+ * additional creators from categories that have more to offer. This means
+ * the "at most 2 per category" rule is a genuine preference, not a hard
+ * cap that would silently return fewer than `count` results when more are
+ * available.
+ */
+export function selectDiverse(pool: SeedCreator[], count: number): SeedCreator[] {
+  const byCategory = new Map<string, SeedCreator[]>();
+  const categoryOrder: string[] = [];
+  for (const creator of pool) {
+    if (!byCategory.has(creator.category)) {
+      byCategory.set(creator.category, []);
+      categoryOrder.push(creator.category);
+    }
+    byCategory.get(creator.category)!.push(creator);
+  }
+
+  const selected: SeedCreator[] = [];
+
+  for (let round = 0; round < MAX_PER_CATEGORY && selected.length < count; round++) {
+    for (const category of categoryOrder) {
+      if (selected.length >= count) break;
+      const candidate = byCategory.get(category)![round];
+      if (candidate) selected.push(candidate);
+    }
+  }
+
+  if (selected.length < count) {
+    for (const category of categoryOrder) {
+      const categoryPool = byCategory.get(category)!;
+      for (let i = MAX_PER_CATEGORY; i < categoryPool.length; i++) {
+        if (selected.length >= count) break;
+        selected.push(categoryPool[i]);
+      }
+      if (selected.length >= count) break;
+    }
+  }
+
+  return selected;
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const viewerId = searchParams.get('viewer_id');
+
+  if (!viewerId || viewerId.trim() === '') {
+    return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+  }
+
+  const countParam = searchParams.get('count');
+  let count = DEFAULT_COUNT;
+  if (countParam !== null) {
+    const parsed = Number(countParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_COUNT) {
+      return NextResponse.json(
+        { error: `count must be an integer between 1 and ${MAX_COUNT}` },
+        { status: 400 }
+      );
+    }
+    count = parsed;
+  }
+
+  const creators = selectDiverse(SEED_CREATORS, count);
+
+  return NextResponse.json({ creators });
+}

--- a/app/api/routesF/live-streams-by-language/route.test.ts
+++ b/app/api/routesF/live-streams-by-language/route.test.ts
@@ -1,0 +1,53 @@
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/live-streams-by-language';
+
+describe('Live Streams by Language', () => {
+  describe('GET /api/routesF/live-streams-by-language', () => {
+    it('returns only streams matching the requested language, sorted by viewer count desc', async () => {
+      const res = await GET(new NextRequest(`${BASE}?language=en`));
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+        'lang-1', // 1200 viewers
+        'lang-4', // 890 viewers
+      ]);
+    });
+
+    it('sorts a different language filter by viewer count desc too', async () => {
+      const res = await GET(new NextRequest(`${BASE}?language=es`));
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+        'lang-2', // 640 viewers
+        'lang-5', // 75 viewers
+      ]);
+    });
+
+    it('returns a single stream for a language with only one match', async () => {
+      const res = await GET(new NextRequest(`${BASE}?language=fr`));
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual(['lang-3']);
+    });
+
+    it('returns every stream sorted by viewer count desc when no language filter is given', async () => {
+      const res = await GET(new NextRequest(BASE));
+      const data = await res.json();
+      expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+        'lang-1',
+        'lang-4',
+        'lang-2',
+        'lang-3',
+        'lang-5',
+      ]);
+    });
+
+    it('returns 400 for an unsupported language', async () => {
+      const res = await GET(new NextRequest(`${BASE}?language=de`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain('Unknown language');
+    });
+  });
+});

--- a/app/api/routesF/live-streams-by-language/route.ts
+++ b/app/api/routesF/live-streams-by-language/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface SeedLanguageStream {
+  stream_id: string;
+  creator_id: string;
+  title: string;
+  language: string;
+  viewers: number;
+}
+
+// Seed live streams tagged with a primary language, bundled per the
+// routesF scope constraint.
+export const SEED_LANGUAGE_STREAMS: SeedLanguageStream[] = [
+  { stream_id: 'lang-1', creator_id: 'creator-1', title: 'Ranked grind', language: 'en', viewers: 1200 },
+  { stream_id: 'lang-2', creator_id: 'creator-2', title: 'Charla y juego', language: 'es', viewers: 640 },
+  { stream_id: 'lang-3', creator_id: 'creator-3', title: 'Musique et discussion', language: 'fr', viewers: 310 },
+  { stream_id: 'lang-4', creator_id: 'creator-4', title: 'Late night lofi', language: 'en', viewers: 890 },
+  { stream_id: 'lang-5', creator_id: 'creator-5', title: 'Cocina en vivo', language: 'es', viewers: 75 },
+];
+
+const SUPPORTED_LANGUAGES = ['en', 'es', 'fr'] as const;
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const language = searchParams.get('language');
+
+  if (language !== null && !(SUPPORTED_LANGUAGES as readonly string[]).includes(language)) {
+    return NextResponse.json(
+      { error: `Unknown language. Supported: ${SUPPORTED_LANGUAGES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const streams = SEED_LANGUAGE_STREAMS
+    .filter((s) => (language === null ? true : s.language === language))
+    .sort((a, b) => b.viewers - a.viewers);
+
+  return NextResponse.json({ streams });
+}

--- a/app/api/routesF/mood-filter/route.test.ts
+++ b/app/api/routesF/mood-filter/route.test.ts
@@ -1,0 +1,37 @@
+import { GET, MOODS } from './route';
+import { NextRequest } from 'next/server';
+
+const BASE = 'http://localhost/api/routesF/mood-filter';
+
+describe('Mood Filter', () => {
+  describe.each(MOODS)('GET /api/routesF/mood-filter?mood=%s', (mood) => {
+    it(`returns only streams tagged with mood "${mood}"`, async () => {
+      const res = await GET(new NextRequest(`${BASE}?mood=${mood}`));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.streams.length).toBeGreaterThan(0);
+      expect(data.streams.every((s: { mood: string }) => s.mood === mood)).toBe(true);
+    });
+  });
+
+  it('returns multiple streams when more than one matches the mood', async () => {
+    const res = await GET(new NextRequest(`${BASE}?mood=chill`));
+    const data = await res.json();
+    expect(data.streams.map((s: { stream_id: string }) => s.stream_id)).toEqual([
+      'mood-1',
+      'mood-6',
+    ]);
+  });
+
+  it('returns 400 when mood is missing', async () => {
+    const res = await GET(new NextRequest(BASE));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown mood', async () => {
+    const res = await GET(new NextRequest(`${BASE}?mood=melancholy`));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toContain('Unknown mood');
+  });
+});

--- a/app/api/routesF/mood-filter/route.ts
+++ b/app/api/routesF/mood-filter/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const MOODS = ['chill', 'hype', 'chat', 'gaming', 'learning'] as const;
+export type Mood = (typeof MOODS)[number];
+
+export interface SeedMoodStream {
+  stream_id: string;
+  creator_id: string;
+  title: string;
+  mood: Mood;
+  viewers: number;
+}
+
+// Seed live streams tagged with a mood, bundled per the routesF scope
+// constraint. At least one stream per mood so every mood has a match.
+export const SEED_MOOD_STREAMS: SeedMoodStream[] = [
+  { stream_id: 'mood-1', creator_id: 'creator-1', title: 'Lofi and chill', mood: 'chill', viewers: 300 },
+  { stream_id: 'mood-2', creator_id: 'creator-2', title: 'Hype ranked climb', mood: 'hype', viewers: 950 },
+  { stream_id: 'mood-3', creator_id: 'creator-3', title: 'Just chatting', mood: 'chat', viewers: 420 },
+  { stream_id: 'mood-4', creator_id: 'creator-4', title: 'Speedrun grind', mood: 'gaming', viewers: 610 },
+  { stream_id: 'mood-5', creator_id: 'creator-5', title: 'Live coding tutorial', mood: 'learning', viewers: 180 },
+  { stream_id: 'mood-6', creator_id: 'creator-6', title: 'Chill painting session', mood: 'chill', viewers: 90 },
+];
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const mood = searchParams.get('mood');
+
+  if (!mood || mood.trim() === '') {
+    return NextResponse.json({ error: 'mood is required' }, { status: 400 });
+  }
+
+  if (!(MOODS as readonly string[]).includes(mood)) {
+    return NextResponse.json(
+      { error: `Unknown mood "${mood}". Supported: ${MOODS.join(', ')}` },
+      { status: 404 }
+    );
+  }
+
+  const streams = SEED_MOOD_STREAMS.filter((s) => s.mood === mood);
+
+  return NextResponse.json({ streams });
+}

--- a/app/api/routesF/quiet-hours-notification-config/check-quiet/route.test.ts
+++ b/app/api/routesF/quiet-hours-notification-config/check-quiet/route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { __resetQuietHoursStore, setConfig } from '../store';
+
+const BASE = 'http://localhost/api/routesF/quiet-hours-notification-config/check-quiet';
+
+function makePost(body: unknown) {
+  return new NextRequest(BASE, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /quiet-hours-notification-config/check-quiet', () => {
+  beforeEach(() => {
+    __resetQuietHoursStore();
+  });
+
+  it('returns false for a viewer with no config (disabled by default)', async () => {
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-15T23:00:00Z' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ in_quiet_hours: false });
+  });
+
+  it('returns true for an instant inside a cross-midnight quiet window', async () => {
+    setConfig('v1', { start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: true });
+
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-15T23:30:00Z' }));
+    expect((await res.json()).in_quiet_hours).toBe(true);
+  });
+
+  it('returns true for an instant just after midnight, still inside the cross-midnight window', async () => {
+    setConfig('v1', { start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: true });
+
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-16T01:00:00Z' }));
+    expect((await res.json()).in_quiet_hours).toBe(true);
+  });
+
+  it('returns false for an instant outside a cross-midnight quiet window', async () => {
+    setConfig('v1', { start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: true });
+
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-15T14:00:00Z' }));
+    expect((await res.json()).in_quiet_hours).toBe(false);
+  });
+
+  it('respects the configured timezone, not the raw UTC hour', async () => {
+    // 14:00 UTC = 23:00 in Tokyo (UTC+9, no DST) -> inside a 22->8 window.
+    setConfig('v1', { start_hour: 22, end_hour: 8, timezone: 'Asia/Tokyo', enabled: true });
+
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-15T14:00:00Z' }));
+    expect((await res.json()).in_quiet_hours).toBe(true);
+  });
+
+  it('gives a different answer for the same instant under UTC vs. a shifted timezone', async () => {
+    const at = '2026-01-15T14:00:00Z';
+    setConfig('utc-viewer', { start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: true });
+    setConfig('tokyo-viewer', { start_hour: 22, end_hour: 8, timezone: 'Asia/Tokyo', enabled: true });
+
+    const utcRes = await POST(makePost({ viewer_id: 'utc-viewer', at }));
+    const tokyoRes = await POST(makePost({ viewer_id: 'tokyo-viewer', at }));
+
+    expect((await utcRes.json()).in_quiet_hours).toBe(false); // 14:00 UTC -> not quiet
+    expect((await tokyoRes.json()).in_quiet_hours).toBe(true); // 23:00 JST -> quiet
+  });
+
+  it('defaults `at` to the current time when omitted', async () => {
+    setConfig('v1', { start_hour: 0, end_hour: 23, timezone: 'UTC', enabled: false });
+    const res = await POST(makePost({ viewer_id: 'v1' }));
+    expect(res.status).toBe(200);
+    expect(typeof (await res.json()).in_quiet_hours).toBe('boolean');
+  });
+
+  it('returns false regardless of the window when the config is disabled', async () => {
+    setConfig('v1', { start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: false });
+
+    const res = await POST(makePost({ viewer_id: 'v1', at: '2026-01-15T23:30:00Z' }));
+    expect((await res.json()).in_quiet_hours).toBe(false);
+  });
+
+  it('returns 400 when viewer_id is missing', async () => {
+    const res = await POST(makePost({ at: '2026-01-15T23:30:00Z' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a malformed `at` timestamp', async () => {
+    const res = await POST(makePost({ viewer_id: 'v1', at: 'not-a-date' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for malformed JSON', async () => {
+    const req = new NextRequest(BASE, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{broken',
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+});

--- a/app/api/routesF/quiet-hours-notification-config/check-quiet/route.ts
+++ b/app/api/routesF/quiet-hours-notification-config/check-quiet/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getConfig, isInQuietHours } from '../store';
+
+// POST /check-quiet { viewer_id, at?: ISO } -> { in_quiet_hours }
+export async function POST(req: NextRequest) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const viewerId = typeof body.viewer_id === 'string' ? body.viewer_id.trim() : '';
+
+  if (!viewerId) {
+    return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+  }
+
+  let at = new Date();
+  if (body.at !== undefined) {
+    if (typeof body.at !== 'string') {
+      return NextResponse.json({ error: 'at must be an ISO 8601 timestamp string' }, { status: 400 });
+    }
+    const parsed = new Date(body.at);
+    if (Number.isNaN(parsed.getTime())) {
+      return NextResponse.json({ error: 'at must be a valid ISO 8601 timestamp' }, { status: 400 });
+    }
+    at = parsed;
+  }
+
+  const config = getConfig(viewerId);
+
+  return NextResponse.json({ in_quiet_hours: isInQuietHours(config, at) });
+}

--- a/app/api/routesF/quiet-hours-notification-config/route.test.ts
+++ b/app/api/routesF/quiet-hours-notification-config/route.test.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server';
+import { GET, PUT } from './route';
+import { __resetQuietHoursStore } from './store';
+
+const BASE = 'http://localhost/api/routesF/quiet-hours-notification-config';
+
+function makeGet(params: Record<string, string> = {}) {
+  const url = new URL(BASE);
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+function makePut(body: unknown) {
+  return new NextRequest(BASE, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('Quiet Hours Notification Config', () => {
+  beforeEach(() => {
+    __resetQuietHoursStore();
+  });
+
+  describe('GET', () => {
+    it('returns the default config for a viewer with nothing saved', async () => {
+      const res = await GET(makeGet({ viewer_id: 'v1' }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toEqual({
+        viewer_id: 'v1',
+        start_hour: 22,
+        end_hour: 8,
+        timezone: 'UTC',
+        enabled: false,
+      });
+    });
+
+    it('returns 400 when viewer_id is missing', async () => {
+      expect((await GET(makeGet())).status).toBe(400);
+    });
+  });
+
+  describe('PUT', () => {
+    it('saves and returns the updated config', async () => {
+      const res = await PUT(
+        makePut({ viewer_id: 'v1', start_hour: 23, end_hour: 7, timezone: 'America/New_York', enabled: true })
+      );
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data).toEqual({
+        viewer_id: 'v1',
+        start_hour: 23,
+        end_hour: 7,
+        timezone: 'America/New_York',
+        enabled: true,
+      });
+
+      const getRes = await GET(makeGet({ viewer_id: 'v1' }));
+      expect(await getRes.json()).toEqual(data);
+    });
+
+    it('rejects a missing viewer_id', async () => {
+      const res = await PUT(makePut({ start_hour: 1, end_hour: 2, timezone: 'UTC', enabled: true }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an out-of-range start_hour', async () => {
+      const res = await PUT(
+        makePut({ viewer_id: 'v1', start_hour: 24, end_hour: 8, timezone: 'UTC', enabled: true })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a non-integer end_hour', async () => {
+      const res = await PUT(
+        makePut({ viewer_id: 'v1', start_hour: 22, end_hour: 8.5, timezone: 'UTC', enabled: true })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid timezone', async () => {
+      const res = await PUT(
+        makePut({ viewer_id: 'v1', start_hour: 22, end_hour: 8, timezone: 'Not/A_Zone', enabled: true })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a non-boolean enabled', async () => {
+      const res = await PUT(
+        makePut({ viewer_id: 'v1', start_hour: 22, end_hour: 8, timezone: 'UTC', enabled: 'yes' })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects malformed JSON with 400', async () => {
+      const req = new NextRequest(BASE, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: '{broken',
+      });
+      expect((await PUT(req)).status).toBe(400);
+    });
+  });
+});

--- a/app/api/routesF/quiet-hours-notification-config/route.ts
+++ b/app/api/routesF/quiet-hours-notification-config/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getConfig, setConfig, isValidTimezone } from './store';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const viewerId = searchParams.get('viewer_id');
+
+  if (!viewerId || viewerId.trim() === '') {
+    return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+  }
+
+  return NextResponse.json(getConfig(viewerId));
+}
+
+function isValidHour(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 23;
+}
+
+export async function PUT(req: NextRequest) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const viewerId = typeof body.viewer_id === 'string' ? body.viewer_id.trim() : '';
+
+  if (!viewerId) {
+    return NextResponse.json({ error: 'viewer_id is required' }, { status: 400 });
+  }
+  if (!isValidHour(body.start_hour)) {
+    return NextResponse.json({ error: 'start_hour must be an integer between 0 and 23' }, { status: 400 });
+  }
+  if (!isValidHour(body.end_hour)) {
+    return NextResponse.json({ error: 'end_hour must be an integer between 0 and 23' }, { status: 400 });
+  }
+  if (typeof body.timezone !== 'string' || !isValidTimezone(body.timezone)) {
+    return NextResponse.json({ error: 'timezone must be a valid IANA time zone name' }, { status: 400 });
+  }
+  if (typeof body.enabled !== 'boolean') {
+    return NextResponse.json({ error: 'enabled must be a boolean' }, { status: 400 });
+  }
+
+  const updated = setConfig(viewerId, {
+    start_hour: body.start_hour,
+    end_hour: body.end_hour,
+    timezone: body.timezone,
+    enabled: body.enabled,
+  });
+
+  return NextResponse.json(updated);
+}

--- a/app/api/routesF/quiet-hours-notification-config/store.test.ts
+++ b/app/api/routesF/quiet-hours-notification-config/store.test.ts
@@ -1,0 +1,120 @@
+import {
+  __resetQuietHoursStore,
+  getConfig,
+  setConfig,
+  isValidTimezone,
+  hourInTimezone,
+  isHourInQuietWindow,
+  isInQuietHours,
+  DEFAULT_CONFIG,
+} from './store';
+
+describe('quiet-hours store', () => {
+  beforeEach(() => {
+    __resetQuietHoursStore();
+  });
+
+  describe('getConfig / setConfig', () => {
+    it('returns the default config for a viewer with nothing stored', () => {
+      expect(getConfig('v1')).toEqual({ viewer_id: 'v1', ...DEFAULT_CONFIG });
+    });
+
+    it('returns a stored config after setConfig', () => {
+      setConfig('v1', { start_hour: 20, end_hour: 6, timezone: 'UTC', enabled: true });
+      expect(getConfig('v1')).toEqual({
+        viewer_id: 'v1',
+        start_hour: 20,
+        end_hour: 6,
+        timezone: 'UTC',
+        enabled: true,
+      });
+    });
+
+    it('keeps configs independent per viewer', () => {
+      setConfig('v1', { start_hour: 20, end_hour: 6, timezone: 'UTC', enabled: true });
+      expect(getConfig('v2')).toEqual({ viewer_id: 'v2', ...DEFAULT_CONFIG });
+    });
+  });
+
+  describe('isValidTimezone', () => {
+    it('accepts a valid IANA timezone', () => {
+      expect(isValidTimezone('America/New_York')).toBe(true);
+      expect(isValidTimezone('UTC')).toBe(true);
+      expect(isValidTimezone('Asia/Tokyo')).toBe(true);
+    });
+
+    it('rejects a garbage timezone string', () => {
+      expect(isValidTimezone('Not/A_Timezone')).toBe(false);
+      expect(isValidTimezone('')).toBe(false);
+    });
+  });
+
+  describe('hourInTimezone', () => {
+    it('extracts the correct local hour for a fixed-offset, no-DST zone', () => {
+      // 14:00 UTC + 9h (JST has no DST) = 23:00 same day in Tokyo.
+      expect(hourInTimezone(new Date('2026-01-15T14:00:00Z'), 'Asia/Tokyo')).toBe(23);
+      // 02:00 UTC + 9h = 11:00 same day in Tokyo.
+      expect(hourInTimezone(new Date('2026-01-15T02:00:00Z'), 'Asia/Tokyo')).toBe(11);
+    });
+
+    it('matches the UTC hour directly for the UTC zone', () => {
+      expect(hourInTimezone(new Date('2026-01-15T14:00:00Z'), 'UTC')).toBe(14);
+    });
+  });
+
+  describe('isHourInQuietWindow', () => {
+    it('handles a same-day window normally', () => {
+      // 9 -> 17 (daytime quiet, unusual but valid)
+      expect(isHourInQuietWindow(9, 9, 17)).toBe(true);
+      expect(isHourInQuietWindow(16, 9, 17)).toBe(true);
+      expect(isHourInQuietWindow(17, 9, 17)).toBe(false); // end is exclusive
+      expect(isHourInQuietWindow(8, 9, 17)).toBe(false);
+      expect(isHourInQuietWindow(20, 9, 17)).toBe(false);
+    });
+
+    it('handles a window that crosses midnight', () => {
+      // 22 -> 8
+      expect(isHourInQuietWindow(23, 22, 8)).toBe(true);
+      expect(isHourInQuietWindow(0, 22, 8)).toBe(true);
+      expect(isHourInQuietWindow(7, 22, 8)).toBe(true);
+      expect(isHourInQuietWindow(22, 22, 8)).toBe(true); // start is inclusive
+      expect(isHourInQuietWindow(8, 22, 8)).toBe(false); // end is exclusive
+      expect(isHourInQuietWindow(12, 22, 8)).toBe(false);
+      expect(isHourInQuietWindow(21, 22, 8)).toBe(false);
+    });
+
+    it('treats start === end as a full 24h window', () => {
+      expect(isHourInQuietWindow(0, 5, 5)).toBe(true);
+      expect(isHourInQuietWindow(23, 5, 5)).toBe(true);
+    });
+  });
+
+  describe('isInQuietHours', () => {
+    const baseConfig = { viewer_id: 'v1', start_hour: 22, end_hour: 8, timezone: 'Asia/Tokyo', enabled: true };
+
+    it('is false when the config is disabled, regardless of the time', () => {
+      const disabled = { ...baseConfig, enabled: false };
+      expect(isInQuietHours(disabled, new Date('2026-01-15T14:00:00Z'))).toBe(false);
+    });
+
+    it('is true for an instant that lands in the cross-midnight window in the configured timezone', () => {
+      // 14:00 UTC = 23:00 JST -> inside [22, 8)
+      expect(isInQuietHours(baseConfig, new Date('2026-01-15T14:00:00Z'))).toBe(true);
+    });
+
+    it('is false for an instant that lands outside the window in the configured timezone', () => {
+      // 02:00 UTC = 11:00 JST -> outside [22, 8)
+      expect(isInQuietHours(baseConfig, new Date('2026-01-15T02:00:00Z'))).toBe(false);
+    });
+
+    it('gives a different answer for the same UTC instant under a different timezone', () => {
+      // 20:00 UTC = 05:00 JST (inside 22->8) but 20:00 UTC in UTC itself is
+      // NOT inside 22->8 -- same instant, different verdicts by timezone.
+      const at = new Date('2026-01-15T20:00:00Z');
+      const jstConfig = { ...baseConfig, timezone: 'Asia/Tokyo' };
+      const utcConfig = { ...baseConfig, timezone: 'UTC' };
+      expect(isInQuietHours(jstConfig, at)).toBe(true);
+      expect(isInQuietHours(utcConfig, at)).toBe(false);
+    });
+  });
+});

--- a/app/api/routesF/quiet-hours-notification-config/store.ts
+++ b/app/api/routesF/quiet-hours-notification-config/store.ts
@@ -1,0 +1,81 @@
+// Shared in-memory state and quiet-hours logic for the
+// quiet-hours-notification-config routesF folder (scope constraint: no
+// imports from lib/, so this is duplicated here rather than reused from
+// any shared app module).
+
+export interface QuietHoursConfig {
+  viewer_id: string;
+  start_hour: number;
+  end_hour: number;
+  timezone: string;
+  enabled: boolean;
+}
+
+export const DEFAULT_CONFIG: Omit<QuietHoursConfig, 'viewer_id'> = {
+  start_hour: 22,
+  end_hour: 8,
+  timezone: 'UTC',
+  enabled: false,
+};
+
+// In-memory store, keyed by viewer id. Module-level so the choice persists
+// across requests within a server instance; a real deployment would back
+// this with the user preferences table.
+const configStore = new Map<string, Omit<QuietHoursConfig, 'viewer_id'>>();
+
+/** Test hook: reset stored configs between test cases. */
+export function __resetQuietHoursStore(): void {
+  configStore.clear();
+}
+
+export function getConfig(viewerId: string): QuietHoursConfig {
+  const stored = configStore.get(viewerId);
+  return { viewer_id: viewerId, ...(stored ?? DEFAULT_CONFIG) };
+}
+
+export function setConfig(viewerId: string, config: Omit<QuietHoursConfig, 'viewer_id'>): QuietHoursConfig {
+  configStore.set(viewerId, config);
+  return { viewer_id: viewerId, ...config };
+}
+
+/** Returns true if `timezone` is a valid IANA time zone name Intl accepts. */
+export function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Extracts the local hour (0-23) `date` falls on in `timezone`. */
+export function hourInTimezone(date: Date, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    hourCycle: 'h23',
+  });
+  return Number(formatter.format(date));
+}
+
+/**
+ * Whether `hour` (0-23) falls within the [startHour, endHour) quiet window.
+ * Handles a window that crosses midnight (e.g. 22 -> 8) by treating it as
+ * "hour >= start OR hour < end" instead of the same-day "hour >= start AND
+ * hour < end". start === end is treated as a full 24h window (always
+ * quiet) rather than zero-width (never quiet) — the more useful reading of
+ * "quiet hours start and end at the same time".
+ */
+export function isHourInQuietWindow(hour: number, startHour: number, endHour: number): boolean {
+  if (startHour === endHour) return true;
+  if (startHour < endHour) return hour >= startHour && hour < endHour;
+  return hour >= startHour || hour < endHour;
+}
+
+/** Whether `at` (an instant) falls within `config`'s quiet hours window, in
+ * the configured timezone. Always false when the config is disabled. */
+export function isInQuietHours(config: QuietHoursConfig, at: Date): boolean {
+  if (!config.enabled) return false;
+  const hour = hourInTimezone(at, config.timezone);
+  return isHourInQuietWindow(hour, config.start_hour, config.end_hour);
+}


### PR DESCRIPTION
## Summary

Four self-contained routesF practice implementations, each with seed data and its own test file(s).

closes #1234
closes #1244
closes #1246
closes #1250

## Changes

- **#1234 — Live streams by language** (`app/api/routesF/live-streams-by-language/`): `GET ?language=en|es|fr` returns live streams matching the language, sorted by viewer count desc. Omitting the filter returns every seed stream, still sorted. Unsupported language → 400.

- **#1244 — Diversity-boosted picks** (`app/api/routesF/diversity-boosted-picks/`): `GET ?viewer_id&count=12` returns a diverse creator set via `selectDiverse`, which round-robins across categories capping at 2 per category, then backfills further from categories with more to offer once every category has contributed its share — so the result never falls short of the requested count just to preserve diversity. Tests verify no category exceeds 2 when the count allows spreading out, and that backfill kicks in correctly when it can't.

- **#1246 — Mood filter** (`app/api/routesF/mood-filter/`): `GET ?mood=chill|hype|chat|gaming|learning` returns streams tagged with that mood, one test per mood via `describe.each`. Missing mood → 400; unrecognized mood → 404, per the issue's explicit spec.

- **#1250 — Quiet hours notification config** (`app/api/routesF/quiet-hours-notification-config/`): `GET`/`PUT` for a per-viewer quiet-hours window (`start_hour`, `end_hour`, `timezone`, `enabled`), and `POST /check-quiet { viewer_id, at? } -> { in_quiet_hours }`. `isHourInQuietWindow` handles a window crossing midnight (e.g. 22→8) via an OR check instead of the same-day AND check. `isInQuietHours` resolves the local hour for the configured IANA timezone via `Intl.DateTimeFormat` (`hourCycle: 'h23'`) rather than the raw UTC hour — verified with a same-instant/different-timezone test showing two viewers configured for different zones get different answers for the identical UTC time. Disabled configs always report `false` regardless of the window.

All work is inside `app/api/routesF/`; no imports from `lib/`, `utils/`, `types/`, or `components/` per the scope constraint — shared logic between a route and its sub-route (e.g. quiet-hours' `store.ts`) is duplicated inside that issue's own subfolder, following the existing `automod-presets/store.ts` precedent in this repo.

## Test plan

- 56 new tests across 6 test files, all passing (`npx jest app/api/routesF/live-streams-by-language app/api/routesF/diversity-boosted-picks app/api/routesF/mood-filter app/api/routesF/quiet-hours-notification-config`).
- Each new file individually confirmed to add zero new TypeScript errors against the project's real `tsconfig.json`.

**Pre-existing and unrelated:** this repo's `npm run build`/`type-check` (and the husky pre-commit hook that runs it) currently fails on `upstream/dev` itself — ~100 files under the differently-named `app/api/routes-f/` (hyphenated, not this issue's `routesF`) import a `_lib/validate` module that doesn't exist in this checkout. Verified this is present on `upstream/dev` before any of my changes. None of the affected files are anywhere near what this PR touches. Commits in this PR used `--no-verify` for that reason (confirmed with the requester first) — each new file was individually checked against the real tsconfig and adds no new errors.